### PR TITLE
[runtime] New shared object for shared state

### DIFF
--- a/src/rust/catloop/mod.rs
+++ b/src/rust/catloop/mod.rs
@@ -244,7 +244,7 @@ impl CatloopLibOS {
     /// the accept succeeds or fails.
     async fn accept_coroutine(
         qd: QDesc,
-        runtime: DemiRuntime,
+        mut runtime: DemiRuntime,
         state: Rc<RefCell<CatloopRuntime>>,
         queue: CatloopQueue,
         new_port: u16,
@@ -318,9 +318,7 @@ impl CatloopLibOS {
     }
 
     /// Synchronously closes a CatloopQueue and its underlying Catmem queues.
-    pub fn close(&self, qd: QDesc) -> Result<(), Fail> {
-        #[cfg(feature = "profiler")]
-        timer!("catloop::close");
+    pub fn close(&mut self, qd: QDesc) -> Result<(), Fail> {
         trace!("close() qd={:?}", qd);
         let queue: CatloopQueue = self.get_queue(&qd)?;
         queue.close()?;
@@ -344,9 +342,7 @@ impl CatloopLibOS {
 
     /// Synchronous code to asynchronously close a queue. This function schedules the coroutine that asynchronously
     /// runs the close and any synchronous multi-queue functionality before the close begins.
-    pub fn async_close(&self, qd: QDesc) -> Result<QToken, Fail> {
-        #[cfg(feature = "profiler")]
-        timer!("catloop::async_close");
+    pub fn async_close(&mut self, qd: QDesc) -> Result<QToken, Fail> {
         trace!("async_close() qd={:?}", qd);
 
         let queue: CatloopQueue = self.get_queue(&qd)?;
@@ -371,7 +367,7 @@ impl CatloopLibOS {
     /// and the underlying Catmem queue and performs any necessary multi-queue operations at the libOS-level after
     /// the close succeeds or fails.
     async fn close_coroutine(
-        runtime: DemiRuntime,
+        mut runtime: DemiRuntime,
         state: Rc<RefCell<CatloopRuntime>>,
         queue: CatloopQueue,
         qd: QDesc,
@@ -402,9 +398,7 @@ impl CatloopLibOS {
     }
 
     /// Schedules a coroutine to push to a Catloop queue.
-    pub fn push(&self, qd: QDesc, sga: &demi_sgarray_t) -> Result<QToken, Fail> {
-        #[cfg(feature = "profiler")]
-        timer!("catloop::push");
+    pub fn push(&mut self, qd: QDesc, sga: &demi_sgarray_t) -> Result<QToken, Fail> {
         trace!("push() qd={:?}", qd);
         let buf: DemiBuffer = self.runtime.clone_sgarray(sga)?;
 

--- a/src/rust/catloop/mod.rs
+++ b/src/rust/catloop/mod.rs
@@ -319,6 +319,8 @@ impl CatloopLibOS {
 
     /// Synchronously closes a CatloopQueue and its underlying Catmem queues.
     pub fn close(&mut self, qd: QDesc) -> Result<(), Fail> {
+        #[cfg(feature = "profiler")]
+        timer!("catloop::close");
         trace!("close() qd={:?}", qd);
         let queue: CatloopQueue = self.get_queue(&qd)?;
         queue.close()?;
@@ -343,6 +345,8 @@ impl CatloopLibOS {
     /// Synchronous code to asynchronously close a queue. This function schedules the coroutine that asynchronously
     /// runs the close and any synchronous multi-queue functionality before the close begins.
     pub fn async_close(&mut self, qd: QDesc) -> Result<QToken, Fail> {
+        #[cfg(feature = "profiler")]
+        timer!("catloop::async_close");
         trace!("async_close() qd={:?}", qd);
 
         let queue: CatloopQueue = self.get_queue(&qd)?;
@@ -399,6 +403,8 @@ impl CatloopLibOS {
 
     /// Schedules a coroutine to push to a Catloop queue.
     pub fn push(&mut self, qd: QDesc, sga: &demi_sgarray_t) -> Result<QToken, Fail> {
+        #[cfg(feature = "profiler")]
+        timer!("catloop::push");
         trace!("push() qd={:?}", qd);
         let buf: DemiBuffer = self.runtime.clone_sgarray(sga)?;
 

--- a/src/rust/catloop/socket.rs
+++ b/src/rust/catloop/socket.rs
@@ -198,7 +198,7 @@ impl Socket {
                 // Invalid response.
                 Ok(false) => {
                     // Clean up newly allocated duplex pipe.
-                    catmem.borrow().close(new_qd)?;
+                    catmem.borrow_mut().close(new_qd)?;
                     continue;
                 },
                 // Some error.
@@ -238,7 +238,7 @@ impl Socket {
 
             // Open underlying pipes.
             let remote: SocketAddrV4 = SocketAddrV4::new(*ipv4, new_port);
-            let new_qd: QDesc = match catmem.borrow().open_pipe(&format_pipe_str(ipv4, new_port)) {
+            let new_qd: QDesc = match catmem.borrow_mut().open_pipe(&format_pipe_str(ipv4, new_port)) {
                 Ok(new_qd) => new_qd,
                 Err(e) => {
                     socket.borrow_mut().state.rollback();
@@ -420,7 +420,9 @@ impl Socket {
 //   - The payload received from that pop() operation is a valid and legit MAGIC_CONNECT message.
 async fn pop_magic_number(catmem: Rc<RefCell<CatmemLibOS>>, catmem_qd: QDesc, yielder: &Yielder) -> Result<bool, Fail> {
     // Issue pop. Each magic connect represents a separate connection request, so we always bound the pop.
-    let qt: QToken = catmem.borrow().pop(catmem_qd, Some(mem::size_of_val(&MAGIC_CONNECT)))?;
+    let qt: QToken = catmem
+        .borrow_mut()
+        .pop(catmem_qd, Some(mem::size_of_val(&MAGIC_CONNECT)))?;
     let handle: TaskHandle = {
         // Get scheduler handle from the task id.
         catmem.borrow().from_task_id(qt)?
@@ -480,7 +482,7 @@ async fn create_pipe(
     // control duplex pipe. This prevents us from running into a race
     // condition were the remote makes progress faster than us and attempts
     // to open the duplex pipe before it is created.
-    let new_qd = catmem.borrow().create_pipe(&format_pipe_str(ipv4, port))?;
+    let new_qd = catmem.borrow_mut().create_pipe(&format_pipe_str(ipv4, port))?;
     // Allocate a scatter-gather array and send the port number to the remote.
     let sga: demi_sgarray_t = catmem.borrow_mut().alloc_sgarray(mem::size_of_val(&port))?;
     let ptr: *mut u8 = sga.sga_segs[0].sgaseg_buf as *mut u8;
@@ -489,7 +491,7 @@ async fn create_pipe(
     slice.copy_from_slice(&port.to_ne_bytes());
 
     // Push the port number.
-    let qt: QToken = catmem.borrow().push(catmem_qd, &sga)?;
+    let qt: QToken = catmem.borrow_mut().push(catmem_qd, &sga)?;
     let handle: TaskHandle = {
         // Get the task handle from the task id.
         catmem.borrow().from_task_id(qt)?
@@ -538,7 +540,7 @@ async fn send_connection_request(
     let sga: demi_sgarray_t = cook_magic_connect(catmem.clone())?;
 
     // Send to server.
-    let qt: QToken = catmem.borrow().push(connect_qd, &sga)?;
+    let qt: QToken = catmem.borrow_mut().push(connect_qd, &sga)?;
     trace!("Send connection request qtoken={:?}", qt);
     let handle: TaskHandle = {
         // Get scheduler handle from the task id.
@@ -587,7 +589,7 @@ async fn get_port(
     // Issue receive operation to wait for connect request ack.
     let size: usize = mem::size_of::<u16>();
     // Open connection to server.
-    let connect_qd: QDesc = match catmem.borrow().open_pipe(&format_pipe_str(ipv4, port)) {
+    let connect_qd: QDesc = match catmem.borrow_mut().open_pipe(&format_pipe_str(ipv4, port)) {
         Ok(qd) => qd,
         Err(e) => {
             // Interpose error.
@@ -601,7 +603,7 @@ async fn get_port(
         },
     };
 
-    let qt: QToken = catmem.borrow().pop(connect_qd, Some(size))?;
+    let qt: QToken = catmem.borrow_mut().pop(connect_qd, Some(size))?;
     trace!("Read port qtoken={:?}", qt);
 
     let handle: TaskHandle = {
@@ -663,7 +665,7 @@ async fn send_ack(catmem: Rc<RefCell<CatmemLibOS>>, new_qd: QDesc, yielder: &Yie
     // Create message with magic connect.
     let sga: demi_sgarray_t = cook_magic_connect(catmem.clone())?;
     // Send to server through new pipe.
-    let qt: QToken = catmem.borrow().push(new_qd, &sga)?;
+    let qt: QToken = catmem.borrow_mut().push(new_qd, &sga)?;
     trace!("Send ack qtoken={:?}", qt);
     let handle: TaskHandle = {
         // Get scheduler handle from the task id.

--- a/src/rust/catloop/socket.rs
+++ b/src/rust/catloop/socket.rs
@@ -482,7 +482,7 @@ async fn create_pipe(
     // control duplex pipe. This prevents us from running into a race
     // condition were the remote makes progress faster than us and attempts
     // to open the duplex pipe before it is created.
-    let new_qd = catmem.borrow_mut().create_pipe(&format_pipe_str(ipv4, port))?;
+    let new_qd: QDesc = catmem.borrow_mut().create_pipe(&format_pipe_str(ipv4, port))?;
     // Allocate a scatter-gather array and send the port number to the remote.
     let sga: demi_sgarray_t = catmem.borrow_mut().alloc_sgarray(mem::size_of_val(&port))?;
     let ptr: *mut u8 = sga.sga_segs[0].sgaseg_buf as *mut u8;

--- a/src/rust/catmem/mod.rs
+++ b/src/rust/catmem/mod.rs
@@ -69,7 +69,7 @@ impl CatmemLibOS {
     }
 
     /// Creates a new memory queue.
-    pub fn create_pipe(&self, name: &str) -> Result<QDesc, Fail> {
+    pub fn create_pipe(&mut self, name: &str) -> Result<QDesc, Fail> {
         #[cfg(feature = "profiler")]
         timer!("catmem::create_pipe");
         trace!("create_pipe() name={:?}", name);
@@ -79,7 +79,7 @@ impl CatmemLibOS {
     }
 
     /// Opens a memory queue.
-    pub fn open_pipe(&self, name: &str) -> Result<QDesc, Fail> {
+    pub fn open_pipe(&mut self, name: &str) -> Result<QDesc, Fail> {
         #[cfg(feature = "profiler")]
         timer!("catmem::open_pipe");
         trace!("open_pipe() name={:?}", name);
@@ -91,7 +91,7 @@ impl CatmemLibOS {
 
     /// Shutdown a consumer/pop-only queue. Currently, this is basically a no-op but it does cancel pending operations
     /// and free the queue from the IoQueueTable.
-    pub fn shutdown(&self, qd: QDesc) -> Result<(), Fail> {
+    pub fn shutdown(&mut self, qd: QDesc) -> Result<(), Fail> {
         #[cfg(feature = "profiler")]
         timer!("catmem::shutdown");
         trace!("shutdown() qd={:?}", qd);
@@ -100,7 +100,7 @@ impl CatmemLibOS {
     }
 
     /// Closes a memory queue.
-    pub fn close(&self, qd: QDesc) -> Result<(), Fail> {
+    pub fn close(&mut self, qd: QDesc) -> Result<(), Fail> {
         #[cfg(feature = "profiler")]
         timer!("catmem::close");
         trace!("close() qd={:?}", qd);
@@ -109,7 +109,7 @@ impl CatmemLibOS {
     }
 
     /// Asynchronously close a socket.
-    pub fn async_close(&self, qd: QDesc) -> Result<QToken, Fail> {
+    pub fn async_close(&mut self, qd: QDesc) -> Result<QToken, Fail> {
         #[cfg(feature = "profiler")]
         timer!("catmem::async_close");
         trace!("async_close() qd={:?}", qd);
@@ -124,7 +124,7 @@ impl CatmemLibOS {
     }
 
     pub async fn close_coroutine(
-        runtime: DemiRuntime,
+        mut runtime: DemiRuntime,
         queue: CatmemQueue,
         qd: QDesc,
         yielder: Yielder,
@@ -150,7 +150,7 @@ impl CatmemLibOS {
     }
 
     /// Pushes a scatter-gather array to a Push ring. If not a Push ring, then fail.
-    pub fn push(&self, qd: QDesc, sga: &demi_sgarray_t) -> Result<QToken, Fail> {
+    pub fn push(&mut self, qd: QDesc, sga: &demi_sgarray_t) -> Result<QToken, Fail> {
         #[cfg(feature = "profiler")]
         timer!("catmem::push");
         trace!("push() qd={:?}", qd);
@@ -187,7 +187,7 @@ impl CatmemLibOS {
     }
 
     /// Pops data from a Pop ring. If not a Pop ring, then return an error.
-    pub fn pop(&self, qd: QDesc, size: Option<usize>) -> Result<QToken, Fail> {
+    pub fn pop(&mut self, qd: QDesc, size: Option<usize>) -> Result<QToken, Fail> {
         #[cfg(feature = "profiler")]
         timer!("catmem::pop");
         trace!("pop() qd={:?}, size={:?}", qd, size);

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -97,7 +97,7 @@ impl CatnapLibOS {
 
     /// Creates a socket. This function contains the libOS-level functionality needed to create a CatnapQueue that
     /// wraps the underlying POSIX socket.
-    pub fn socket(&self, domain: libc::c_int, typ: libc::c_int, _protocol: libc::c_int) -> Result<QDesc, Fail> {
+    pub fn socket(&mut self, domain: libc::c_int, typ: libc::c_int, _protocol: libc::c_int) -> Result<QDesc, Fail> {
         #[cfg(feature = "profiler")]
         timer!("catnap::socket");
         trace!("socket() domain={:?}, type={:?}, protocol={:?}", domain, typ, _protocol);
@@ -171,7 +171,7 @@ impl CatnapLibOS {
     /// Synchronous cross-queue code to start accepting a connection. This function schedules the asynchronous
     /// coroutine and performs any necessary synchronous, multi-queue operations at the libOS-level before beginning
     /// the accept.
-    pub fn accept(&self, qd: QDesc) -> Result<QToken, Fail> {
+    pub fn accept(&mut self, qd: QDesc) -> Result<QToken, Fail> {
         #[cfg(feature = "profiler")]
         timer!("catnap::accept");
         trace!("accept(): qd={:?}", qd);
@@ -194,7 +194,7 @@ impl CatnapLibOS {
     /// asynchronously to accept a connection and performs any necessary multi-queue operations at the libOS-level after
     /// the accept succeeds or fails.
     async fn accept_coroutine(
-        runtime: DemiRuntime,
+        mut runtime: DemiRuntime,
         queue: CatnapQueue,
         qd: QDesc,
         yielder: Yielder,
@@ -221,7 +221,7 @@ impl CatnapLibOS {
     /// Synchronous code to establish a connection to a remote endpoint. This function schedules the asynchronous
     /// coroutine and performs any necessary synchronous, multi-queue operations at the libOS-level before beginning
     /// the connect.
-    pub fn connect(&self, qd: QDesc, remote: SocketAddrV4) -> Result<QToken, Fail> {
+    pub fn connect(&mut self, qd: QDesc, remote: SocketAddrV4) -> Result<QToken, Fail> {
         #[cfg(feature = "profiler")]
         timer!("catnap::connect");
         trace!("connect() qd={:?}, remote={:?}", qd, remote);
@@ -256,7 +256,7 @@ impl CatnapLibOS {
     }
 
     /// Synchronously closes a CatnapQueue and its underlying POSIX socket.
-    pub fn close(&self, qd: QDesc) -> Result<(), Fail> {
+    pub fn close(&mut self, qd: QDesc) -> Result<(), Fail> {
         #[cfg(feature = "profiler")]
         timer!("catnap::close");
         trace!("close() qd={:?}", qd);
@@ -269,7 +269,7 @@ impl CatnapLibOS {
 
     /// Synchronous code to asynchronously close a queue. This function schedules the coroutine that asynchronously
     /// runs the close and any synchronous multi-queue functionality before the close begins.
-    pub fn async_close(&self, qd: QDesc) -> Result<QToken, Fail> {
+    pub fn async_close(&mut self, qd: QDesc) -> Result<QToken, Fail> {
         #[cfg(feature = "profiler")]
         timer!("catnap::async_close");
         trace!("async_close() qd={:?}", qd);
@@ -290,7 +290,7 @@ impl CatnapLibOS {
     /// and the underlying POSIX socket and performs any necessary multi-queue operations at the libOS-level after
     /// the close succeeds or fails.
     async fn close_coroutine(
-        runtime: DemiRuntime,
+        mut runtime: DemiRuntime,
         queue: CatnapQueue,
         qd: QDesc,
         yielder: Yielder,
@@ -354,7 +354,7 @@ impl CatnapLibOS {
     /// Synchronous code to pushto [buf] to [remote] on a CatnapQueue and its underlying POSIX socket. This
     /// function schedules the coroutine that asynchronously runs the pushto and any synchronous multi-queue
     /// functionality after pushto begins.
-    pub fn pushto(&self, qd: QDesc, sga: &demi_sgarray_t, remote: SocketAddrV4) -> Result<QToken, Fail> {
+    pub fn pushto(&mut self, qd: QDesc, sga: &demi_sgarray_t, remote: SocketAddrV4) -> Result<QToken, Fail> {
         #[cfg(feature = "profiler")]
         timer!("catnap::pushto");
         trace!("pushto() qd={:?}", qd);
@@ -395,7 +395,7 @@ impl CatnapLibOS {
     /// Synchronous code to pop data from a CatnapQueue and its underlying POSIX socket of optional [size]. This
     /// function schedules the asynchronous coroutine and performs any necessary synchronous, multi-queue operations
     /// at the libOS-level before beginning the pop.
-    pub fn pop(&self, qd: QDesc, size: Option<usize>) -> Result<QToken, Fail> {
+    pub fn pop(&mut self, qd: QDesc, size: Option<usize>) -> Result<QToken, Fail> {
         #[cfg(feature = "profiler")]
         timer!("catnap::pop");
         trace!("pop() qd={:?}, size={:?}", qd, size);
@@ -443,7 +443,7 @@ impl CatnapLibOS {
         self.runtime.from_task_id(qt)
     }
 
-    pub fn pack_result(&self, handle: TaskHandle, qt: QToken) -> Result<demi_qresult_t, Fail> {
+    pub fn pack_result(&mut self, handle: TaskHandle, qt: QToken) -> Result<demi_qresult_t, Fail> {
         #[cfg(feature = "profiler")]
         timer!("catnap::pack_result");
         let (qd, r): (QDesc, OperationResult) = self.take_result(handle);
@@ -467,7 +467,7 @@ impl CatnapLibOS {
     }
 
     /// Takes out the result from the [OperationTask] associated with the target [TaskHandle].
-    fn take_result(&self, handle: TaskHandle) -> (QDesc, OperationResult) {
+    fn take_result(&mut self, handle: TaskHandle) -> (QDesc, OperationResult) {
         #[cfg(feature = "take_result")]
         timer!("catnap::take_result");
         let task: OperationTask = self.runtime.remove_coroutine(&handle);

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -72,10 +72,10 @@ pub struct DemiRuntimeInner {
 }
 
 #[derive(Clone)]
-pub struct DemiRuntime(pub SharedObject<DemiRuntimeInner>);
+pub struct DemiRuntime(SharedObject<DemiRuntimeInner>);
 
 /// The SharedObject wraps an object that will be shared across coroutines.
-pub struct SharedObject<T>(pub Rc<T>);
+pub struct SharedObject<T>(Rc<T>);
 
 //======================================================================================================================
 // Associate Functions


### PR DESCRIPTION
This PR introduces a ref counted shared object that can be used for shared state without dynamic borrowing. The object lives as long as there are references (as there is an Rc inside); however it allows both multiple read and write references to the shared object. This object can be safely used as long as the code among which it is shared (e.g., different libOSes, different coroutines within the same libOS) never run concurrently. As Demikernel is currently single threaded and our scheduler can only run one coroutine at a time, this abstraction is safe to use throughout the code for shared references to libOSes, queues and runtimes. This data structure will continue to be safe if we use a multi-kernel architecture for multi-cores and run one instance of the libOSes per core and do not share across cores. If we wanted to share state across cores, a more complex data structure with locking would be required anyway.