### PR TITLE
[catloop] Ensure Accepting in `accept`

### DIFF
--- a/src/rust/catloop/socket.rs
+++ b/src/rust/catloop/socket.rs
@@ -165,6 +165,7 @@ impl Socket {
             .catmem_qd
             .expect("Must be a catmem queue in this state.");
         loop {
+            socket.borrow_mut().state.may_accept()?;
             // Grab next request from the control duplex pipe.
             let new_qd: QDesc = match pop_magic_number(catmem.clone(), catmem_qd, &yielder).await {
                 // Received a valid magic number so create the new connection. This involves create the new duplex pipe

--- a/src/rust/runtime/network/socket/state.rs
+++ b/src/rust/runtime/network/socket/state.rs
@@ -302,6 +302,16 @@ impl SocketStateMachine {
         Ok(())
     }
 
+    /// Ensures that the target [SocketState] is accepting incoming connections.
+    fn ensure_accepting(&self) -> Result<(), Fail> {
+        if self.current != SocketState::Accepting {
+            let cause: String = format!("socket is not listening");
+            error!("ensure_listening(): {}", cause);
+            return Err(Fail::new(libc::EINVAL, &cause));
+        }
+        Ok(())
+    }
+
     /// Ensures that the target [SocketState] is connected.
     fn ensure_connected(&self) -> Result<(), Fail> {
         if self.current != SocketState::Connected {

--- a/src/rust/runtime/network/socket/state.rs
+++ b/src/rust/runtime/network/socket/state.rs
@@ -81,6 +81,7 @@ impl SocketStateMachine {
     pub fn may_accept(&self) -> Result<(), Fail> {
         self.ensure_not_closing()?;
         self.ensure_not_closed()?;
+        self.ensure_accepting()?;
         Ok(())
     }
 


### PR DESCRIPTION
## Description

This PR introduces a check for the accepting state on the `accept()` async path.