### PR TITLE
[inetstack] Generic Checksum

### DIFF
--- a/src/rust/inetstack/protocols/mod.rs
+++ b/src/rust/inetstack/protocols/mod.rs
@@ -13,7 +13,41 @@ pub mod udp;
 
 pub use peer::Peer;
 
+use ::std::slice::ChunksExact;
+
 pub enum Protocol {
     Tcp,
     Udp,
+}
+/// Computes the generic checksum of a bytes array.
+/// 
+/// This iterates all 16-bit array elements, summing 
+/// the values into a 32-bit variable. This functions 
+/// paddies with zero an octet at the end (if necessary) 
+/// to turn into a 16-bit element. Also, this may use 
+/// an initial value depending on the parameter `"start"`.
+pub fn compute_generic_checksum(buf: &[u8], start: Option<u32>) -> u32 {
+    let mut state: u32 = match start {
+        Some(state) => state,
+        None => 0xFFFF
+    };
+
+    let mut chunks_iter: ChunksExact<u8> = buf.chunks_exact(2);
+    while let Some(chunk) = chunks_iter.next() {
+        state += u16::from_be_bytes([chunk[0], chunk[1]]) as u32;
+    }
+
+    if let Some(&b) = chunks_iter.remainder().get(0) {
+        state += u16::from_be_bytes([b, 0]) as u32;
+    }
+
+    state
+}
+
+/// Folds 32-bit sum into 16-bit checksum value.
+pub fn fold16(mut state: u32) -> u16 {
+    while state > 0xFFFF {
+        state -= 0xFFFF;
+    }
+    !state as u16
 }


### PR DESCRIPTION
### Description

- This PR closes https://github.com/demikernel/demikernel/issues/205

### Summary of Changes

- Created two auxiliary functions: `generic_checksum` and `fold16` to compute one's complement checksum;
- Updated ICMPv4, IPv4, UDP, and TCP protocols to use `generic_checksum` in parse and serialize functions.