### PR TITLE
[catmem] Move to catnap arch

### DIFF
--- a/src/rust/catmem/mod.rs
+++ b/src/rust/catmem/mod.rs
@@ -32,14 +32,10 @@ use crate::{
         TaskHandle,
         TaskWithResult,
         Yielder,
-        YielderHandle,
     },
 };
 use ::std::{
-    cell::{
-        RefCell,
-        RefMut,
-    },
+    cell::RefCell,
     future::Future,
     mem,
     pin::Pin,
@@ -102,7 +98,7 @@ impl CatmemLibOS {
     }
 
     /// Creates a new memory queue and connects to the [mode] end.
-    pub fn create_pipe(&mut self, name: &str, mode: QMode) -> Result<QDesc, Fail> {
+    pub fn create_pipe(&self, name: &str, mode: QMode) -> Result<QDesc, Fail> {
         trace!("create_pipe() name={:?}", name);
         let qd: QDesc = self.qtable.borrow_mut().alloc(CatmemQueue::create(name, mode)?);
 
@@ -110,7 +106,7 @@ impl CatmemLibOS {
     }
 
     /// Opens a memory queue and connects to the [mode] end.
-    pub fn open_pipe(&mut self, name: &str, mode: QMode) -> Result<QDesc, Fail> {
+    pub fn open_pipe(&self, name: &str, mode: QMode) -> Result<QDesc, Fail> {
         trace!("open_pipe() name={:?}", name);
 
         let qd: QDesc = self.qtable.borrow_mut().alloc(CatmemQueue::open(name, mode)?);
@@ -120,108 +116,57 @@ impl CatmemLibOS {
 
     /// Shutdown a consumer/pop-only queue. Currently, this is basically a no-op but it does cancel pending operations
     /// and free the queue from the IoQueueTable.
-    pub fn shutdown(&mut self, qd: QDesc) -> Result<(), Fail> {
+    pub fn shutdown(&self, qd: QDesc) -> Result<(), Fail> {
         trace!("shutdown() qd={:?}", qd);
-        let mut queue: CatmemQueue = self.get_queue(qd)?;
-        queue.prepare_close()?;
-        queue.commit();
-        queue.prepare_closed()?;
-        queue.cancel_pending_ops(Fail::new(libc::ECANCELED, "this queue was shutdown"));
-        queue.commit();
+        self.get_queue(qd)?.shutdown()?;
         self.qtable.borrow_mut().free(&qd);
         Ok(())
     }
 
     /// Closes a memory queue.
-    pub fn close(&mut self, qd: QDesc) -> Result<(), Fail> {
+    pub fn close(&self, qd: QDesc) -> Result<(), Fail> {
         trace!("close() qd={:?}", qd);
-        let mut queue: CatmemQueue = self.get_queue(qd)?;
-        queue.prepare_close()?;
-        match queue.close() {
-            Ok(()) => {
-                queue.commit();
-                queue.prepare_closed()?;
-                queue.cancel_pending_ops(Fail::new(libc::ECANCELED, "this queue was closed"));
-                queue.commit();
-                self.qtable.borrow_mut().free(&qd);
-                Ok(())
-            },
-            Err(e) => {
-                queue.abort();
-                Err(e)
-            },
-        }
+        self.get_queue(qd)?.close()?;
+        self.qtable.borrow_mut().free(&qd);
+        Ok(())
     }
 
     /// Asynchronously close a socket.
-    pub fn async_close(&mut self, qd: QDesc) -> Result<QToken, Fail> {
+    pub fn async_close(&self, qd: QDesc) -> Result<QToken, Fail> {
         trace!("async_close() qd={:?}", qd);
-        let queue: CatmemQueue = self.get_queue(qd)?;
-        // Check that queue is not already closed and move to the closing state.
-        queue.prepare_close()?;
+        let coroutine = move |yielder: Yielder| -> Result<TaskHandle, Fail> {
+            let coroutine: Pin<Box<Operation>> = self.async_close_coroutine(qd, yielder)?;
+            let task_name: String = format!("catmem::async_close for qd={:?}", qd);
+            self.insert_coroutine(&task_name, coroutine)
+        };
+        Ok(self.get_queue(qd)?.async_close(coroutine)?)
+    }
 
+    pub fn async_close_coroutine(&self, qd: QDesc, yielder: Yielder) -> Result<Pin<Box<Operation>>, Fail> {
         let qtable_ptr: Rc<RefCell<IoQueueTable<CatmemQueue>>> = self.qtable.clone();
-        let yielder: Yielder = Yielder::new();
-        let coroutine: Pin<Box<Operation>> = Box::pin(async move {
-            if let Err(e) = queue.prepare_closed() {
-                warn!("async_close() qd={:?}: {:?}", qd, &e);
-                return (qd, OperationResult::Failed(e));
-            }
+        let queue: CatmemQueue = self.get_queue(qd)?;
+        Ok(Box::pin(async move {
             // Wait for close operation to complete.
-            match queue.async_close(yielder).await {
+            match queue.do_async_close(yielder).await {
                 // Operation completed successfully, thus free resources.
                 Ok(()) => {
-                    queue.commit();
-                    let mut qtable_: RefMut<IoQueueTable<CatmemQueue>> = qtable_ptr.borrow_mut();
-                    match qtable_.get_mut(&qd) {
-                        Some(queue) => {
-                            // Cancel all pending operations.
-                            queue.cancel_pending_ops(Fail::new(libc::ECANCELED, "this queue was closed"));
-                        },
-                        None => {
-                            let cause: &String = &format!("invalid queue descriptor: {:?}", qd);
-                            error!("{}", &cause);
-                            return (qd, OperationResult::Failed(Fail::new(libc::EBADF, cause)));
-                        },
-                    }
-
                     // Release the queue descriptor, even if pushing EoF failed. This will prevent any further
                     // operations on the queue, as well as it will ensure that the underlying shared ring buffer will
                     // be eventually released.
-                    qtable_.free(&qd);
+                    qtable_ptr.borrow_mut().free(&qd);
                     (qd, OperationResult::Close)
                 },
                 // Operation failed, thus warn and return an error.
                 Err(e) => {
-                    queue.abort();
                     warn!("async_close(): {:?}", &e);
                     (qd, OperationResult::Failed(e))
                 },
             }
-        });
-        {
-            // Schedule coroutine.
-            let queue: CatmemQueue = self.get_queue(qd)?;
-            let task_name: String = format!("catmem::async_close for qd={:?}", qd);
-            let task: OperationTask = OperationTask::new(task_name, coroutine);
-            let handle: TaskHandle = match self.scheduler.insert(task) {
-                Some(handle) => {
-                    queue.commit();
-                    handle
-                },
-                None => {
-                    queue.abort();
-                    let cause: String = format!("cannot schedule coroutine (qd={:?})", qd);
-                    error!("async_close(): {}", &cause);
-                    return Err(Fail::new(libc::EAGAIN, &cause));
-                },
-            };
-            Ok(handle.get_task_id().into())
-        }
+        }))
     }
 
     /// Pushes a scatter-gather array to a Push ring. If not a Push ring, then fail.
-    pub fn push(&mut self, qd: QDesc, sga: &demi_sgarray_t) -> Result<QToken, Fail> {
+    pub fn push(&self, qd: QDesc, sga: &demi_sgarray_t) -> Result<QToken, Fail> {
         trace!("push() qd={:?}", qd);
 
         let buf: DemiBuffer = self.clone_sgarray(sga)?;
@@ -231,91 +176,55 @@ impl CatmemLibOS {
             error!("push(): {}", cause);
             return Err(Fail::new(libc::EINVAL, &cause));
         }
+
+        // Issue pop operation.
+        let coroutine = move |yielder: Yielder| -> Result<TaskHandle, Fail> {
+            let coroutine: Pin<Box<Operation>> = self.push_coroutine(qd, buf, yielder)?;
+            let task_name: String = format!("Catmem::push for qd={:?}", qd);
+            self.insert_coroutine(&task_name, coroutine)
+        };
+        self.get_queue(qd)?.push(coroutine)
+    }
+
+    pub fn push_coroutine(&self, qd: QDesc, buf: DemiBuffer, yielder: Yielder) -> Result<Pin<Box<Operation>>, Fail> {
         let queue: CatmemQueue = self.get_queue(qd)?;
 
-        // Create co-routine.
-        let yielder: Yielder = Yielder::new();
-        let yielder_handle: YielderHandle = yielder.get_handle();
-        let coroutine: Pin<Box<Operation>> = {
-            Box::pin(async move {
-                // Handle result.
-                match queue.push(buf, yielder).await {
-                    Ok(()) => (qd, OperationResult::Push),
-                    Err(e) => (qd, OperationResult::Failed(e)),
-                }
-            })
-        };
-        let task_id: String = format!("Catmem::push for qd={:?}", qd);
-        let task: OperationTask = OperationTask::new(task_id, coroutine);
-        let handle: TaskHandle = match self.scheduler.insert(task) {
-            Some(handle) => handle,
-            None => {
-                let cause: String = format!("cannot schedule co-routine (qd={:?})", qd);
-                error!("push(): {}", cause);
-                return Err(Fail::new(libc::EAGAIN, &cause));
-            },
-        };
-        self.get_queue(qd)?.add_pending_op(&handle, &yielder_handle);
-        let qt: QToken = handle.get_task_id().into();
-        trace!("push() qt={:?}", qt);
-        Ok(qt)
+        Ok(Box::pin(async move {
+            // Handle result.
+            match queue.do_push(buf, yielder).await {
+                Ok(()) => (qd, OperationResult::Push),
+                Err(e) => (qd, OperationResult::Failed(e)),
+            }
+        }))
     }
 
     /// Pops data from a Pop ring. If not a Pop ring, then return an error.
-    pub fn pop(&mut self, qd: QDesc, size: Option<usize>) -> Result<QToken, Fail> {
+    pub fn pop(&self, qd: QDesc, size: Option<usize>) -> Result<QToken, Fail> {
         trace!("pop() qd={:?}, size={:?}", qd, size);
 
         // We just assert 'size' here, because it was previously checked at PDPIX layer.
         debug_assert!(size.is_none() || ((size.unwrap() > 0) && (size.unwrap() <= limits::POP_SIZE_MAX)));
 
         // Issue pop operation.
+        let coroutine = move |yielder: Yielder| -> Result<TaskHandle, Fail> {
+            let coroutine: Pin<Box<Operation>> = self.pop_coroutine(qd, size, yielder)?;
+            let task_name: String = format!("Catmem::pop for qd={:?}", qd);
+            self.insert_coroutine(&task_name, coroutine)
+        };
+        self.get_queue(qd)?.pop(coroutine)
+    }
+
+    fn pop_coroutine(&self, qd: QDesc, size: Option<usize>, yielder: Yielder) -> Result<Pin<Box<Operation>>, Fail> {
         let queue: CatmemQueue = self.get_queue(qd)?;
-        let yielder: Yielder = Yielder::new();
-        let yielder_handle: YielderHandle = yielder.get_handle();
-        let qtable_ptr: Rc<RefCell<IoQueueTable<CatmemQueue>>> = self.qtable.clone();
-        let coroutine: Pin<Box<Operation>> = Box::pin(async move {
+
+        Ok(Box::pin(async move {
             // Wait for pop to complete.
-            let (buf, eof) = match queue.pop(size, yielder).await {
-                Ok((buf, eof)) => (buf, eof),
+            let (buf, _) = match queue.do_pop(size, yielder).await {
+                Ok(result) => result,
                 Err(e) => return (qd, OperationResult::Failed(e)),
             };
-
-            let mut qtable_: RefMut<IoQueueTable<CatmemQueue>> = qtable_ptr.borrow_mut();
-
-            if eof {
-                match qtable_.get_mut(&qd) {
-                    Some(queue) => {
-                        if let Err(e) = queue.prepare_close() {
-                            warn!("pop() qd={:?}: {:?}", qd, &e);
-                            return (qd, OperationResult::Failed(e));
-                        }
-                        queue.commit();
-                    },
-                    None => {
-                        let cause: &String = &format!("invalid queue descriptor: {:?}", qd);
-                        error!("{}", &cause);
-                        return (qd, OperationResult::Failed(Fail::new(libc::EBADF, cause)));
-                    },
-                };
-            };
-
             (qd, OperationResult::Pop(buf))
-        });
-
-        let task_id: String = format!("Catmem::pop for qd={:?}", qd);
-        let task: OperationTask = OperationTask::new(task_id, coroutine);
-        let handle: TaskHandle = match self.scheduler.insert(task) {
-            Some(handle) => handle,
-            None => {
-                let cause: String = format!("cannot schedule co-routine (qd={:?})", qd);
-                error!("pop(): {}", cause);
-                return Err(Fail::new(libc::EAGAIN, &cause));
-            },
-        };
-        self.get_queue(qd)?.add_pending_op(&handle, &yielder_handle);
-        let qt: QToken = handle.get_task_id().into();
-        trace!("pop() qt={:?}", qt);
-        Ok(qt)
+        }))
     }
 
     /// Allocates a scatter-gather array.
@@ -326,6 +235,18 @@ impl CatmemLibOS {
     /// Releases a scatter-gather array.
     pub fn free_sgarray(&self, sga: demi_sgarray_t) -> Result<(), Fail> {
         MemoryRuntime::free_sgarray(self, sga)
+    }
+
+    pub fn insert_coroutine(&self, task_name: &str, coroutine: Pin<Box<Operation>>) -> Result<TaskHandle, Fail> {
+        let task: OperationTask = OperationTask::new(task_name.to_string(), coroutine);
+        match self.scheduler.insert(task) {
+            Some(handle) => Ok(handle),
+            None => {
+                let cause: String = format!("cannot schedule coroutine (task_name={:?})", &task_name);
+                error!("insert_coroutine(): {}", cause);
+                Err(Fail::new(libc::EAGAIN, &cause))
+            },
+        }
     }
 
     /// Takes out the [OperationResult] associated with the target [TaskHandle].
@@ -428,7 +349,7 @@ impl CatmemLibOS {
 impl Drop for CatmemLibOS {
     // Releases all sockets allocated by Catnap.
     fn drop(&mut self) {
-        for queue in self.qtable.borrow_mut().drain() {
+        for mut queue in self.qtable.borrow_mut().drain() {
             if let Err(e) = queue.close() {
                 error!("push_eof() failed: {:?}", e);
                 warn!("leaking shared memory region");

--- a/src/rust/catmem/queue.rs
+++ b/src/rust/catmem/queue.rs
@@ -5,16 +5,20 @@
 // Imports
 //======================================================================================================================
 
-use super::{
-    ring::Ring,
-    QMode,
-};
 use crate::{
+    catmem::{
+        ring::{
+            Ring,
+            MAX_RETRIES_PUSH_EOF,
+        },
+        QMode,
+    },
     runtime::{
         fail::Fail,
         limits,
         memory::DemiBuffer,
         queue::IoQueue,
+        QToken,
         QType,
     },
     scheduler::{
@@ -24,17 +28,13 @@ use crate::{
     },
 };
 use ::std::{
-    cell::RefCell,
+    cell::{
+        RefCell,
+        RefMut,
+    },
     collections::HashMap,
     rc::Rc,
 };
-
-//======================================================================================================================
-// Constants
-//======================================================================================================================
-
-/// Maximum number of retries for pushing a EoF signal.
-const MAX_RETRIES_PUSH_EOF: u32 = 16;
 
 //======================================================================================================================
 // Structures
@@ -94,71 +94,48 @@ impl CatmemQueue {
         }
     }
 
+    pub fn shutdown(&mut self) -> Result<(), Fail> {
+        {
+            let mut ring: RefMut<Ring> = self.ring.borrow_mut();
+            ring.prepare_close()?;
+            ring.commit();
+            ring.prepare_closed()?;
+            ring.commit();
+        }
+        self.cancel_pending_ops(Fail::new(libc::ECANCELED, "this queue was shutdown"));
+
+        Ok(())
+    }
+
     /// This function closes a ring endpoint.
     /// TODO merge this with async_close().
-    pub fn close(&self) -> Result<(), Fail> {
-        match &mut *self.ring.borrow_mut() {
-            Ring::PushOnly(ring) => {
-                // Attempt to push EoF.
-                // Maximum number of retries. This is set to an arbitrary small value.
-                for _ in 0..MAX_RETRIES_PUSH_EOF {
-                    match ring.try_close() {
-                        Ok(()) => return Ok(()),
-                        Err(_) => continue,
-                    }
-                }
-                let cause: String = format!("failed to push EoF");
-                error!("push_eof(): {}", cause);
-                Err(Fail::new(libc::EIO, &cause))
-            },
-            // Nothing to do on close for a pop ring.
-            Ring::PopOnly(_) => Ok(()),
+    pub fn close(&mut self) -> Result<(), Fail> {
+        {
+            let mut ring: RefMut<Ring> = self.ring.borrow_mut();
+            ring.prepare_close()?;
+            ring.close()?;
+            ring.commit();
+            ring.prepare_closed()?;
+            ring.commit();
         }
+        self.cancel_pending_ops(Fail::new(libc::ECANCELED, "this queue was closed"));
+        Ok(())
     }
 
-    /// Prepares a transition to the closing state.
-    pub fn prepare_close(&self) -> Result<(), Fail> {
-        match &mut *self.ring.borrow_mut() {
-            Ring::PushOnly(ring) => ring.prepare_close(),
-            Ring::PopOnly(ring) => ring.prepare_close(),
-        }
-    }
-
-    /// Prepares a transition to the closed state.
-    pub fn prepare_closed(&self) -> Result<(), Fail> {
-        match &mut *self.ring.borrow_mut() {
-            Ring::PushOnly(ring) => ring.prepare_closed(),
-            Ring::PopOnly(ring) => ring.prepare_closed(),
-        }
-    }
-
-    /// This function commits the queue to closing.
-    pub fn commit(&self) {
-        match &mut *self.ring.borrow_mut() {
-            Ring::PushOnly(ring) => ring.commit(),
-            Ring::PopOnly(ring) => ring.commit(),
-        }
-    }
-
-    /// This function aborts a pending operation.
-    pub fn abort(&self) {
-        match &mut *self.ring.borrow_mut() {
-            Ring::PushOnly(ring) => ring.abort(),
-            Ring::PopOnly(_) => warn!("abort() called on a pop-only queue"),
-        }
-    }
-
-    fn try_close(&self) -> Result<(), Fail> {
-        match &mut *self.ring.borrow_mut() {
-            Ring::PushOnly(ring) => ring.try_close(),
-            Ring::PopOnly(_) => Ok(()),
-        }
+    /// Start an asynchronous coroutine to close this queue. This function contains all of the single-queue,
+    /// asynchronous code necessary to run a close and any single-queue functionality after the close completes.
+    pub fn async_close<F>(&self, insert_coroutine: F) -> Result<QToken, Fail>
+    where
+        F: FnOnce(Yielder) -> Result<TaskHandle, Fail>,
+    {
+        self.ring.borrow_mut().prepare_close()?;
+        self.do_generic_sync_control_path_call(insert_coroutine, false)
     }
 
     /// This function perms an async close on the target queue.
-    pub async fn async_close(&self, yielder: Yielder) -> Result<(), Fail> {
+    pub async fn do_async_close(&self, yielder: Yielder) -> Result<(), Fail> {
         for _ in 0..MAX_RETRIES_PUSH_EOF {
-            if let Ok(_) = self.try_close() {
+            if let Ok(_) = self.ring.borrow_mut().try_close() {
                 return Ok(());
             }
             if let Err(cause) = yielder.yield_once().await {
@@ -179,13 +156,26 @@ impl CatmemQueue {
                 error!("{}", &cause);
                 Err(Fail::new(libc::EINVAL, cause))
             },
-            Ring::PopOnly(ring) => Ok(ring.try_pop()?),
+            Ring::PopOnly(ring) => {
+                let (byte, eof) = ring.try_pop()?;
+                if eof {
+                    ring.prepare_close()?;
+                    ring.commit();
+                }
+                Ok((byte, eof))
+            },
         }
+    }
+
+    /// Schedule a coroutine to pop from this queue. This function contains all of the single-queue,
+    /// asynchronous code necessary to pop a buffer and any single-queue functionality after the pop completes.
+    pub fn pop<F: FnOnce(Yielder) -> Result<TaskHandle, Fail>>(&self, insert_coroutine: F) -> Result<QToken, Fail> {
+        self.do_generic_sync_data_path_call(insert_coroutine)
     }
 
     /// This function pops a buffer of optional [size] from the queue. If the queue is connected to the push end of a
     /// shared memory ring, this function returns an error.
-    pub async fn pop(&self, size: Option<usize>, yielder: Yielder) -> Result<(DemiBuffer, bool), Fail> {
+    pub async fn do_pop(&self, size: Option<usize>, yielder: Yielder) -> Result<(DemiBuffer, bool), Fail> {
         let size: usize = size.unwrap_or(limits::RECVBUF_SIZE_MAX);
         let mut buf: DemiBuffer = DemiBuffer::new(size as u16);
         let mut index: usize = 0;
@@ -230,6 +220,12 @@ impl CatmemQueue {
         Ok((buf, eof))
     }
 
+    /// Schedule a coroutine to push to this queue. This function contains all of the single-queue,
+    /// asynchronous code necessary to run push a buffer and any single-queue functionality after the push completes.
+    pub fn push<F: FnOnce(Yielder) -> Result<TaskHandle, Fail>>(&self, insert_coroutine: F) -> Result<QToken, Fail> {
+        self.do_generic_sync_data_path_call(insert_coroutine)
+    }
+
     /// This private function tries to push a single byte and is used for scoping the borrow.
     fn try_push(&self, byte: &u8) -> Result<bool, Fail> {
         match &mut *self.ring.borrow_mut() {
@@ -244,7 +240,7 @@ impl CatmemQueue {
 
     /// This function tries to push [buf] to the shared memory ring. If the queue is connected to the pop end, then
     /// this function returns an error.
-    pub async fn push(&self, buf: DemiBuffer, yielder: Yielder) -> Result<(), Fail> {
+    pub async fn do_push(&self, buf: DemiBuffer, yielder: Yielder) -> Result<(), Fail> {
         for byte in &buf[..] {
             loop {
                 match self.try_push(byte)? {
@@ -263,15 +259,58 @@ impl CatmemQueue {
         Ok(())
     }
 
+    /// Generic function for spawning a control-path coroutine on [self].
+    fn do_generic_sync_control_path_call<F>(&self, coroutine: F, add_as_pending_op: bool) -> Result<QToken, Fail>
+    where
+        F: FnOnce(Yielder) -> Result<TaskHandle, Fail>,
+    {
+        // Spawn coroutine.
+        let yielder: Yielder = Yielder::new();
+        let yielder_handle: YielderHandle = yielder.get_handle();
+        let task_handle: TaskHandle = match coroutine(yielder) {
+            // We successfully spawned the coroutine.
+            Ok(handle) => {
+                // Commit the operation on the socket.
+                self.ring.borrow_mut().commit();
+                handle
+            },
+            // We failed to spawn the coroutine.
+            Err(e) => {
+                // Abort the operation on the socket.
+                self.ring.borrow_mut().abort();
+                return Err(e);
+            },
+        };
+
+        // If requested, add this operation to the list of pending operations on this queue.
+        if add_as_pending_op {
+            self.add_pending_op(&task_handle, &yielder_handle);
+        }
+
+        Ok(task_handle.get_task_id().into())
+    }
+
+    /// Generic function for spawning a data-path coroutine on [self].
+    fn do_generic_sync_data_path_call<F>(&self, coroutine: F) -> Result<QToken, Fail>
+    where
+        F: FnOnce(Yielder) -> Result<TaskHandle, Fail>,
+    {
+        let yielder: Yielder = Yielder::new();
+        let yielder_handle: YielderHandle = yielder.get_handle();
+        let task_handle: TaskHandle = coroutine(yielder)?;
+        self.add_pending_op(&task_handle, &yielder_handle);
+        Ok(task_handle.get_task_id().into())
+    }
+
     /// Adds a new operation to the list of pending operations on this queue.
-    pub fn add_pending_op(&mut self, handle: &TaskHandle, yielder_handle: &YielderHandle) {
+    pub fn add_pending_op(&self, handle: &TaskHandle, yielder_handle: &YielderHandle) {
         self.pending_ops
             .borrow_mut()
             .insert(handle.clone(), yielder_handle.clone());
     }
 
     /// Removes an operation from the list of pending operations on this queue.
-    pub fn remove_pending_op(&mut self, handle: &TaskHandle) {
+    pub fn remove_pending_op(&self, handle: &TaskHandle) {
         self.pending_ops
             .borrow_mut()
             .remove_entry(handle)

--- a/src/rust/catmem/ring/mod.rs
+++ b/src/rust/catmem/ring/mod.rs
@@ -65,7 +65,7 @@ impl Ring {
         Ok(Self::PushOnly(PushRing::open(name, RING_BUFFER_CAPACITY)?))
     }
 
-    /// This function commits the ring to closing.
+    /// Commits the pending operation.
     pub fn commit(&mut self) {
         match self {
             Ring::PushOnly(ring) => ring.commit(),
@@ -73,7 +73,7 @@ impl Ring {
         }
     }
 
-    /// This function aborts a pending operation.
+    /// Aborts a pending operation.
     pub fn abort(&mut self) {
         match self {
             Ring::PushOnly(ring) => ring.abort(),
@@ -97,6 +97,7 @@ impl Ring {
         }
     }
 
+    /// Closes the target ring.
     pub fn close(&mut self) -> Result<(), Fail> {
         match self {
             Ring::PushOnly(ring) => {
@@ -116,6 +117,7 @@ impl Ring {
         }
     }
 
+    /// Attempts to close the target ring.
     pub fn try_close(&mut self) -> Result<(), Fail> {
         match self {
             Ring::PushOnly(ring) => ring.try_close(),

--- a/src/rust/catmem/ring/mod.rs
+++ b/src/rust/catmem/ring/mod.rs
@@ -27,6 +27,9 @@ use crate::runtime::fail::Fail;
 /// padding. Still, this is intentionally set so as the effective capacity is large enough to hold 16 KB of data.
 const RING_BUFFER_CAPACITY: usize = 65536;
 
+/// Maximum number of retries for pushing a EoF signal.
+pub const MAX_RETRIES_PUSH_EOF: u32 = 16;
+
 //======================================================================================================================
 // Structures
 //======================================================================================================================
@@ -60,5 +63,63 @@ impl Ring {
     /// Opens an existing shared memory ring and connects to the push/producer end.
     pub fn open_push_ring(name: &str) -> Result<Self, Fail> {
         Ok(Self::PushOnly(PushRing::open(name, RING_BUFFER_CAPACITY)?))
+    }
+
+    /// This function commits the ring to closing.
+    pub fn commit(&mut self) {
+        match self {
+            Ring::PushOnly(ring) => ring.commit(),
+            Ring::PopOnly(ring) => ring.commit(),
+        }
+    }
+
+    /// This function aborts a pending operation.
+    pub fn abort(&mut self) {
+        match self {
+            Ring::PushOnly(ring) => ring.abort(),
+            Ring::PopOnly(_) => warn!("abort() called on a pop-only queue"),
+        }
+    }
+
+    /// Prepares a transition to the closing state.
+    pub fn prepare_close(&mut self) -> Result<(), Fail> {
+        match self {
+            Ring::PushOnly(ring) => ring.prepare_close(),
+            Ring::PopOnly(ring) => ring.prepare_close(),
+        }
+    }
+
+    /// Prepares a transition to the closed state.
+    pub fn prepare_closed(&mut self) -> Result<(), Fail> {
+        match self {
+            Ring::PushOnly(ring) => ring.prepare_closed(),
+            Ring::PopOnly(ring) => ring.prepare_closed(),
+        }
+    }
+
+    pub fn close(&mut self) -> Result<(), Fail> {
+        match self {
+            Ring::PushOnly(ring) => {
+                // Attempt to push EoF.
+                // Maximum number of retries. This is set to an arbitrary small value.
+                for _ in 0..MAX_RETRIES_PUSH_EOF {
+                    match ring.try_close() {
+                        Ok(()) => return Ok(()),
+                        Err(_) => continue,
+                    }
+                }
+                let cause: String = format!("failed to push EoF");
+                error!("push_eof(): {}", cause);
+                Err(Fail::new(libc::EIO, &cause))
+            },
+            Ring::PopOnly(_) => Ok(()),
+        }
+    }
+
+    pub fn try_close(&mut self) -> Result<(), Fail> {
+        match self {
+            Ring::PushOnly(ring) => ring.try_close(),
+            Ring::PopOnly(_) => Ok(()),
+        }
     }
 }


### PR DESCRIPTION
This PR moves the catmem libOS closer to the Catnap architecture. It moves all state machine manipulation into the CatmemQueue and pushes some into the Ring data structure. It also moves to the unified Operation and OperationTask data types from the runtime.