### PR TITLE
[inetstack] TCP ctrlblk checks SeqNumber of out-of-order FIN

### DIFF
--- a/src/rust/inetstack/protocols/tcp/established/ctrlblk.rs
+++ b/src/rust/inetstack/protocols/tcp/established/ctrlblk.rs
@@ -1122,8 +1122,9 @@ impl<const N: usize> ControlBlock<N> {
         if added_out_of_order {
             match self.out_of_order_fin.get() {
                 Some(fin) => {
-                    debug_assert_eq!(fin, recv_next);
-                    return true;
+                    if fin == recv_next {
+                        return true;
+                    }
                 },
                 _ => (),
             }


### PR DESCRIPTION
This PR fixes a bug in TCP control block that does not properly check the sequence number before processing out-of-order FIN.