### PR TITLE
[catloop] Rollback Port Allocation

### DIFF
--- a/src/rust/catloop/futures/accept.rs
+++ b/src/rust/catloop/futures/accept.rs
@@ -60,7 +60,7 @@ pub async fn accept_coroutine(
         )
         .await
         {
-            // Recieved a valid magic number so create the new connection. This involves create the new duplex pipe
+            // Received a valid magic number so create the new connection. This involves create the new duplex pipe
             // and sending the port number to the remote.
             Ok(true) => create_pipe(&catmem, control_duplex_pipe.clone(), ipv4, new_port, &yielder).await?,
             // Invalid request.


### PR DESCRIPTION
## Description

This PR closes #621

## Summary of Changes

- Updated `CatloopLibOS` inserting the `EphemeralPorts` allocator.
- Allocated ports using the port allocator.
- Rollbacked the port allocation when the `accept` failed.
- Rollbacked the port allocation when the socket closed.