### PR TITLE
[catnap] Moving to Standalone Async Functions

### DIFF
--- a/src/rust/catnap/queue.rs
+++ b/src/rust/catnap/queue.rs
@@ -77,32 +77,12 @@ impl CatnapQueue {
 
     /// Binds the target queue to `local` address.
     pub fn bind(&self, local: SocketAddrV4) -> Result<(), Fail> {
-        let mut socket: RefMut<Socket> = self.socket.borrow_mut();
-        match socket.bind(local) {
-            Ok(_) => {
-                socket.commit();
-                Ok(())
-            },
-            Err(e) => {
-                socket.abort();
-                Err(e)
-            },
-        }
+        self.socket.borrow_mut().bind(local)
     }
 
     /// Sets the target queue to listen for incoming connections.
     pub fn listen(&self, backlog: usize) -> Result<(), Fail> {
-        let mut socket: RefMut<Socket> = self.socket.borrow_mut();
-        match socket.listen(backlog) {
-            Ok(_) => {
-                socket.commit();
-                Ok(())
-            },
-            Err(e) => {
-                socket.abort();
-                Err(e)
-            },
-        }
+        self.socket.borrow_mut().listen(backlog)
     }
 
     /// Starts a coroutine to begin accepting on this queue. This function contains all of the single-queue,
@@ -122,20 +102,16 @@ impl CatnapQueue {
     /// Asynchronously accepts a new connection on the queue. This function contains all of the single-queue,
     /// asynchronous code necessary to run an accept and any single-queue functionality after the accept completes.
     pub async fn do_accept(&self, yielder: Yielder) -> Result<Self, Fail> {
-        // Check whether we are accepting on this queue.
-        self.socket.borrow_mut().prepare_accepted()?;
-
         loop {
             let mut socket: RefMut<Socket> = self.socket.borrow_mut();
             // Try to call underlying platform accept.
             match socket.try_accept() {
                 Ok(new_accepted_socket) => {
-                    socket.commit();
                     break Ok(Self {
                         qtype: self.qtype,
                         socket: Rc::new(RefCell::new(new_accepted_socket)),
                         pending_ops: Rc::new(RefCell::new(HashMap::<TaskHandle, YielderHandle>::new())),
-                    });
+                    })
                 },
                 Err(Fail { errno, cause: _ }) if retry_errno(errno) => {
                     // Operation in progress. Check if cancelled.
@@ -144,12 +120,16 @@ impl CatnapQueue {
                     drop(socket);
                     if let Err(e) = yielder.yield_once().await {
                         self.socket.borrow_mut().rollback();
-                        break Err(e);
+                        return Err(e);
                     }
+                },
+                Err(Fail { errno, cause: _ }) if errno == libc::EBADF => {
+                    // Socket has been closed.
+                    return Err(Fail::new(errno, "socket was closed"));
                 },
                 Err(e) => {
                     socket.rollback();
-                    break Err(e);
+                    return Err(e);
                 },
             }
         }
@@ -173,15 +153,10 @@ impl CatnapQueue {
     /// Asynchronously connects the target queue to a remote address. This function contains all of the single-queue,
     /// asynchronous code necessary to run a connect and any single-queue functionality after the connect completes.
     pub async fn do_connect(&self, remote: SocketAddrV4, yielder: Yielder) -> Result<(), Fail> {
-        self.socket.borrow_mut().prepare_connected()?;
-
         loop {
             let mut socket: RefMut<Socket> = self.socket.borrow_mut();
             match socket.try_connect(remote) {
-                Ok(r) => {
-                    socket.commit();
-                    break Ok(r);
-                },
+                Ok(r) => return Ok(r),
                 Err(Fail { errno, cause: _ }) if retry_errno(errno) => {
                     // Operation in progress. Check if cancelled.
                     // We drop the socket here to ensure that the borrow_mut() in the next iteration of the loop
@@ -189,12 +164,16 @@ impl CatnapQueue {
                     drop(socket);
                     if let Err(e) = yielder.yield_once().await {
                         self.socket.borrow_mut().rollback();
-                        break Err(e);
+                        return Err(e);
                     }
+                },
+                Err(Fail { errno, cause: _ }) if errno == libc::EBADF => {
+                    // Socket has been closed.
+                    return Err(Fail::new(errno, "Socket was closed"));
                 },
                 Err(e) => {
                     socket.rollback();
-                    break Err(e);
+                    return Err(e);
                 },
             }
         }
@@ -212,33 +191,23 @@ impl CatnapQueue {
 
     /// Close this queue. This function contains all the single-queue functionality to synchronously close a queue.
     pub fn close(&self) -> Result<(), Fail> {
-        let mut socket: RefMut<Socket> = self.socket.borrow_mut();
-        socket.prepare_close()?;
-        socket.commit();
-        match socket.try_close() {
-            Ok(_) => {
-                socket.prepare_closed()?;
+        match self.socket.borrow_mut().close() {
+            Ok(()) => {
                 self.cancel_pending_ops(Fail::new(libc::ECANCELED, "This queue was closed"));
-                socket.commit();
                 Ok(())
             },
-            Err(e) => {
-                socket.abort();
-                Err(e)
-            },
+            Err(e) => Err(e),
         }
     }
 
     /// Asynchronously closes this queue. This function contains all of the single-queue, asynchronous code necessary
     /// to close a queue and any single-queue functionality after the close completes.
     pub async fn do_close(&self, yielder: Yielder) -> Result<(), Fail> {
-        self.socket.borrow_mut().prepare_closed()?;
         loop {
             let mut socket: RefMut<Socket> = self.socket.borrow_mut();
             match socket.try_close() {
                 Ok(()) => {
                     self.cancel_pending_ops(Fail::new(libc::ECANCELED, "This queue was closed"));
-                    socket.commit();
                     return Ok(());
                 },
                 Err(Fail { errno, cause: _ }) if retry_errno(errno) => {
@@ -252,7 +221,7 @@ impl CatnapQueue {
                     }
                 },
                 Err(e) => {
-                    socket.rollback();
+                    self.socket.borrow_mut().rollback();
                     return Err(e);
                 },
             }

--- a/tests/rust/tcp-test/wait/mod.rs
+++ b/tests/rust/tcp-test/wait/mod.rs
@@ -271,6 +271,7 @@ fn wait_for_accept_after_issuing_async_close(libos: &mut LibOS, local: &SocketAd
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_ACCEPT && qr.qr_ret == 0 => {
             anyhow::bail!("accept() should not succeed because remote should not be connecting")
         },
+        Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && qr.qr_ret == libc::EBADF as i64 => {},
         Ok(_) => anyhow::bail!("wait() should not succeed with accept()"),
         Err(_) => anyhow::bail!("wait() should timeout with accept()"),
     }
@@ -287,6 +288,10 @@ fn wait_for_accept_after_issuing_async_close(libos: &mut LibOS, local: &SocketAd
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && qr.qr_ret == libc::ECANCELED as i64 => {
             accepted_completed = true
         },
+        Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && qr.qr_ret == libc::EBADF as i64 => {
+            accepted_completed = true
+        },
+
         Ok(_) => anyhow::bail!("wait() should not succeed with accept()"),
         Err(_) => anyhow::bail!("wait() should timeout with accept()"),
     }


### PR DESCRIPTION
## Description

This is the first commit in a series that attempt to move async functions to standalone ones. This also enables us to move state machine transitions to the sockets level.