### PR TITLE
[catmem] Checks for Push and Pop

### DIFF
--- a/src/rust/catmem/ring.rs
+++ b/src/rust/catmem/ring.rs
@@ -87,11 +87,8 @@ impl Ring {
     /// Try to pop a byte from the shared memory ring. If successful, return the byte and whether the eof flag is set,
     /// otherwise return None for a retry.
     pub fn try_pop(&mut self) -> Result<(Option<u8>, bool), Fail> {
-        if self.state_machine.is_closing() {
-            return Err(Fail::new(libc::ECANCELED, "queue is closing"));
-        } else if self.state_machine.is_closed() {
-            return Err(Fail::new(libc::ECANCELED, "queue was closed"));
-        };
+        self.state_machine.may_pop()?;
+
         if !self.mutex.try_lock() {
             let cause: String = format!("could not lock ring buffer to pop byte");
             warn!("try_pop(): {}", &cause);

--- a/src/rust/catmem/ring.rs
+++ b/src/rust/catmem/ring.rs
@@ -110,11 +110,8 @@ impl Ring {
     /// Try to send a byte through the shared memory ring. If there is no space or another thread is writing to this
     /// ring, return [false], otherwise, return [true] if successfully enqueued.
     pub fn try_push(&mut self, byte: &u8) -> Result<bool, Fail> {
-        if self.state_machine.is_closing() {
-            return Err(Fail::new(libc::ECANCELED, "queue is closing"));
-        } else if self.state_machine.is_closed() {
-            return Err(Fail::new(libc::ECANCELED, "queue was closed"));
-        };
+        self.state_machine.may_push()?;
+
         let x: u16 = (*byte & 0xff) as u16;
         // Try to lock the ring buffer.
         if !self.mutex.try_lock() {

--- a/src/rust/runtime/network/ring/state.rs
+++ b/src/rust/runtime/network/ring/state.rs
@@ -107,6 +107,16 @@ impl RingStateMachine {
             RingControlOperation::Closed => Err(fail(op, &(format!("ring is closed")), libc::EBADF)),
         }
     }
+
+    /// Ensures that the target [RingState] is not [RingState::Closing].
+    fn ensure_not_closing(&self) -> Result<(), Fail> {
+        if self.current == RingState::Closing {
+            let cause: String = format!("ring is closing");
+            error!("ensure_not_closing(): {}", cause);
+            return Err(Fail::new(libc::EBADF, &cause));
+        }
+        Ok(())
+    }
 }
 
 //======================================================================================================================

--- a/src/rust/runtime/network/ring/state.rs
+++ b/src/rust/runtime/network/ring/state.rs
@@ -42,9 +42,11 @@ impl RingStateMachine {
         }
     }
 
-    /// Asserts whether the current state is [RingState::Closed].
-    pub fn is_closed(&self) -> bool {
-        self.current == RingState::Closed
+    /// Asserts wether the target [RingState] is in a state were we push data.
+    pub fn may_push(&self) -> Result<(), Fail> {
+        self.ensure_not_closing()?;
+        self.ensure_not_closed()?;
+        Ok(())
     }
 
     /// Asserts whether the current state is [RingState::Closing].

--- a/src/rust/runtime/network/ring/state.rs
+++ b/src/rust/runtime/network/ring/state.rs
@@ -117,7 +117,8 @@ impl RingStateMachine {
         if self.current == RingState::Closing {
             let cause: String = format!("ring is closing");
             error!("ensure_not_closing(): {}", cause);
-            return Err(Fail::new(libc::EBADF, &cause));
+            // FIXME: https://github.com/microsoft/demikernel/issues/916
+            return Err(Fail::new(libc::ECANCELED, &cause));
         }
         Ok(())
     }
@@ -127,7 +128,8 @@ impl RingStateMachine {
         if self.current == RingState::Closed {
             let cause: String = format!("ring is closed");
             error!("ensure_not_clossed(): {}", cause);
-            return Err(Fail::new(libc::EBADF, &cause));
+            // FIXME: https://github.com/microsoft/demikernel/issues/916
+            return Err(Fail::new(libc::ECANCELED, &cause));
         }
         Ok(())
     }

--- a/src/rust/runtime/network/ring/state.rs
+++ b/src/rust/runtime/network/ring/state.rs
@@ -117,6 +117,16 @@ impl RingStateMachine {
         }
         Ok(())
     }
+
+    /// Ensures that the target [RingState] is not [RingState::Closed].
+    fn ensure_not_closed(&self) -> Result<(), Fail> {
+        if self.current == RingState::Closed {
+            let cause: String = format!("ring is closed");
+            error!("ensure_not_clossed(): {}", cause);
+            return Err(Fail::new(libc::EBADF, &cause));
+        }
+        Ok(())
+    }
 }
 
 //======================================================================================================================

--- a/src/rust/runtime/network/ring/state.rs
+++ b/src/rust/runtime/network/ring/state.rs
@@ -49,9 +49,11 @@ impl RingStateMachine {
         Ok(())
     }
 
-    /// Asserts whether the current state is [RingState::Closing].
-    pub fn is_closing(&self) -> bool {
-        self.current == RingState::Closing
+    /// Asserts wether the target [RingState] is in a state were we pop data.
+    pub fn may_pop(&self) -> Result<(), Fail> {
+        self.ensure_not_closing()?;
+        self.ensure_not_closed()?;
+        Ok(())
     }
 
     /// Prepares to move into the next state.


### PR DESCRIPTION
## Description

This PR adds checks for push and pop aynsc paths.

Note that this PR also adds a workaround for https://github.com/microsoft/demikernel/issues/916