### PR TITLE
[catloop] `INADDR_ANY` Should Be Supported As The Wildcard Address

### DIFF
--- a/src/rust/catloop/mod.rs
+++ b/src/rust/catloop/mod.rs
@@ -143,6 +143,7 @@ impl CatloopLibOS {
         }
 
         // Check if we are binding to the wildcard port.
+        // FIXME: https://github.com/demikernel/demikernel/issues/582
         if local.port() == 0 {
             let cause: String = format!("cannot bind to port 0 (qd={:?})", qd);
             error!("bind(): {}", cause);

--- a/src/rust/catloop/mod.rs
+++ b/src/rust/catloop/mod.rs
@@ -59,7 +59,10 @@ use ::std::{
         RefMut,
     },
     mem,
-    net::SocketAddrV4,
+    net::{
+        Ipv4Addr,
+        SocketAddrV4,
+    },
     pin::Pin,
     rc::Rc,
 };
@@ -130,6 +133,14 @@ impl CatloopLibOS {
     /// CatloopQueue to a local address.
     pub fn bind(&mut self, qd: QDesc, local: SocketAddrV4) -> Result<(), Fail> {
         trace!("bind() qd={:?}, local={:?}", qd, local);
+
+        // Check if we are binding to the wildcard address.
+        // FIXME: https://github.com/demikernel/demikernel/issues/189
+        if local.ip() == &Ipv4Addr::UNSPECIFIED {
+            let cause: String = format!("cannot bind to wildcard address (qd={:?})", qd);
+            error!("bind(): {}", cause);
+            return Err(Fail::new(libc::ENOTSUP, &cause));
+        }
 
         // Check if we are binding to the wildcard port.
         if local.port() == 0 {


### PR DESCRIPTION
## Description

This PR is a workaround for https://github.com/microsoft/demikernel/issues/189.