### PR TITLE
[DemiRuntime] Add close to NetworkQueue trait and move drop to DemiRuntime

### DIFF
--- a/src/demikernel.code-workspace
+++ b/src/demikernel.code-workspace
@@ -1,0 +1,75 @@
+{
+	"folders": [
+		{
+			"name": "demikernel",
+			"path": ".."
+		}
+	],
+	"settings": {
+		"rust-analyzer.cargo.features": [
+			"catnap-libos",
+			"catcollar-libos",
+			"catnip-libos",
+			"catpowder-libos",
+			"catmem-libos",
+			"catloop-libos",
+			"mlx4"
+		],
+		"rust-analyzer.server.extraEnv": {
+			"PKG_CONFIG_PATH": "/home/irene/lib/pkgconfig/:/home/irene/lib/x86_64-linux-gnu/pkgconfig"
+		},
+		"C_Cpp.default.compilerPath": "/usr/bin/gcc",
+		"files.associations": {
+			"wait.h": "c",
+			"sga.h": "c",
+			"dlfcn.h": "c",
+			"stdio.h": "c",
+			"unistd.h": "c",
+			"glue.h": "c",
+			"libos.h": "c",
+			"interpose.h": "c",
+			"utils.h": "c",
+			"epoll.h": "c"
+		},
+		"editor.formatOnSave": true,
+		"editor.formatOnPaste": false,
+		"cSpell.ignoreWords": [
+			"DGRAM",
+			"EADDRINUSE",
+			"EAGAIN",
+			"EBADF",
+			"ECONNREFUSED",
+			"EDESTADDRREQ",
+			"EINVAL",
+			"ENOTSUP",
+			"INET",
+			"demi",
+			"libos",
+			"numsegs",
+			"pushto",
+			"qresult",
+			"qtoken",
+			"saddr",
+			"seglen",
+			"segs",
+			"sgaalloc",
+			"sgafree",
+			"sgarray",
+			"sgaseg",
+			"sockaddr",
+			"socklen",
+			"struct",
+			"sockqd"
+		],
+		"cSpell.words": [
+			"catcollar",
+			"Catloop",
+			"catpowder",
+			"getpeername",
+			"PDPIX"
+		],
+		"rust-analyzer.linkedProjects": [
+			"./Cargo.toml"
+		]
+	}
+}

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -481,29 +481,6 @@ impl CatnapLibOS {
     }
 }
 
-//======================================================================================================================
-// Trait Implementations
-//======================================================================================================================
-
-impl Drop for CatnapLibOS {
-    // Releases all sockets allocated by Catnap.
-    fn drop(&mut self) {
-        for boxed_queue_ptr in self.runtime.get_mut_qtable().drain() {
-            let queue: Option<&CatnapQueue> = DemiRuntime::downcast_queue_ptr(&boxed_queue_ptr);
-            match queue {
-                Some(queue) => {
-                    if let Err(e) = queue.close() {
-                        error!("close() failed (error={:?}", e);
-                    }
-                },
-                None => {
-                    error!("drop(): attempting to drop something that is not a CatnapQueue");
-                },
-            }
-        }
-    }
-}
-
 //==============================================================================
 // Standalone Functions
 //==============================================================================

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -39,7 +39,6 @@ use crate::{
         DemiRuntime,
         QDesc,
         QToken,
-        Runtime,
     },
     scheduler::{
         TaskHandle,
@@ -54,7 +53,6 @@ use ::std::{
     },
     pin::Pin,
 };
-use std::any::Any;
 
 #[cfg(feature = "profiler")]
 use crate::timer;

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -212,6 +212,22 @@ impl NetworkQueue for IoQueueType {
     fn as_any_ref(&self) -> &dyn Any {
         self
     }
+
+    /// Closes the queue in the IoQueueTable for drop.
+    fn close(&self) -> Result<(), Fail> {
+        self.as_ref().close()
+    }
+}
+
+impl Drop for DemiRuntime {
+    // Releases closes all network queues in the IoQueueTable
+    fn drop(&mut self) {
+        for queue in self.qtable.borrow_mut().drain() {
+            if let Err(e) = queue.close() {
+                error!("close() failed (error={:?}", e);
+            }
+        }
+    }
 }
 
 //======================================================================================================================

--- a/src/rust/runtime/queue/mod.rs
+++ b/src/rust/runtime/queue/mod.rs
@@ -10,7 +10,10 @@ mod qtype;
 // Imports
 //======================================================================================================================
 
-use crate::scheduler::TaskWithResult;
+use crate::{
+    runtime::Fail,
+    scheduler::TaskWithResult,
+};
 use ::slab::{
     Iter,
     Slab,
@@ -47,10 +50,11 @@ pub trait IoQueue: Any {
     fn get_qtype(&self) -> QType;
 }
 
-pub trait NetworkQueue: IoQueue{
+pub trait NetworkQueue: IoQueue {
     fn local(&self) -> Option<SocketAddrV4>;
     fn remote(&self) -> Option<SocketAddrV4>;
     fn as_any_ref(&self) -> &dyn Any;
+    fn close(&self) -> Result<(), Fail>;
 }
 
 /// I/O queue descriptors table.


### PR DESCRIPTION
This PR adds a close function to the NetworkQueue trait and implements it in Catnap. It removes the drop function from CatnapLibOS because it is a stateless object and moves it to DemiRuntime instead, which will encapsulate all of our state from now on. This PR also removes the need to downcast on drop, which might fail, and ensures that all queues are closed after we exit.