### PR TITLE
[catloop] Move IoQueueTable 

### DIFF
--- a/src/rust/catloop/queue.rs
+++ b/src/rust/catloop/queue.rs
@@ -13,6 +13,7 @@ use crate::{
         memory::DemiBuffer,
         queue::{
             IoQueue,
+            NetworkQueue,
             QType,
         },
         OperationResult,
@@ -26,12 +27,10 @@ use crate::{
     },
 };
 use ::std::{
+    any::Any,
     cell::RefCell,
     collections::HashMap,
-    net::{
-        Ipv4Addr,
-        SocketAddrV4,
-    },
+    net::SocketAddrV4,
     rc::Rc,
 };
 
@@ -202,7 +201,6 @@ impl CatloopQueue {
     /// Removes an operation from the list of pending operations on this queue. This function should only be called if
     /// add_pending_op() was previously called.
     /// TODO: Remove this when we clean up take_result().
-    #[deprecated]
     pub fn remove_pending_op(&self, handle: &TaskHandle) {
         self.pending_ops.borrow_mut().remove(handle);
     }
@@ -225,5 +223,22 @@ impl CatloopQueue {
 impl IoQueue for CatloopQueue {
     fn get_qtype(&self) -> QType {
         self.qtype
+    }
+}
+
+impl NetworkQueue for CatloopQueue {
+    /// Returns the local address to which the target queue is bound.
+    fn local(&self) -> Option<SocketAddrV4> {
+        self.socket.borrow().local()
+    }
+
+    /// Returns the remote address to which the target queue is connected to.
+    fn remote(&self) -> Option<SocketAddrV4> {
+        self.socket.borrow().remote()
+    }
+
+    /// Returns this queue as an Any for dynamic typing
+    fn as_any_ref(&self) -> &dyn Any {
+        self
     }
 }

--- a/src/rust/catloop/runtime.rs
+++ b/src/rust/catloop/runtime.rs
@@ -6,22 +6,13 @@
 //======================================================================================================================
 
 use crate::{
-    catloop::CatloopQueue,
     inetstack::protocols::ip::EphemeralPorts,
-    runtime::{
-        fail::Fail,
-        memory::MemoryRuntime,
-        queue::{
-            IoQueueTable,
-            QDesc,
-        },
-    },
+    runtime::fail::Fail,
 };
 use ::rand::{
     prelude::SmallRng,
     SeedableRng,
 };
-use ::std::net::SocketAddrV4;
 
 //======================================================================================================================
 // Structures
@@ -31,8 +22,6 @@ use ::std::net::SocketAddrV4;
 pub struct CatloopRuntime {
     /// Ephemeral port allocator.
     ephemeral_ports: EphemeralPorts,
-    /// Table of queue descriptors, it has one entry for each existing queue descriptor in Catloop LibOS.
-    qtable: IoQueueTable<CatloopQueue>,
 }
 
 //======================================================================================================================
@@ -45,41 +34,7 @@ impl CatloopRuntime {
         let mut rng: SmallRng = SmallRng::from_entropy();
         Self {
             ephemeral_ports: EphemeralPorts::new(&mut rng),
-            qtable: IoQueueTable::<CatloopQueue>::new(),
         }
-    }
-
-    /// Allocates a new [CatloopQueue].
-    pub fn alloc_queue(&mut self, queue: CatloopQueue) -> QDesc {
-        self.qtable.alloc(queue)
-    }
-
-    pub fn free_queue(&mut self, qd: QDesc) {
-        self.qtable.free(&qd);
-    }
-
-    /// Gets the [CatloopQueue] associated with `qd`. If not `qd` does not refer to a valid, then return `EBADF` is returned.
-    pub fn get_queue(&self, qd: QDesc) -> Result<CatloopQueue, Fail> {
-        match self.qtable.get(&qd) {
-            Some(queue) => Ok(queue.clone()),
-            None => {
-                let cause: String = format!("invalid queue descriptor (qd={:?})", qd);
-                error!("get_queue(): {}", cause);
-                Err(Fail::new(libc::EBADF, &cause))
-            },
-        }
-    }
-
-    /// Checks whether `local` is bound to `addr`. On successful completion it returns `true` if not bound and `false` if
-    /// already in use.
-    pub fn is_bound_to_addr(&self, local: SocketAddrV4) -> bool {
-        for (_, queue) in self.qtable.get_values() {
-            match queue.local() {
-                Some(addr) if addr == local => return false,
-                _ => continue,
-            }
-        }
-        true
     }
 
     /// Allocates an ephemeral port. If `port` is `Some(port)` then it tries to allocate `port`.
@@ -95,30 +50,5 @@ impl CatloopRuntime {
     /// Releases an ephemeral `port`.
     pub fn free_ephemeral_port(&mut self, port: u16) -> Result<(), Fail> {
         self.ephemeral_ports.free(port)
-    }
-}
-
-//======================================================================================================================
-// Trait Implementations
-//======================================================================================================================
-
-/// Memory Runtime Trait Implementation for Catloop Runtime
-impl MemoryRuntime for CatloopRuntime {}
-
-impl Drop for CatloopRuntime {
-    /// Releases all resources allocated by Catloop.
-    fn drop(&mut self) {
-        for (qd, queue) in self.qtable.get_values() {
-            if let Err(e) = queue.close() {
-                warn!("drop(): leaking qd={:?} (e={:?})", qd, e);
-            }
-            if let Some(addr) = queue.local() {
-                if EphemeralPorts::is_private(addr.port()) {
-                    if self.ephemeral_ports.free(addr.port()).is_err() {
-                        warn!("drop(): leaking ephemeral port (port={})", addr.port());
-                    }
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
This PR moves Catloop to using a shared IoQueueTable inside DemiRuntime