### PR TITLE
[test] Missing cases on IPv4 test-unit

### DIFF
--- a/src/rust/inetstack/protocols/ipv4/datagram.rs
+++ b/src/rust/inetstack/protocols/ipv4/datagram.rs
@@ -308,6 +308,14 @@ impl Ipv4Header {
     /// Computes the checksum of the target IPv4 header.
     pub fn compute_checksum(buf: &[u8]) -> u16 {
         let mut state: u32 = 0xffff;
+
+        // Do not compute checksum if buffer is too small.
+        if buf.len() < IPV4_HEADER_MIN_SIZE as usize {
+            // This should not happen by construction. If it does, log it.
+            warn!("compute_checksum: buffer is too small (len={})", buf.len());
+            return 0;
+        }
+
         for i in 0..5 {
             state += u16::from_be_bytes([buf[2 * i], buf[2 * i + 1]]) as u32;
         }

--- a/src/rust/inetstack/protocols/ipv4/tests.rs
+++ b/src/rust/inetstack/protocols/ipv4/tests.rs
@@ -72,7 +72,8 @@ fn build_ipv4_header(
 
     // Header checksum.
     if checksum.is_none() {
-        checksum = Some(Ipv4Header::compute_checksum(&buf[..20]));
+        let header_size: usize = (ihl as usize) << 2;
+        checksum = Some(Ipv4Header::compute_checksum(&buf[..header_size]));
     }
     buf[10..12].copy_from_slice(&checksum.unwrap().to_be_bytes());
 }

--- a/src/rust/inetstack/protocols/ipv4/tests.rs
+++ b/src/rust/inetstack/protocols/ipv4/tests.rs
@@ -92,7 +92,7 @@ fn test_ipv4_header_parse_good() -> Result<()> {
     let data: [u8; PAYLOAD_SIZE] = [1, 2, 3, 4, 5, 6, 7, 8];
     let data_bytes: DemiBuffer = DemiBuffer::from_slice(&data).expect("'data' should fit in a DemiBuffer");
 
-    for ihl in 5..15 {
+    for ihl in 5..16 {
         let header_size: usize = (ihl as usize) << 2;
         let datagram_size: usize = header_size + PAYLOAD_SIZE;
         build_ipv4_header(


### PR DESCRIPTION
## Description

This PR closes #781.

## Summary of Changes

- Updated the upper bound of the for in the test_ipv4_header_parse_good test to include the value 15.
- Added the header length in the build_ipv4_header function.
- Verified the minimum size of the buffer in the compute_checksum function.