### PR TITLE
[catmem] Broken Trace Statement

### DIFF
--- a/src/rust/catcollar/futures/connect.rs
+++ b/src/rust/catcollar/futures/connect.rs
@@ -75,7 +75,7 @@ impl Future for ConnectFuture {
         } {
             // Operation completed.
             stats if stats == 0 => {
-                trace!("connection established ({:?})", self_.saddr);
+                trace!("connection established (fd={:?})", self_.fd);
                 Poll::Ready(Ok(()))
             },
 


### PR DESCRIPTION
## Description

This is a hotfix for recent bug that was triggered by some third-party crate that got updated.