### PR TITLE
[pal] Move SOMAXCONN to PAL

### DIFF
--- a/src/rust/catcollar/mod.rs
+++ b/src/rust/catcollar/mod.rs
@@ -30,6 +30,7 @@ use self::futures::{
 use crate::{
     demikernel::config::Config,
     pal::{
+        constants::SOMAXCONN,
         data_structures::{
             SockAddr,
             SockAddrIn,
@@ -211,7 +212,7 @@ impl CatcollarLibOS {
         trace!("listen() qd={:?}, backlog={:?}", qd, backlog);
 
         // We just assert backlog here, because it was previously checked at PDPIX layer.
-        debug_assert!((backlog > 0) && (backlog <= libc::SOMAXCONN as usize));
+        debug_assert!((backlog > 0) && (backlog <= SOMAXCONN as usize));
 
         // Issue listen operation.
         match self.qtable.borrow().get(&qd) {

--- a/src/rust/catloop/mod.rs
+++ b/src/rust/catloop/mod.rs
@@ -27,6 +27,7 @@ use crate::{
     demi_sgarray_t,
     inetstack::protocols::ip::EphemeralPorts,
     pal::{
+        constants::SOMAXCONN,
         data_structures::SockAddr,
         linux,
     },
@@ -234,7 +235,7 @@ impl CatloopLibOS {
         trace!("listen() qd={:?}, backlog={:?}", qd, backlog);
 
         // We just assert backlog here, because it was previously checked at PDPIX layer.
-        debug_assert!((backlog > 0) && (backlog <= libc::SOMAXCONN as usize));
+        debug_assert!((backlog > 0) && (backlog <= SOMAXCONN as usize));
 
         // Check if the queue descriptor is registered in the sockets table.
         match self.qtable.borrow_mut().get_mut(&qd) {

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -32,6 +32,7 @@ use self::{
 use crate::{
     demikernel::config::Config,
     pal::{
+        constants::SOMAXCONN,
         data_structures::{
             SockAddr,
             SockAddrIn,
@@ -252,7 +253,7 @@ impl CatnapLibOS {
         trace!("listen() qd={:?}, backlog={:?}", qd, backlog);
 
         // We just assert backlog here, because it was previously checked at PDPIX layer.
-        debug_assert!((backlog > 0) && (backlog <= libc::SOMAXCONN as usize));
+        debug_assert!((backlog > 0) && (backlog <= SOMAXCONN as usize));
 
         // Issue listen operation.
         match self.qtable.borrow_mut().get_mut(&qd) {

--- a/src/rust/demikernel/libos/network.rs
+++ b/src/rust/demikernel/libos/network.rs
@@ -6,6 +6,7 @@
 //======================================================================================================================
 
 use crate::{
+    pal::constants::SOMAXCONN,
     runtime::{
         fail::Fail,
         types::{
@@ -102,13 +103,13 @@ impl NetworkLibOS {
     /// Marks a socket as a passive one.
     pub fn listen(&mut self, sockqd: QDesc, mut backlog: usize) -> Result<(), Fail> {
         // Truncate backlog length.
-        if backlog > libc::SOMAXCONN as usize {
+        if backlog > SOMAXCONN as usize {
             let cause: String = format!(
                 "backlog length is too large, truncating (qd={:?}, backlog={:?})",
                 sockqd, backlog
             );
             debug!("listen(): {}", &cause);
-            backlog = libc::SOMAXCONN as usize;
+            backlog = SOMAXCONN as usize;
         }
 
         // Round up backlog length.

--- a/src/rust/pal/constants.rs
+++ b/src/rust/pal/constants.rs
@@ -20,6 +20,9 @@ pub const SOCK_STREAM: i32 = WinSock::SOCK_STREAM as i32;
 #[cfg(target_os = "windows")]
 pub const SOCK_DGRAM: i32 = WinSock::SOCK_DGRAM as i32;
 
+#[cfg(target_os = "windows")]
+pub const SOMAXCONN: i32 = WinSock::SOMAXCONN;
+
 //==============================================================================
 // Linux constants
 //==============================================================================
@@ -35,3 +38,6 @@ pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
 
 #[cfg(target_os = "linux")]
 pub const SOCK_DGRAM: i32 = libc::SOCK_DGRAM;
+
+#[cfg(target_os = "linux")]
+pub const SOMAXCONN: i32 = libc::SOMAXCONN;

--- a/tests/rust/tcp-test/listen/mod.rs
+++ b/tests/rust/tcp-test/listen/mod.rs
@@ -27,11 +27,17 @@ pub const AF_INET: i32 = windows::Win32::Networking::WinSock::AF_INET.0 as i32;
 #[cfg(target_os = "windows")]
 pub const SOCK_STREAM: i32 = windows::Win32::Networking::WinSock::SOCK_STREAM as i32;
 
+#[cfg(target_os = "windows")]
+pub const SOMAXCONN: i32 = windows::Win32::Networking::WinSock::SOMAXCONN;
+
 #[cfg(target_os = "linux")]
 pub const AF_INET: i32 = libc::AF_INET;
 
 #[cfg(target_os = "linux")]
 pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
+
+#[cfg(target_os = "linux")]
+pub const SOMAXCONN: i32 = libc::SOMAXCONN;
 
 //======================================================================================================================
 // Standalone Functions
@@ -126,7 +132,7 @@ fn listen_large_backlog_length(libos: &mut LibOS, local: &SocketAddrV4) -> Resul
     libos.bind(sockqd, local.to_owned())?;
 
     // Backlog length.
-    let backlog: usize = (libc::SOMAXCONN + 1) as usize;
+    let backlog: usize = (SOMAXCONN + 1) as usize;
 
     // Succeed to listen().
     libos.listen(sockqd, backlog)?;


### PR DESCRIPTION
Making sure that the SOMAXCONN constant is available on Windows as well. It's not a part of libc (like on Linux).