### PR TITLE
[src] Use FIXME comments instead of `deprecated` attribute

### DIFF
--- a/src/rust/catnap/queue.rs
+++ b/src/rust/catnap/queue.rs
@@ -381,7 +381,8 @@ impl CatnapQueue {
     /// Removes an operation from the list of pending operations on this queue. This function should only be called if
     /// add_pending_op() was previously called.
     /// TODO: Remove this when we clean up take_result().
-    #[deprecated]
+    /// This function is deprecated, do not use.
+    /// FIXME: https://github.com/microsoft/demikernel/issues/888
     pub fn remove_pending_op(&self, handle: &TaskHandle) {
         self.pending_ops.borrow_mut().remove(handle);
     }

--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -599,7 +599,8 @@ impl<const N: usize> InetStack<N> {
     }
 
     /// Waits for any operation to complete.
-    #[deprecated]
+    /// This function is deprecated, do not use.
+    /// FIXME: https://github.com/microsoft/demikernel/issues/890
     pub fn wait_any2(&mut self, qts: &[QToken]) -> Result<(usize, QDesc, OperationResult), Fail> {
         #[cfg(feature = "profiler")]
         timer!("inetstack::wait_any2");

--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -573,7 +573,8 @@ impl<const N: usize> InetStack<N> {
     }
 
     /// Waits for an operation to complete.
-    #[deprecated]
+    /// This function is deprecated, do not use.
+    /// FIXME: https://github.com/microsoft/demikernel/issues/889
     pub fn wait2(&mut self, qt: QToken) -> Result<(QDesc, OperationResult), Fail> {
         #[cfg(feature = "profiler")]
         timer!("inetstack::wait2");

--- a/src/rust/scheduler/handle.rs
+++ b/src/rust/scheduler/handle.rs
@@ -53,7 +53,11 @@ pub struct YielderHandle {
 impl TaskHandle {
     /// Creates a new Task Handle.
     pub fn new(task_id: u64, waker_page_ref: WakerPageRef, waker_page_offset: usize) -> Self {
-        Self { task_id, waker_page_ref, waker_page_offset }
+        Self {
+            task_id,
+            waker_page_ref,
+            waker_page_offset,
+        }
     }
 
     /// Queries whether or not the coroutine in the Task has completed.
@@ -67,7 +71,8 @@ impl TaskHandle {
     }
 
     /// Removes the task from the scheduler and keeps it from running again.
-    #[deprecated]
+    /// This function is deprecated, do not use.
+    /// FIXME: https://github.com/microsoft/demikernel/issues/886
     pub fn deschedule(&mut self) {
         self.waker_page_ref.mark_dropped(self.waker_page_offset);
     }


### PR DESCRIPTION
Partially addresses: #878

After this fix, there should be no `deprecated` warnings in the build log.