### PR TITLE
[Catmem] Enhancement: Mutex locking

### DIFF
--- a/src/rust/catmem/ring/pop_ring.rs
+++ b/src/rust/catmem/ring/pop_ring.rs
@@ -14,6 +14,7 @@ use crate::{
             state::RingStateMachine,
         },
     },
+    scheduler::Mutex,
 };
 
 //======================================================================================================================
@@ -26,6 +27,8 @@ pub struct PopRing {
     state_machine: RingStateMachine,
     /// Underlying buffer.
     buffer: SharedRingBuffer<u16>,
+    /// Mutex to ensure single-threaded access to this ring.
+    mutex: Mutex,
 }
 
 //======================================================================================================================
@@ -38,6 +41,7 @@ impl PopRing {
         Ok(Self {
             state_machine: RingStateMachine::new(),
             buffer: SharedRingBuffer::create(name, size)?,
+            mutex: Mutex::new(),
         })
     }
 
@@ -46,6 +50,7 @@ impl PopRing {
         Ok(Self {
             state_machine: RingStateMachine::new(),
             buffer: SharedRingBuffer::open(name, size)?,
+            mutex: Mutex::new(),
         })
     }
 
@@ -55,7 +60,12 @@ impl PopRing {
         if self.state_machine.is_closed() {
             return Err(Fail::new(libc::ECONNRESET, "queue was closed"));
         };
-        if let Some(bytes) = self.buffer.try_dequeue() {
+        if !self.mutex.try_lock() {
+            return Ok((None, false));
+        }
+        let out: Option<u16> = self.buffer.try_dequeue();
+        self.mutex.unlock();
+        if let Some(bytes) = out {
             let (high, low): (u8, u8) = (((bytes >> 8) & 0xff) as u8, (bytes & 0xff) as u8);
             Ok((Some(low), high != 0))
         } else {

--- a/src/rust/scheduler/mod.rs
+++ b/src/rust/scheduler/mod.rs
@@ -31,6 +31,7 @@
 //! the scheduler. The [YielderHandle] identifies a specific blocked coroutine and can be used to wake the coroutine.
 
 mod handle;
+pub mod mutex;
 mod page;
 mod pin_slab;
 pub mod scheduler;
@@ -47,6 +48,7 @@ pub use self::{
         TaskHandle,
         YielderHandle,
     },
+    mutex::Mutex,
     scheduler::Scheduler,
     task::{
         Task,

--- a/src/rust/scheduler/mutex.rs
+++ b/src/rust/scheduler/mutex.rs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use crate::{
+    runtime::fail::Fail,
+    scheduler::yielder::Yielder,
+};
+
+use ::std::{
+    cell::{
+        Ref,
+        RefCell,
+    },
+    rc::Rc,
+    sync::atomic::{
+        AtomicBool,
+        Ordering,
+    },
+};
+
+//======================================================================================================================
+// Structures
+//======================================================================================================================
+
+/// Mutex for ensuring single-threaded access to a resource.
+#[derive(Clone)]
+pub struct Mutex {
+    locked: Rc<RefCell<AtomicBool>>,
+}
+
+//======================================================================================================================
+// Associate Functions
+//======================================================================================================================
+impl Mutex {
+    pub fn new() -> Self {
+        Self {
+            locked: Rc::new(RefCell::<AtomicBool>::new(AtomicBool::new(false))),
+        }
+    }
+
+    /// Acquire this lock. If the lock is locked, then yield once and try again until we are able to acquire the lock.
+    pub async fn lock(&self, yielder: Yielder) -> Result<(), Fail> {
+        let mut locked: Ref<AtomicBool> = self.locked.borrow();
+        while locked.swap(true, Ordering::Acquire) {
+            drop(locked);
+            // Could not acquire lock. Yield and try again.
+            // TODO: Make this more efficient by signaling.
+            match yielder.yield_once().await {
+                Ok(()) => locked = self.locked.borrow(),
+                Err(cause) => return Err(cause),
+            }
+        }
+        Ok(())
+    }
+
+    /// Try to acquire this lock. Return [true] if successful
+    pub fn try_lock(&self) -> bool {
+        let locked: Ref<AtomicBool> = self.locked.borrow();
+        match locked.swap(true, Ordering::Acquire) {
+            // The lock was previously locked.
+            true => false,
+            false => true,
+        }
+    }
+
+    /// Release this lock.
+    pub fn unlock(&self) {
+        // Unlock this mutex. Must return true as it was previously locked.
+        assert_eq!(self.locked.borrow_mut().swap(false, Ordering::Release), true);
+    }
+}


### PR DESCRIPTION
This PR adds a simple mutex to the scheduler that can be used to guarantee serialized access to the data structure. The mutex can either be used by polling it or passing in a yielder that will yield back to the scheduler if the mutex is currently locked. This PR is a fix to issue #842, although all the producers must be in a single process and all consumers as well. 