### PR TITLE
[makefile] Allowing mlx5 driver for ConnectX-6 NICs

### DIFF
--- a/linux.mk
+++ b/linux.mk
@@ -56,7 +56,7 @@ export CARGO_FEATURES := --features=$(LIBOS)-libos
 
 # Switch for DPDK
 ifeq ($(LIBOS),catnip)
-DRIVER ?= $(shell [ ! -z "`lspci | grep -E "ConnectX-[4,5]"`" ] && echo mlx5 || echo mlx4)
+DRIVER ?= $(shell [ ! -z "`lspci | grep -E "ConnectX-[4,5,6]"`" ] && echo mlx5 || echo mlx4)
 CARGO_FEATURES += --features=$(DRIVER)
 endif
 


### PR DESCRIPTION
This PR updates [linux.mk](https://github.com/microsoft/demikernel/blob/dev/linux.mk) file allowing to use the `mlx5` driver on ConnectX-6 NICs.