### PR TITLE
[catmem] Missing `async_close`

### DIFF
--- a/src/rust/catmem/futures/close.rs
+++ b/src/rust/catmem/futures/close.rs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use std::rc::Rc;
+
+use crate::{
+    collections::shared_ring::SharedRingBuffer,
+    runtime::fail::Fail,
+    scheduler::Yielder,
+};
+
+//======================================================================================================================
+// Constants
+//======================================================================================================================
+
+/// End of file signal.
+const EOF: u16 = (1 & 0xff) << 8;
+
+/// Maximum number of retries for pushing a EoF signal.
+const MAX_RETRIES_PUSH_EOF: u32 = 16;
+
+//======================================================================================================================
+// Standalone Functions
+//======================================================================================================================
+
+/// This function calls close on a file descriptor until it is closed successfully.
+/// TODO merge this with push_eof(), when async_close() and close() are merged.
+pub async fn close_coroutine(ring: Rc<SharedRingBuffer<u16>>, yielder: Yielder) -> Result<(), Fail> {
+    // Maximum number of retries. This is set to an arbitrary small value.
+    let mut retries: u32 = MAX_RETRIES_PUSH_EOF;
+
+    loop {
+        match ring.try_enqueue(EOF) {
+            // Operation completed.
+            Ok(()) => break,
+            // Operation not completed yet, check what happened.
+            Err(_) => {
+                retries -= 1;
+                // Check if we have retried many times.
+                if retries == 0 {
+                    // We did, thus fail.
+                    let cause: String = format!("failed to push EoF");
+                    error!("push_eof(): {}", cause);
+                    return Err(Fail::new(libc::EIO, &cause));
+                } else {
+                    // We did not, thus retry.
+                    match yielder.yield_once().await {
+                        Ok(()) => continue,
+                        Err(cause) => return Err(cause),
+                    }
+                }
+            },
+        }
+    }
+
+    Ok(())
+}
+
+/// Pushes the EoF signal to a shared ring buffer.
+/// TODO merge this with close_coroutine(), when async_close() and close() are merged.
+pub fn push_eof(ring: Rc<SharedRingBuffer<u16>>) -> Result<(), Fail> {
+    // Maximum number of retries. This is set to an arbitrary small value.
+    let mut retries: u32 = MAX_RETRIES_PUSH_EOF;
+    const EOF: u16 = (1 & 0xff) << 8;
+
+    loop {
+        match ring.try_enqueue(EOF) {
+            Ok(()) => break,
+            Err(_) => {
+                retries -= 1;
+                if retries == 0 {
+                    let cause: String = format!("failed to push EoF");
+                    error!("push_eof(): {}", cause);
+                    return Err(Fail::new(libc::EIO, &cause));
+                }
+            },
+        }
+    }
+
+    Ok(())
+}

--- a/src/rust/catmem/futures/mod.rs
+++ b/src/rust/catmem/futures/mod.rs
@@ -5,6 +5,7 @@
 // Exports
 //======================================================================================================================
 
+pub mod close;
 pub mod pop;
 pub mod push;
 
@@ -22,5 +23,6 @@ use crate::runtime::{
 pub enum OperationResult {
     Push,
     Pop(DemiBuffer),
+    Close,
     Failed(Fail),
 }

--- a/src/rust/demikernel/libos/memory.rs
+++ b/src/rust/demikernel/libos/memory.rs
@@ -67,6 +67,16 @@ impl MemoryLibOS {
         }
     }
 
+    /// Asynchronously closes a memory queue.
+    #[allow(unreachable_patterns, unused_variables)]
+    pub fn async_close(&mut self, memqd: QDesc) -> Result<QToken, Fail> {
+        match self {
+            #[cfg(feature = "catmem-libos")]
+            MemoryLibOS::Catmem(libos) => libos.async_close(memqd),
+            _ => unreachable!("unknown memory libos"),
+        }
+    }
+
     /// Pushes a scatter-gather array to a memory queue.
     #[allow(unreachable_patterns, unused_variables)]
     pub fn push(&mut self, memqd: QDesc, sga: &demi_sgarray_t) -> Result<QToken, Fail> {

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -217,7 +217,7 @@ impl LibOS {
     pub fn async_close(&mut self, qd: QDesc) -> Result<QToken, Fail> {
         let result: Result<QToken, Fail> = match self {
             LibOS::NetworkLibOS(libos) => libos.async_close(qd),
-            _ => unimplemented!("No async close for memory libOSes"),
+            LibOS::MemoryLibOS(libos) => libos.async_close(qd),
         };
 
         self.poll();


### PR DESCRIPTION
## Description

- This PR closes https://github.com/microsoft/demikernel/issues/659.

## Summary of Changes

- Implemented `async_close()` for Catmem LibOS
- Fixed async close tests on pipes
- Enabled standalone tests for Catmem LibOS