### PR TITLE
[tests] Turn on and fix Pipe Integration Tests

### DIFF
--- a/linux.mk
+++ b/linux.mk
@@ -215,7 +215,7 @@ test-unit-rust: test-clean
 	$(CARGO) test --test sga $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_loop_decoupled_big
 
 # Runs Rust integration tests.
-test-integration-rust: test-clean
+test-integration-rust:
 	$(CARGO) test --test $(TEST_INTEGRATION) $(CARGO_FLAGS) $(CARGO_FEATURES) -- $(ARGS)
 
 # Cleans dangling test resources.

--- a/linux.mk
+++ b/linux.mk
@@ -186,7 +186,7 @@ export MSS ?= 1500
 export PEER ?= server
 export TEST ?= udp-push-pop
 export TEST_INTEGRATION ?= tcp-test
-export TIMEOUT ?= 30
+export TIMEOUT ?= 60
 
 # Runs system tests.
 test-system: test-system-rust
@@ -200,23 +200,23 @@ test-unit: test-unit-rust
 
 # C unit tests.
 test-unit-c: test-clean $(BINDIR)/syscalls.elf
-	$(BINDIR)/syscalls.elf
+	timeout $(TIMEOUT) $(BINDIR)/syscalls.elf
 
 # Rust unit tests.
 test-unit-rust: test-clean
-	$(CARGO) test --lib $(CARGO_FLAGS) $(CARGO_FEATURES) -- --nocapture
-	$(CARGO) test --test udp $(CARGO_FLAGS) $(CARGO_FEATURES) -- --nocapture
-	$(CARGO) test --test tcp $(CARGO_FLAGS) $(CARGO_FEATURES) -- --nocapture
-	$(CARGO) test --test sga $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_single_small
-	$(CARGO) test --test sga $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_loop_tight_small
-	$(CARGO) test --test sga $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_loop_decoupled_small
-	$(CARGO) test --test sga $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_single_big
-	$(CARGO) test --test sga $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_loop_tight_big
-	$(CARGO) test --test sga $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_loop_decoupled_big
+	timeout $(TIMEOUT) $(CARGO) test --lib $(CARGO_FLAGS) $(CARGO_FEATURES) -- --nocapture
+	timeout $(TIMEOUT) $(CARGO) test --test udp $(CARGO_FLAGS) $(CARGO_FEATURES) -- --nocapture
+	timeout $(TIMEOUT) $(CARGO) test --test tcp $(CARGO_FLAGS) $(CARGO_FEATURES) -- --nocapture
+	timeout $(TIMEOUT) $(CARGO) test --test sga $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_single_small
+	timeout $(TIMEOUT) $(CARGO) test --test sga $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_loop_tight_small
+	timeout $(TIMEOUT) $(CARGO) test --test sga $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_loop_decoupled_small
+	timeout $(TIMEOUT) $(CARGO) test --test sga $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_single_big
+	timeout $(TIMEOUT) $(CARGO) test --test sga $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_loop_tight_big
+	timeout $(TIMEOUT) $(CARGO) test --test sga $(BUILD) $(CARGO_FEATURES) -- --nocapture --test-threads=1 test_unit_sga_alloc_free_loop_decoupled_big
 
 # Runs Rust integration tests.
 test-integration-rust:
-	$(CARGO) test --test $(TEST_INTEGRATION) $(CARGO_FLAGS) $(CARGO_FEATURES) -- $(ARGS)
+	timeout $(TIMEOUT) $(CARGO) test --test $(TEST_INTEGRATION) $(CARGO_FLAGS) $(CARGO_FEATURES) -- $(ARGS)
 
 # Cleans dangling test resources.
 test-clean:

--- a/tests/rust/pipe-test/pop_wait/client.rs
+++ b/tests/rust/pipe-test/pop_wait/client.rs
@@ -13,6 +13,10 @@ use ::demikernel::{
     QDesc,
     QToken,
 };
+use ::log::{
+    error,
+    warn,
+};
 use ::std::slice;
 use std::time::Duration;
 
@@ -77,8 +81,8 @@ impl PipeClient {
 
         // Succeed to release scatter-gather-array.
         if let Err(e) = self.libos.sgafree(sga) {
-            println!("WARN: leaking sga");
-            println!("ERROR: sgafree() failed (error={:?})", e);
+            warn!("leaking sga");
+            error!("sgafree() failed (error={:?})", e);
         }
 
         qt
@@ -114,8 +118,8 @@ impl Drop for PipeClient {
     fn drop(&mut self) {
         // Ignore error.
         if let Err(e) = self.libos.close(self.pipeqd) {
-            println!("WARN: leaking pipeqd={:?}", self.pipeqd);
-            println!("ERROR: close() failed (error={:?})", e);
+            warn!("leaking pipeqd={:?}", self.pipeqd);
+            error!("close() failed (error={:?})", e);
         }
     }
 }

--- a/tests/rust/pipe-test/push_wait/server.rs
+++ b/tests/rust/pipe-test/push_wait/server.rs
@@ -16,6 +16,10 @@ use ::demikernel::{
     QDesc,
     QToken,
 };
+use ::log::{
+    error,
+    warn,
+};
 
 //======================================================================================================================
 // Structures
@@ -68,8 +72,8 @@ impl PipeServer {
         n += sga.sga_segs[0].sgaseg_len as usize;
 
         if let Err(e) = self.libos.sgafree(sga) {
-            println!("ERROR: sgafree() failed (error={:?})", e);
-            println!("WARN: leaking sga");
+            error!("sgafree() failed (error={:?})", e);
+            warn!("leaking sga");
         }
 
         Ok(n)
@@ -105,8 +109,8 @@ impl Drop for PipeServer {
         if let Some(pipeqd) = self.pipeqd {
             // Ignore error.
             if let Err(e) = self.libos.close(pipeqd) {
-                println!("ERROR: close() failed (error={:?})", e);
-                println!("WARN: leaking pipeqd={:?}", pipeqd);
+                error!("close() failed (error={:?})", e);
+                warn!("leaking pipeqd={:?}", pipeqd);
             }
         }
     }

--- a/tools/demikernel_ci.py
+++ b/tools/demikernel_ci.py
@@ -522,8 +522,8 @@ def main():
     # Extract test options.
     test_unit: bool = args.test_unit
     test_system: str = args.test_system
-    server_addr: str = args.server_addr if test_system else ""
-    client_addr: str = args.client_addr if test_system else ""
+    server_addr: str = args.server_addr
+    client_addr: str = args.client_addr
 
     # Output directory.
     output_dir: str = args.output_dir

--- a/tools/demikernel_ci.py
+++ b/tools/demikernel_ci.py
@@ -168,7 +168,7 @@ def job_test_integration_tcp_rust(
 
 def job_test_integration_pipe_rust(
         repo: str, libos: str, is_debug: bool, run_mode: str, server: str, client: str, server_addr: str,
-        is_sudo: bool, config_path: str, log_directory: str) -> bool:
+        delay: float, is_sudo: bool, config_path: str, log_directory: str) -> bool:
     server_args: str = "--peer server --pipe-name {}:12345 --run-mode {}".format(server_addr, run_mode)
     client_args: str = "--peer client --pipe-name {}:12345 --run-mode {}".format(server_addr, run_mode)
     server_cmd: str = "test-integration-rust TEST_INTEGRATION=pipe-test LIBOS={} ARGS=\\\"{}\\\"".format(
@@ -179,6 +179,7 @@ def job_test_integration_pipe_rust(
     jobs: dict[str, subprocess.Popen[str]] = {}
     jobs[test_name + "-server-" + server] = remote_run(server, repo, is_debug, server_cmd, is_sudo, config_path)
     if run_mode != "standalone":
+        time.sleep(delay)
         jobs[test_name + "-client-" + client] = remote_run(client, repo, is_debug, client_cmd, is_sudo, config_path)
     return wait_and_report(test_name, log_directory, jobs, True)
 
@@ -366,19 +367,19 @@ def run_pipeline(
                     repository, libos, is_debug, server, client, server_addr, client_addr, is_sudo, config_path, log_directory)
             elif libos == "catmem":
                 status["integration_tests"] = job_test_integration_pipe_rust(
-                    repository, libos, is_debug, "standalone", server, client, server_addr, is_sudo,
+                    repository, libos, is_debug, "standalone", server, client, server_addr, delay, is_sudo,
                     config_path, log_directory)
                 status["integration_tests"] = job_test_integration_pipe_rust(
-                    repository, libos, is_debug, "push-wait", server, client, server_addr, is_sudo,
+                    repository, libos, is_debug, "push-wait", server, client, server_addr, delay, is_sudo,
                     config_path, log_directory)
                 status["integration_tests"] = job_test_integration_pipe_rust(
-                    repository, libos, is_debug, "pop-wait", server, client, server_addr, is_sudo,
+                    repository, libos, is_debug, "pop-wait", server, client, server_addr, delay, is_sudo,
                     config_path, log_directory)
                 status["integration_tests"] = job_test_integration_pipe_rust(
-                    repository, libos, is_debug, "push-wait-async", server, client, server_addr, is_sudo,
+                    repository, libos, is_debug, "push-wait-async", server, client, server_addr, delay, is_sudo,
                     config_path, log_directory)
                 status["integration_tests"] = job_test_integration_pipe_rust(
-                    repository, libos, is_debug, "pop-wait-async", server, client, server_addr, is_sudo,
+                    repository, libos, is_debug, "pop-wait-async", server, client, server_addr, delay, is_sudo,
                     config_path, log_directory)
 
     # STEP 4: Run system tests.

--- a/tools/demikernel_ci.py
+++ b/tools/demikernel_ci.py
@@ -170,7 +170,7 @@ def job_test_integration_pipe_rust(
         repo: str, libos: str, is_debug: bool, run_mode: str, server: str, client: str, server_addr: str,
         is_sudo: bool, config_path: str, log_directory: str) -> bool:
     server_args: str = "--peer server --pipe-name {}:12345 --run-mode {}".format(server_addr, run_mode)
-    client_args: str = "--peer client --pipe-name {}:23456 --run-mode {}".format(server_addr, run_mode)
+    client_args: str = "--peer client --pipe-name {}:12345 --run-mode {}".format(server_addr, run_mode)
     server_cmd: str = "test-integration-rust TEST_INTEGRATION=pipe-test LIBOS={} ARGS=\\\"{}\\\"".format(
         libos, server_args)
     client_cmd: str = "test-integration-rust TEST_INTEGRATION=pipe-test LIBOS={} ARGS=\\\"{}\\\"".format(
@@ -367,6 +367,18 @@ def run_pipeline(
             elif libos == "catmem":
                 status["integration_tests"] = job_test_integration_pipe_rust(
                     repository, libos, is_debug, "standalone", server, client, server_addr, is_sudo,
+                    config_path, log_directory)
+                status["integration_tests"] = job_test_integration_pipe_rust(
+                    repository, libos, is_debug, "push-wait", server, client, server_addr, is_sudo,
+                    config_path, log_directory)
+                status["integration_tests"] = job_test_integration_pipe_rust(
+                    repository, libos, is_debug, "pop-wait", server, client, server_addr, is_sudo,
+                    config_path, log_directory)
+                status["integration_tests"] = job_test_integration_pipe_rust(
+                    repository, libos, is_debug, "push-wait-async", server, client, server_addr, is_sudo,
+                    config_path, log_directory)
+                status["integration_tests"] = job_test_integration_pipe_rust(
+                    repository, libos, is_debug, "pop-wait-async", server, client, server_addr, is_sudo,
                     config_path, log_directory)
 
     # STEP 4: Run system tests.


### PR DESCRIPTION
This PR turns on 4 tests: push-wait and pop-wait and push-wait-async and pop-wait-async. It also fixes a bug in catmem that causes the tests to fail and fixes some bugs in the tests themselves. I have turned off close for now due to an issue that will be fixed by issue #701 