### PR TITLE
[catloop] Don't Allow `accept()` On A Socket That Is Already Accepting

### DIFF
--- a/src/rust/catloop/queue.rs
+++ b/src/rust/catloop/queue.rs
@@ -88,9 +88,6 @@ impl CatloopQueue {
     where
         F: FnOnce(Yielder) -> Result<TaskHandle, Fail>,
     {
-        // Check whether we are accepting on this queue.
-        self.socket.borrow_mut().prepare_accept()?;
-
         let yielder: Yielder = Yielder::new();
         let yielder_handle: YielderHandle = yielder.get_handle();
 

--- a/src/rust/catloop/queue.rs
+++ b/src/rust/catloop/queue.rs
@@ -88,6 +88,9 @@ impl CatloopQueue {
     where
         F: FnOnce(Yielder) -> Result<TaskHandle, Fail>,
     {
+        // Check whether we are accepting on this queue.
+        self.socket.borrow_mut().prepare_accept()?;
+
         let yielder: Yielder = Yielder::new();
         let yielder_handle: YielderHandle = yielder.get_handle();
 
@@ -98,9 +101,10 @@ impl CatloopQueue {
 
     /// Asynchronously accepts a new connection on the queue. This function contains all of the single-queue,
     /// asynchronous code necessary to run an accept and any single-queue functionality after the accept completes.
-    pub async fn do_accept(&self, ipv4: &Ipv4Addr, new_port: u16, yielder: &Yielder) -> Result<Self, Fail> {
+    pub async fn do_accept(&self, new_port: u16, yielder: &Yielder) -> Result<Self, Fail> {
         // Try to call underlying platform accept.
-        match Socket::do_accept(self.socket.clone(), ipv4, new_port, yielder).await {
+        // It is safe to unwrap here because we ensured that the socket is bound, thus it is assigned a local address.
+        match Socket::do_accept(self.socket.clone(), self.local().unwrap().ip(), new_port, yielder).await {
             Ok(new_accepted_socket) => Ok(Self {
                 qtype: self.qtype,
                 socket: Rc::new(RefCell::new(new_accepted_socket)),

--- a/src/rust/catloop/socket.rs
+++ b/src/rust/catloop/socket.rs
@@ -151,6 +151,11 @@ impl Socket {
         self.do_generic_sync_control_path_call(coroutine, yielder)
     }
 
+    /// Begins the accept operation.
+    pub fn prepare_accept(&mut self) -> Result<(), Fail> {
+        self.state.prepare(SocketOp::Accept)
+    }
+
     /// Attempts to accept a new connection on this socket. On success, returns a new Socket for the accepted connection.
     pub async fn do_accept(
         socket: Rc<RefCell<Self>>,

--- a/src/rust/catloop/socket.rs
+++ b/src/rust/catloop/socket.rs
@@ -147,12 +147,8 @@ impl Socket {
     where
         F: FnOnce(Yielder) -> Result<TaskHandle, Fail>,
     {
+        self.state.prepare(SocketOp::Accept)?;
         self.do_generic_sync_control_path_call(coroutine, yielder)
-    }
-
-    /// Begins the accept operation.
-    pub fn prepare_accept(&mut self) -> Result<(), Fail> {
-        self.state.prepare(SocketOp::Accept)
     }
 
     /// Attempts to accept a new connection on this socket. On success, returns a new Socket for the accepted connection.

--- a/src/rust/catloop/socket.rs
+++ b/src/rust/catloop/socket.rs
@@ -147,7 +147,6 @@ impl Socket {
     where
         F: FnOnce(Yielder) -> Result<TaskHandle, Fail>,
     {
-        self.state.prepare(SocketOp::Accept)?;
         self.do_generic_sync_control_path_call(coroutine, yielder)
     }
 


### PR DESCRIPTION
## Description

This PR closes https://github.com/microsoft/demikernel/issues/829.