### PR TITLE
[catnap] Remove all Rc<RefCell> and replace with SharedObject

### DIFF
--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -190,7 +190,7 @@ impl SharedCatnapLibOS {
         #[cfg(feature = "profiler")]
         timer!("catnap::accept");
         trace!("accept(): qd={:?}", qd);
-        let me: Self = self.clone();
+        let self_: Self = self.clone();
         let coroutine = |yielder: Yielder| -> Result<TaskHandle, Fail> {
             // Asynchronous accept code. Clone the self reference and move into the coroutine.
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().accept_coroutine(qd, yielder));
@@ -199,7 +199,7 @@ impl SharedCatnapLibOS {
             self.runtime.insert_coroutine(&task_name, coroutine)
         };
 
-        Ok(me.get_shared_queue(&qd)?.accept(coroutine)?)
+        Ok(self_.get_shared_queue(&qd)?.accept(coroutine)?)
     }
 
     /// Asynchronous cross-queue code for accepting a connection. This function returns a coroutine that runs
@@ -290,7 +290,7 @@ impl SharedCatnapLibOS {
         timer!("catnap::async_close");
         trace!("async_close() qd={:?}", qd);
 
-        let me: Self = self.clone();
+        let self_: Self = self.clone();
         let coroutine = |yielder: Yielder| -> Result<TaskHandle, Fail> {
             // Async code to close this queue.
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().close_coroutine(qd, yielder));
@@ -298,7 +298,7 @@ impl SharedCatnapLibOS {
             self.runtime.insert_coroutine(&task_name, coroutine)
         };
 
-        Ok(me.get_shared_queue(&qd)?.async_close(coroutine)?)
+        Ok(self_.get_shared_queue(&qd)?.async_close(coroutine)?)
     }
 
     /// Asynchronous code to close a queue. This function returns a coroutine that runs asynchronously to close a queue
@@ -342,13 +342,13 @@ impl SharedCatnapLibOS {
         if buf.len() == 0 {
             return Err(Fail::new(libc::EINVAL, "zero-length buffer"));
         };
-        let me: Self = self.clone();
+        let self_: Self = self.clone();
         let coroutine = |yielder: Yielder| -> Result<TaskHandle, Fail> {
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().push_coroutine(qd, buf, yielder));
             let task_name: String = format!("Catnap::push for qd={:?}", qd);
             self.runtime.insert_coroutine(&task_name, coroutine)
         };
-        Ok(me.get_shared_queue(&qd)?.push(coroutine)?)
+        Ok(self_.get_shared_queue(&qd)?.push(coroutine)?)
     }
 
     /// Asynchronous code to push [buf] to a SharedCatnapQueue and its underlying POSIX socket. This function returns a
@@ -383,13 +383,13 @@ impl SharedCatnapLibOS {
         if buf.len() == 0 {
             return Err(Fail::new(libc::EINVAL, "zero-length buffer"));
         }
-        let me: Self = self.clone();
+        let self_: Self = self.clone();
         let coroutine = |yielder: Yielder| -> Result<TaskHandle, Fail> {
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().pushto_coroutine(qd, buf, remote, yielder));
             let task_name: String = format!("Catnap::pushto for qd={:?}", qd);
             self.runtime.insert_coroutine(&task_name, coroutine)
         };
-        Ok(me.get_shared_queue(&qd)?.push(coroutine)?)
+        Ok(self_.get_shared_queue(&qd)?.push(coroutine)?)
     }
 
     /// Asynchronous code to pushto [buf] to [remote] on a SharedCatnapQueue and its underlying POSIX socket. This function
@@ -429,13 +429,13 @@ impl SharedCatnapLibOS {
 
         // We just assert 'size' here, because it was previously checked at PDPIX layer.
         debug_assert!(size.is_none() || ((size.unwrap() > 0) && (size.unwrap() <= limits::POP_SIZE_MAX)));
-        let me: Self = self.clone();
+        let self_: Self = self.clone();
         let coroutine = |yielder: Yielder| -> Result<TaskHandle, Fail> {
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().pop_coroutine(qd, size, yielder));
             let task_name: String = format!("Catnap::pop for qd={:?}", qd);
             self.runtime.insert_coroutine(&task_name, coroutine)
         };
-        Ok(me.get_shared_queue(&qd)?.pop(coroutine)?)
+        Ok(self_.get_shared_queue(&qd)?.pop(coroutine)?)
     }
 
     /// Asynchronous code to pop data from a SharedCatnapQueue and its underlying POSIX socket of optional [size]. This

--- a/src/rust/catnap/queue.rs
+++ b/src/rust/catnap/queue.rs
@@ -24,6 +24,7 @@ use crate::{
             QType,
         },
         QToken,
+        SharedObject,
     },
     scheduler::{
         TaskHandle,
@@ -33,14 +34,12 @@ use crate::{
 };
 use ::std::{
     any::Any,
-    cell::{
-        Ref,
-        RefCell,
-        RefMut,
-    },
     collections::HashMap,
     net::SocketAddrV4,
-    rc::Rc,
+    ops::{
+        Deref,
+        DerefMut,
+    },
 };
 
 //======================================================================================================================
@@ -49,13 +48,13 @@ use ::std::{
 
 /// CatnapQueue represents a single Catnap queue. It contains all of the Catnap-specific functionality that operates on
 /// a single queue. It is stateless, all state is kept in the Socket data structure.
-#[derive(Clone)]
 pub struct CatnapQueue {
     qtype: QType,
-    socket: Rc<RefCell<Socket>>,
-    pending_ops: Rc<RefCell<HashMap<TaskHandle, YielderHandle>>>,
+    socket: Socket,
+    pending_ops: HashMap<TaskHandle, YielderHandle>,
 }
-
+#[derive(Clone)]
+pub struct SharedCatnapQueue(SharedObject<CatnapQueue>);
 //======================================================================================================================
 // Associated Functions
 //======================================================================================================================
@@ -74,56 +73,61 @@ impl CatnapQueue {
 
         Ok(Self {
             qtype,
-            socket: Rc::new(RefCell::new(Socket::new(domain, typ)?)),
-            pending_ops: Rc::new(RefCell::new(HashMap::<TaskHandle, YielderHandle>::new())),
+            socket: Socket::new(domain, typ)?,
+            pending_ops: HashMap::<TaskHandle, YielderHandle>::new(),
         })
+    }
+}
+
+/// Associate Functions for Catnap LibOS
+impl SharedCatnapQueue {
+    pub fn new(domain: libc::c_int, typ: libc::c_int) -> Result<Self, Fail> {
+        Ok(Self(SharedObject::new(CatnapQueue::new(domain, typ)?)))
     }
 
     /// Binds the target queue to `local` address.
-    pub fn bind(&self, local: SocketAddrV4) -> Result<(), Fail> {
-        self.socket.borrow_mut().bind(local)
+    pub fn bind(&mut self, local: SocketAddrV4) -> Result<(), Fail> {
+        self.socket.bind(local)
     }
 
     /// Sets the target queue to listen for incoming connections.
-    pub fn listen(&self, backlog: usize) -> Result<(), Fail> {
-        self.socket.borrow_mut().listen(backlog)
+    pub fn listen(&mut self, backlog: usize) -> Result<(), Fail> {
+        self.socket.listen(backlog)
     }
 
     /// Starts a coroutine to begin accepting on this queue. This function contains all of the single-queue,
     /// synchronous functionality necessary to start an accept.
-    pub fn accept<F>(&self, insert_coroutine: F) -> Result<QToken, Fail>
+    pub fn accept<F>(&mut self, insert_coroutine: F) -> Result<QToken, Fail>
     where
         F: FnOnce(Yielder) -> Result<TaskHandle, Fail>,
     {
         let yielder: Yielder = Yielder::new();
         let yielder_handle: YielderHandle = yielder.get_handle();
 
-        let task_handle: TaskHandle = self.socket.borrow_mut().accept(insert_coroutine, yielder)?;
+        let task_handle: TaskHandle = self.socket.accept(insert_coroutine, yielder)?;
         self.add_pending_op(&task_handle, &yielder_handle);
         Ok(task_handle.get_task_id().into())
     }
 
     /// Asynchronously accepts a new connection on the queue. This function contains all of the single-queue,
     /// asynchronous code necessary to run an accept and any single-queue functionality after the accept completes.
-    pub async fn do_accept(&self, yielder: Yielder) -> Result<Self, Fail> {
+    pub async fn do_accept(&mut self, yielder: Yielder) -> Result<Self, Fail> {
         loop {
-            let mut socket: RefMut<Socket> = self.socket.borrow_mut();
             // Try to call underlying platform accept.
-            match socket.try_accept() {
+            match self.socket.try_accept() {
                 Ok(new_accepted_socket) => {
-                    break Ok(Self {
+                    return Ok(Self(SharedObject::new(CatnapQueue {
                         qtype: self.qtype,
-                        socket: Rc::new(RefCell::new(new_accepted_socket)),
-                        pending_ops: Rc::new(RefCell::new(HashMap::<TaskHandle, YielderHandle>::new())),
-                    })
+                        socket: new_accepted_socket,
+                        pending_ops: HashMap::<TaskHandle, YielderHandle>::new(),
+                    })))
                 },
                 Err(Fail { errno, cause: _ }) if retry_errno(errno) => {
                     // Operation in progress. Check if cancelled.
                     // We drop the socket here to ensure that the borrow_mut() in the next iteration of the loop
                     // succeeds.
-                    drop(socket);
                     if let Err(e) = yielder.yield_once().await {
-                        self.socket.borrow_mut().rollback();
+                        self.socket.rollback();
                         return Err(e);
                     }
                 },
@@ -132,7 +136,7 @@ impl CatnapQueue {
                     return Err(Fail::new(errno, "socket was closed"));
                 },
                 Err(e) => {
-                    socket.rollback();
+                    self.socket.rollback();
                     return Err(e);
                 },
             }
@@ -142,32 +146,30 @@ impl CatnapQueue {
     /// Start an asynchronous coroutine to start connecting this queue. This function contains all of the single-queue,
     /// asynchronous code necessary to connect to a remote endpoint and any single-queue functionality after the
     /// connect completes.
-    pub fn connect<F>(&self, insert_coroutine: F) -> Result<QToken, Fail>
+    pub fn connect<F>(&mut self, insert_coroutine: F) -> Result<QToken, Fail>
     where
         F: FnOnce(Yielder) -> Result<TaskHandle, Fail>,
     {
         let yielder: Yielder = Yielder::new();
         let yielder_handle: YielderHandle = yielder.get_handle();
 
-        let task_handle: TaskHandle = self.socket.borrow_mut().connect(insert_coroutine, yielder)?;
+        let task_handle: TaskHandle = self.socket.connect(insert_coroutine, yielder)?;
         self.add_pending_op(&task_handle, &yielder_handle);
         Ok(task_handle.get_task_id().into())
     }
 
     /// Asynchronously connects the target queue to a remote address. This function contains all of the single-queue,
     /// asynchronous code necessary to run a connect and any single-queue functionality after the connect completes.
-    pub async fn do_connect(&self, remote: SocketAddrV4, yielder: Yielder) -> Result<(), Fail> {
+    pub async fn do_connect(&mut self, remote: SocketAddrV4, yielder: Yielder) -> Result<(), Fail> {
         loop {
-            let mut socket: RefMut<Socket> = self.socket.borrow_mut();
-            match socket.try_connect(remote) {
+            match self.socket.try_connect(remote) {
                 Ok(r) => return Ok(r),
                 Err(Fail { errno, cause: _ }) if retry_errno(errno) => {
                     // Operation in progress. Check if cancelled.
                     // We drop the socket here to ensure that the borrow_mut() in the next iteration of the loop
                     // succeeds.
-                    drop(socket);
                     if let Err(e) = yielder.yield_once().await {
-                        self.socket.borrow_mut().rollback();
+                        self.socket.rollback();
                         return Err(e);
                     }
                 },
@@ -176,7 +178,7 @@ impl CatnapQueue {
                     return Err(Fail::new(errno, "Socket was closed"));
                 },
                 Err(e) => {
-                    socket.rollback();
+                    self.socket.rollback();
                     return Err(e);
                 },
             }
@@ -184,18 +186,18 @@ impl CatnapQueue {
     }
 
     /// Start an asynchronous coroutine to close this queue.
-    pub fn async_close<F>(&self, insert_coroutine: F) -> Result<QToken, Fail>
+    pub fn async_close<F>(&mut self, insert_coroutine: F) -> Result<QToken, Fail>
     where
         F: FnOnce(Yielder) -> Result<TaskHandle, Fail>,
     {
         let yielder: Yielder = Yielder::new();
-        let task_handle: TaskHandle = self.socket.borrow_mut().async_close(insert_coroutine, yielder)?;
+        let task_handle: TaskHandle = self.socket.async_close(insert_coroutine, yielder)?;
         Ok(task_handle.get_task_id().into())
     }
 
     /// Close this queue. This function contains all the single-queue functionality to synchronously close a queue.
-    pub fn close(&self) -> Result<(), Fail> {
-        match self.socket.borrow_mut().close() {
+    pub fn close(&mut self) -> Result<(), Fail> {
+        match self.socket.close() {
             Ok(()) => {
                 self.cancel_pending_ops(Fail::new(libc::ECANCELED, "This queue was closed"));
                 Ok(())
@@ -206,10 +208,9 @@ impl CatnapQueue {
 
     /// Asynchronously closes this queue. This function contains all of the single-queue, asynchronous code necessary
     /// to close a queue and any single-queue functionality after the close completes.
-    pub async fn do_close(&self, yielder: Yielder) -> Result<(), Fail> {
+    pub async fn do_close(&mut self, yielder: Yielder) -> Result<(), Fail> {
         loop {
-            let mut socket: RefMut<Socket> = self.socket.borrow_mut();
-            match socket.try_close() {
+            match self.socket.try_close() {
                 Ok(()) => {
                     self.cancel_pending_ops(Fail::new(libc::ECANCELED, "This queue was closed"));
                     return Ok(());
@@ -218,14 +219,13 @@ impl CatnapQueue {
                     // Operation in progress. Check if cancelled.
                     // We drop the socket here to ensure that the borrow_mut() in the next iteration of the loop
                     // succeeds.
-                    drop(socket);
                     if let Err(e) = yielder.yield_once().await {
-                        self.socket.borrow_mut().rollback();
+                        self.socket.rollback();
                         return Err(e);
                     }
                 },
                 Err(e) => {
-                    self.socket.borrow_mut().rollback();
+                    self.socket.rollback();
                     return Err(e);
                 },
             }
@@ -234,7 +234,10 @@ impl CatnapQueue {
 
     /// Schedule a coroutine to push to this queue. This function contains all of the single-queue,
     /// asynchronous code necessary to run push a buffer and any single-queue functionality after the push completes.
-    pub fn push<F: FnOnce(Yielder) -> Result<TaskHandle, Fail>>(&self, insert_coroutine: F) -> Result<QToken, Fail> {
+    pub fn push<F: FnOnce(Yielder) -> Result<TaskHandle, Fail>>(
+        &mut self,
+        insert_coroutine: F,
+    ) -> Result<QToken, Fail> {
         self.do_generic_sync_data_path_call(insert_coroutine)
     }
 
@@ -247,8 +250,7 @@ impl CatnapQueue {
         yielder: Yielder,
     ) -> Result<(), Fail> {
         loop {
-            let socket: Ref<Socket> = self.socket.borrow();
-            match socket.try_push(buf, addr) {
+            match self.socket.try_push(buf, addr) {
                 Ok(()) => {
                     if buf.len() == 0 {
                         return Ok(());
@@ -256,14 +258,12 @@ impl CatnapQueue {
                     // Operation in progress. Check if cancelled.
                     // We drop the socket here to ensure that the borrow_mut() in the next iteration of the loop
                     // succeeds.
-                    drop(socket);
                     yielder.yield_once().await?;
                 },
                 Err(Fail { errno, cause: _ }) if retry_errno(errno) => {
                     // Operation in progress. Check if cancelled.
                     // We drop the socket here to ensure that the borrow_mut() in the next iteration of the loop
                     // succeeds.
-                    drop(socket);
                     yielder.yield_once().await?;
                 },
                 Err(e) => return Err(e),
@@ -274,7 +274,7 @@ impl CatnapQueue {
     /// Schedules a coroutine to pop from this queue. This function contains all of the single-queue,
     /// asynchronous code necessary to pop a buffer from this queue and any single-queue functionality after the pop
     /// completes.
-    pub fn pop<F: FnOnce(Yielder) -> Result<TaskHandle, Fail>>(&self, insert_coroutine: F) -> Result<QToken, Fail> {
+    pub fn pop<F: FnOnce(Yielder) -> Result<TaskHandle, Fail>>(&mut self, insert_coroutine: F) -> Result<QToken, Fail> {
         self.do_generic_sync_data_path_call(insert_coroutine)
     }
 
@@ -292,14 +292,12 @@ impl CatnapQueue {
         debug_assert!(buf.len() == size);
 
         loop {
-            let socket: Ref<Socket> = self.socket.borrow();
-            match socket.try_pop(&mut buf, size) {
+            match self.socket.try_pop(&mut buf, size) {
                 Ok(addr) => return Ok((addr, buf.clone())),
                 Err(Fail { errno, cause: _ }) if retry_errno(errno) => {
                     // Operation in progress. Check if cancelled.
                     // We drop the socket here to ensure that the borrow_mut() in the next iteration of the loop
                     // succeeds.
-                    drop(socket);
                     yielder.yield_once().await?;
                 },
                 Err(e) => return Err(e),
@@ -308,7 +306,7 @@ impl CatnapQueue {
     }
 
     /// Generic function for spawning a data-path coroutine on [self].
-    fn do_generic_sync_data_path_call<F>(&self, coroutine: F) -> Result<QToken, Fail>
+    fn do_generic_sync_data_path_call<F>(&mut self, coroutine: F) -> Result<QToken, Fail>
     where
         F: FnOnce(Yielder) -> Result<TaskHandle, Fail>,
     {
@@ -320,10 +318,8 @@ impl CatnapQueue {
     }
 
     /// Adds a new operation to the list of pending operations on this queue.
-    fn add_pending_op(&self, handle: &TaskHandle, yielder_handle: &YielderHandle) {
-        self.pending_ops
-            .borrow_mut()
-            .insert(handle.clone(), yielder_handle.clone());
+    fn add_pending_op(&mut self, handle: &TaskHandle, yielder_handle: &YielderHandle) {
+        self.pending_ops.insert(handle.clone(), yielder_handle.clone());
     }
 
     /// Removes an operation from the list of pending operations on this queue. This function should only be called if
@@ -331,14 +327,14 @@ impl CatnapQueue {
     /// TODO: Remove this when we clean up take_result().
     /// This function is deprecated, do not use.
     /// FIXME: https://github.com/microsoft/demikernel/issues/888
-    pub fn remove_pending_op(&self, handle: &TaskHandle) {
-        self.pending_ops.borrow_mut().remove(handle);
+    pub fn remove_pending_op(&mut self, handle: &TaskHandle) {
+        self.pending_ops.remove(handle);
     }
 
     /// Cancel all currently pending operations on this queue. If the operation is not complete and the coroutine has
     /// yielded, wake the coroutine with an error.
-    fn cancel_pending_ops(&self, cause: Fail) {
-        for (handle, mut yielder_handle) in self.pending_ops.borrow_mut().drain() {
+    fn cancel_pending_ops(&mut self, cause: Fail) {
+        for (handle, mut yielder_handle) in self.pending_ops.drain() {
             if !handle.has_completed() {
                 yielder_handle.wake_with(Err(cause.clone()));
             }
@@ -350,7 +346,7 @@ impl CatnapQueue {
 // Trait implementation
 //======================================================================================================================
 
-impl IoQueue for CatnapQueue {
+impl IoQueue for SharedCatnapQueue {
     fn get_qtype(&self) -> crate::QType {
         self.qtype
     }
@@ -368,14 +364,28 @@ impl IoQueue for CatnapQueue {
     }
 }
 
-impl NetworkQueue for CatnapQueue {
+impl Deref for SharedCatnapQueue {
+    type Target = CatnapQueue;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl DerefMut for SharedCatnapQueue {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.deref_mut()
+    }
+}
+
+impl NetworkQueue for SharedCatnapQueue {
     /// Returns the local address to which the target queue is bound.
     fn local(&self) -> Option<SocketAddrV4> {
-        self.socket.borrow().local()
+        self.socket.local()
     }
 
     /// Returns the remote address to which the target queue is connected to.
     fn remote(&self) -> Option<SocketAddrV4> {
-        self.socket.borrow().remote()
+        self.socket.remote()
     }
 }

--- a/src/rust/catnap/queue.rs
+++ b/src/rust/catnap/queue.rs
@@ -53,8 +53,10 @@ pub struct CatnapQueue {
     socket: Socket,
     pending_ops: HashMap<TaskHandle, YielderHandle>,
 }
+
 #[derive(Clone)]
 pub struct SharedCatnapQueue(SharedObject<CatnapQueue>);
+
 //======================================================================================================================
 // Associated Functions
 //======================================================================================================================
@@ -124,8 +126,6 @@ impl SharedCatnapQueue {
                 },
                 Err(Fail { errno, cause: _ }) if retry_errno(errno) => {
                     // Operation in progress. Check if cancelled.
-                    // We drop the socket here to ensure that the borrow_mut() in the next iteration of the loop
-                    // succeeds.
                     if let Err(e) = yielder.yield_once().await {
                         self.socket.rollback();
                         return Err(e);
@@ -166,8 +166,6 @@ impl SharedCatnapQueue {
                 Ok(r) => return Ok(r),
                 Err(Fail { errno, cause: _ }) if retry_errno(errno) => {
                     // Operation in progress. Check if cancelled.
-                    // We drop the socket here to ensure that the borrow_mut() in the next iteration of the loop
-                    // succeeds.
                     if let Err(e) = yielder.yield_once().await {
                         self.socket.rollback();
                         return Err(e);
@@ -217,8 +215,6 @@ impl SharedCatnapQueue {
                 },
                 Err(Fail { errno, cause: _ }) if retry_errno(errno) => {
                     // Operation in progress. Check if cancelled.
-                    // We drop the socket here to ensure that the borrow_mut() in the next iteration of the loop
-                    // succeeds.
                     if let Err(e) = yielder.yield_once().await {
                         self.socket.rollback();
                         return Err(e);
@@ -256,14 +252,10 @@ impl SharedCatnapQueue {
                         return Ok(());
                     }
                     // Operation in progress. Check if cancelled.
-                    // We drop the socket here to ensure that the borrow_mut() in the next iteration of the loop
-                    // succeeds.
                     yielder.yield_once().await?;
                 },
                 Err(Fail { errno, cause: _ }) if retry_errno(errno) => {
                     // Operation in progress. Check if cancelled.
-                    // We drop the socket here to ensure that the borrow_mut() in the next iteration of the loop
-                    // succeeds.
                     yielder.yield_once().await?;
                 },
                 Err(e) => return Err(e),
@@ -296,8 +288,6 @@ impl SharedCatnapQueue {
                 Ok(addr) => return Ok((addr, buf.clone())),
                 Err(Fail { errno, cause: _ }) if retry_errno(errno) => {
                     // Operation in progress. Check if cancelled.
-                    // We drop the socket here to ensure that the borrow_mut() in the next iteration of the loop
-                    // succeeds.
                     yielder.yield_once().await?;
                 },
                 Err(e) => return Err(e),

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -47,7 +47,7 @@ use crate::catloop::CatloopLibOS;
 #[cfg(feature = "catmem-libos")]
 use crate::catmem::CatmemLibOS;
 #[cfg(all(feature = "catnap-libos"))]
-use crate::catnap::CatnapLibOS;
+use crate::catnap::SharedCatnapLibOS;
 #[cfg(feature = "catnip-libos")]
 use crate::catnip::CatnipLibOS;
 #[cfg(feature = "catpowder-libos")]
@@ -91,7 +91,9 @@ impl LibOS {
         #[allow(unreachable_patterns)]
         let libos: LibOS = match libos_name {
             #[cfg(all(feature = "catnap-libos"))]
-            LibOSName::Catnap => Self::NetworkLibOS(NetworkLibOS::Catnap(CatnapLibOS::new(&config, runtime.clone()))),
+            LibOSName::Catnap => {
+                Self::NetworkLibOS(NetworkLibOS::Catnap(SharedCatnapLibOS::new(&config, runtime.clone())))
+            },
             #[cfg(feature = "catcollar-libos")]
             LibOSName::Catcollar => Self::NetworkLibOS(NetworkLibOS::Catcollar(CatcollarLibOS::new(&config))),
             #[cfg(feature = "catpowder-libos")]

--- a/src/rust/demikernel/libos/network.rs
+++ b/src/rust/demikernel/libos/network.rs
@@ -25,7 +25,7 @@ use crate::catcollar::CatcollarLibOS;
 #[cfg(feature = "catloop-libos")]
 use crate::catloop::CatloopLibOS;
 #[cfg(all(feature = "catnap-libos"))]
-use crate::catnap::CatnapLibOS;
+use crate::catnap::SharedCatnapLibOS;
 #[cfg(feature = "catnip-libos")]
 use crate::catnip::CatnipLibOS;
 #[cfg(feature = "catpowder-libos")]
@@ -40,7 +40,7 @@ pub enum NetworkLibOS {
     #[cfg(feature = "catpowder-libos")]
     Catpowder(CatpowderLibOS),
     #[cfg(all(feature = "catnap-libos"))]
-    Catnap(CatnapLibOS),
+    Catnap(SharedCatnapLibOS),
     #[cfg(feature = "catcollar-libos")]
     Catcollar(CatcollarLibOS),
     #[cfg(feature = "catnip-libos")]

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -156,6 +156,16 @@ impl DemiRuntimeInner {
     pub fn free_queue<T: IoQueue>(&mut self, qd: &QDesc) -> Result<T, Fail> {
         self.qtable.free(qd)
     }
+
+    /// Gets a reference to the queue associated with [qd].
+    pub fn get_queue<'a, T: IoQueue>(&'a self, qd: &QDesc) -> Result<&'a T, Fail> {
+        self.qtable.get(qd)
+    }
+
+    /// Gets a mutable reference to the queue associated with [qd].
+    pub fn get_mut_queue<'a, T: IoQueue>(&'a mut self, qd: &QDesc) -> Result<&'a mut T, Fail> {
+        self.qtable.get_mut(qd)
+    }
 }
 
 impl<T> SharedObject<T> {

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -157,14 +157,11 @@ impl DemiRuntimeInner {
         self.qtable.free(qd)
     }
 
-    /// Gets a reference to the queue associated with [qd].
-    pub fn get_queue<'a, T: IoQueue>(&'a self, qd: &QDesc) -> Result<&'a T, Fail> {
-        self.qtable.get(qd)
-    }
-
-    /// Gets a mutable reference to the queue associated with [qd].
-    pub fn get_mut_queue<'a, T: IoQueue>(&'a mut self, qd: &QDesc) -> Result<&'a mut T, Fail> {
-        self.qtable.get_mut(qd)
+    /// Gets a reference to a shared queue. It is very important that this function bump the reference count (using
+    /// clone) so that we can track how many references to this shared queue that we have handed out.
+    /// TODO: This should only return SharedObject types but for now we will also allow other clonable queue types.
+    pub fn get_shared_queue<T: IoQueue + Clone>(&self, qd: &QDesc) -> Result<T, Fail> {
+        Ok(self.qtable.get::<T>(qd)?.clone())
     }
 }
 
@@ -190,7 +187,7 @@ impl<T> Deref for SharedObject<T> {
 }
 
 impl<T> DerefMut for SharedObject<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut Self::Target {
         let ptr: *mut T = Rc::as_ptr(&self.0) as *mut T;
         unsafe { &mut *ptr }
     }

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -159,7 +159,7 @@ impl DemiRuntimeInner {
 
     /// Gets a reference to a shared queue. It is very important that this function bump the reference count (using
     /// clone) so that we can track how many references to this shared queue that we have handed out.
-    /// TODO: This should only return SharedObject types but for now we will also allow other clonable queue types.
+    /// TODO: This should only return SharedObject types but for now we will also allow other cloneable queue types.
     pub fn get_shared_queue<T: IoQueue + Clone>(&self, qd: &QDesc) -> Result<T, Fail> {
         Ok(self.qtable.get::<T>(qd)?.clone())
     }


### PR DESCRIPTION
This PR removes all of the dynamic borrows in Catnap and replaces them with our new SharedObject abstraction. We rename the shared state objects to SharedCatnapLibOS and SharedCatnapQueue to indicate that they are shared across coroutines. 