### PR TITLE
[catmem] Use Full Ring Name

### DIFF
--- a/src/rust/catmem/queue.rs
+++ b/src/rust/catmem/queue.rs
@@ -221,17 +221,13 @@ impl CatmemQueue {
         self.do_generic_sync_data_path_call(insert_coroutine)
     }
 
-    /// This private function tries to push a single byte and is used for scoping the borrow.
-    fn try_push(&self, byte: &u8) -> Result<bool, Fail> {
-        self.ring.borrow_mut().try_push(byte)
-    }
-
     /// This function tries to push [buf] to the shared memory ring. If the queue is connected to the pop end, then
     /// this function returns an error.
     pub async fn do_push(&self, buf: DemiBuffer, yielder: Yielder) -> Result<(), Fail> {
         for byte in &buf[..] {
             loop {
-                match self.try_push(byte)? {
+                let push_result: bool = self.ring.borrow_mut().try_push(byte)?;
+                match push_result {
                     true => break,
                     false => {
                         // Operation not completed. Check if it was cancelled.

--- a/src/rust/catmem/ring.rs
+++ b/src/rust/catmem/ring.rs
@@ -145,14 +145,9 @@ impl Ring {
         Err(Fail::new(libc::EIO, &cause))
     }
 
-    /// Attempts to close the target ring.
-    pub fn try_close(&mut self) -> Result<(), Fail> {
-        self.do_close()
-    }
-
     /// Try to send an eof through the shared memory ring. If success, this queue is now closed, otherwise, return
     /// EAGAIN and retry.
-    fn do_close(&mut self) -> Result<(), Fail> {
+    pub fn try_close(&mut self) -> Result<(), Fail> {
         // Try to lock the ring buffer.
         if !self.mutex.try_lock() {
             let cause: String = format!("could not lock ring buffer to push EOF");

--- a/src/rust/catmem/ring.rs
+++ b/src/rust/catmem/ring.rs
@@ -63,7 +63,7 @@ impl Ring {
             return Err(Fail::new(libc::EINVAL, "name of shared memory region cannot be empty"));
         }
         Ok(Self {
-            push_buf: SharedRingBuffer::create(&format!("{}:_", name), RING_BUFFER_CAPACITY)?,
+            push_buf: SharedRingBuffer::create(&format!("{}:tx", name), RING_BUFFER_CAPACITY)?,
             pop_buf: SharedRingBuffer::create(&format!("{}:rx", name), RING_BUFFER_CAPACITY)?,
             state_machine: RingStateMachine::new(),
             mutex: Mutex::new(),
@@ -78,7 +78,7 @@ impl Ring {
         }
         Ok(Self {
             push_buf: SharedRingBuffer::open(&format!("{}:rx", name), RING_BUFFER_CAPACITY)?,
-            pop_buf: SharedRingBuffer::open(&format!("{}:_", name), RING_BUFFER_CAPACITY)?,
+            pop_buf: SharedRingBuffer::open(&format!("{}:tx", name), RING_BUFFER_CAPACITY)?,
             state_machine: RingStateMachine::new(),
             mutex: Mutex::new(),
         })

--- a/src/rust/collections/concurrent_ring.rs
+++ b/src/rust/collections/concurrent_ring.rs
@@ -450,7 +450,6 @@ mod test {
     /// Capacity for ring buffer in bytes.
     const RING_BUFFER_CAPACITY: usize = 4096;
     const ITERATIONS: usize = 128;
-    const CONCURRENT_CLIENTS: usize = 10;
 
     /// Creates a ring buffer with a valid capacity.
     fn do_new() -> Result<ConcurrentRingBuffer> {


### PR DESCRIPTION
## Description

This PR adds the following improvements:
- Squashes `try_push`, `try_pop` and `try_close` functions.
- Changed ring to use full name

Motivation for first point:  When refactoring, we created private, one-line-functions for scoping. I merged these and fixed scoping rules to easy navigation across layers.