### PR TITLE
[scheduler] Removing the `deschedule()` function

### DIFF
--- a/src/rust/inetstack/protocols/tcp/active_open.rs
+++ b/src/rust/inetstack/protocols/tcp/active_open.rs
@@ -330,6 +330,10 @@ impl<const N: usize> ActiveOpenSocket<N> {
 
 impl<const N: usize> Drop for ActiveOpenSocket<N> {
     fn drop(&mut self) {
-        self.handle.deschedule();
+        let handle: &TaskHandle = &self.handle;
+        match self.scheduler.remove(handle) {
+            Some(_) => debug!("Task (id={:?}) removed.", handle.get_task_id()),
+            None => panic!("Cannot remove the Task (id={:?}).", handle.get_task_id()),
+        }
     }
 }

--- a/src/rust/inetstack/protocols/tcp/established/mod.rs
+++ b/src/rust/inetstack/protocols/tcp/established/mod.rs
@@ -99,6 +99,10 @@ impl<const N: usize> EstablishedSocket<N> {
 
 impl<const N: usize> Drop for EstablishedSocket<N> {
     fn drop(&mut self) {
-        self.background.deschedule();
+        let handle: &TaskHandle = &self.background;
+        match self.cb.scheduler.remove(handle) {
+            Some(_) => debug!("Task (id={:?}) removed.", handle.get_task_id()),
+            None => panic!("Cannot remove the Task (id={:?}).", handle.get_task_id()),
+        }
     }
 }

--- a/src/rust/inetstack/protocols/tcp/passive_open.rs
+++ b/src/rust/inetstack/protocols/tcp/passive_open.rs
@@ -224,8 +224,12 @@ impl<const N: usize> PassiveSocket<N> {
                 local_window_scale, remote_window_scale
             );
 
-            if let Some(mut inflight) = self.inflight.remove(&remote) {
-                inflight.handle.deschedule();
+            if let Some(inflight) = self.inflight.remove(&remote) {
+                let handle: TaskHandle = inflight.handle;
+                match self.scheduler.remove(&handle) {
+                    Some(_) => debug!("Task (id={:?}) removed.", handle.get_task_id()),
+                    None => panic!("Cannot remove the Task (id={:?}).", handle.get_task_id()),
+                }
             }
 
             let cb = ControlBlock::new(

--- a/src/rust/inetstack/protocols/tcp/queue.rs
+++ b/src/rust/inetstack/protocols/tcp/queue.rs
@@ -10,7 +10,13 @@ use crate::runtime::{
     queue::IoQueue,
     QType,
 };
-use ::std::any::Any;
+use ::std::{
+    any::Any,
+    mem::{
+        swap,
+        forget,
+    },
+};
 
 //======================================================================================================================
 // Structures
@@ -43,8 +49,11 @@ impl<const N: usize> TcpQueue<N> {
     }
 
     /// Set underlying TCP socket data structure.
-    pub fn set_socket(&mut self, s: Socket<N>) {
-        self.socket = s;
+    pub fn set_socket(&mut self, mut s: Socket<N>) {
+        swap(&mut s, &mut self.socket);
+
+        // Don't run the Socket destructor at this moment.
+        forget(s);
     }
 }
 

--- a/src/rust/scheduler/handle.rs
+++ b/src/rust/scheduler/handle.rs
@@ -69,13 +69,6 @@ impl TaskHandle {
     pub fn get_task_id(&self) -> u64 {
         self.task_id
     }
-
-    /// Removes the task from the scheduler and keeps it from running again.
-    /// This function is deprecated, do not use.
-    /// FIXME: https://github.com/microsoft/demikernel/issues/886
-    pub fn deschedule(&mut self) {
-        self.waker_page_ref.mark_dropped(self.waker_page_offset);
-    }
 }
 
 impl YielderHandle {


### PR DESCRIPTION
This PR closes #886, replacing the `deschedule()` calls to `scheduler.remove()`. For this, we update some functions of TCP in `inetstack` (998cecfa93557a8548259a5fea3401f753b56446, 4155df8cbaf43d0fb5d191368c5c141b0e1da5c6, and b613d1b79aa2ffc6a848c5759d954cbb54850f3c) and in `set_socket` function (eb3073828e07abc21e1366d10d243962a9ba45d6) to avoid memory leak.

Finally, in fd00700151f27867c0e0a60aebc2bb721f810e89, we remove the `deschedule()` function.