### PR TITLE
[demikernel] Enhancement: generalize libOS APIs and C bindings from SocketAddrV4 to SocketAddr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,9 @@ bin/
 *.swo
 *.swp
 
-# vscode
+# vscode and visual studio
 .vscode/
+.vs/
 
 # gdb
 .gdb.*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ libc = "0.2.147"
 log = "0.4.20"
 rand = { version = "0.8.5", features = ["small_rng"] }
 slab = "0.4.9"
+socket2 = "0.4.7"
 yaml-rust = "0.4.5"
 x86 = "0.52.0"
 
@@ -53,8 +54,6 @@ windows = { version = "0.44.0", features = [
     "Win32_Foundation",
     "Win32_Networking_WinSock",
 ] }
-# Provides the Rust socket API for Windows.
-socket2 = "0.4.7"
 
 #=======================================================================================================================
 # Targets

--- a/examples/rust/tcp-dump.rs
+++ b/examples/rust/tcp-dump.rs
@@ -26,7 +26,10 @@ use ::demikernel::{
     QToken,
 };
 use ::std::{
-    net::SocketAddrV4,
+    net::{
+        SocketAddr,
+        SocketAddrV4
+    },
     str::FromStr,
     time::{
         Duration,
@@ -122,7 +125,7 @@ impl Application {
     /// Instantiates the application.
     pub fn new(mut libos: LibOS, args: &ProgramArguments) -> Result<Self> {
         // Extract arguments.
-        let local: SocketAddrV4 = args.get_local();
+        let local: SocketAddr = SocketAddr::V4(args.get_local());
 
         // Create TCP socket.
         let sockqd: QDesc = match libos.socket(AF_INET, SOCK_STREAM, 0) {

--- a/examples/rust/tcp-dump.rs
+++ b/examples/rust/tcp-dump.rs
@@ -26,10 +26,7 @@ use ::demikernel::{
     QToken,
 };
 use ::std::{
-    net::{
-        SocketAddr,
-        SocketAddrV4
-    },
+    net::SocketAddr,
     str::FromStr,
     time::{
         Duration,
@@ -57,7 +54,7 @@ pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
 #[derive(Debug)]
 pub struct ProgramArguments {
     /// Local socket IPv4 address.
-    local: SocketAddrV4,
+    local: SocketAddr,
 }
 
 /// Associate functions for Program Arguments
@@ -82,7 +79,7 @@ impl ProgramArguments {
 
         // Default arguments.
         let mut args: ProgramArguments = ProgramArguments {
-            local: SocketAddrV4::from_str(Self::DEFAULT_LOCAL)?,
+            local: SocketAddr::from_str(Self::DEFAULT_LOCAL)?,
         };
 
         // Local address.
@@ -94,13 +91,13 @@ impl ProgramArguments {
     }
 
     /// Returns the local endpoint address parameter stored in the target program arguments.
-    pub fn get_local(&self) -> SocketAddrV4 {
+    pub fn get_local(&self) -> SocketAddr {
         self.local
     }
 
     /// Sets the local address and port number parameters in the target program arguments.
     fn set_local_addr(&mut self, addr: &str) -> Result<()> {
-        self.local = SocketAddrV4::from_str(addr)?;
+        self.local = SocketAddr::from_str(addr)?;
         Ok(())
     }
 }
@@ -125,7 +122,7 @@ impl Application {
     /// Instantiates the application.
     pub fn new(mut libos: LibOS, args: &ProgramArguments) -> Result<Self> {
         // Extract arguments.
-        let local: SocketAddr = SocketAddr::V4(args.get_local());
+        let local: SocketAddr = args.get_local();
 
         // Create TCP socket.
         let sockqd: QDesc = match libos.socket(AF_INET, SOCK_STREAM, 0) {

--- a/examples/rust/tcp-ping-pong.rs
+++ b/examples/rust/tcp-ping-pong.rs
@@ -16,7 +16,10 @@ use ::demikernel::{
 };
 use ::std::{
     env,
-    net::SocketAddrV4,
+    net::{
+        SocketAddr,
+        SocketAddrV4,
+    },
     slice,
     str::FromStr,
     u8,
@@ -231,7 +234,7 @@ impl TcpServer {
     }
 
     pub fn run(&mut self, local: SocketAddrV4, nrounds: usize) -> Result<()> {
-        if let Err(e) = self.libos.bind(self.sockqd, local) {
+        if let Err(e) = self.libos.bind(self.sockqd, SocketAddr::V4(local)) {
             anyhow::bail!("bind failed: {:?}", e)
         };
 

--- a/examples/rust/tcp-ping-pong.rs
+++ b/examples/rust/tcp-ping-pong.rs
@@ -16,10 +16,7 @@ use ::demikernel::{
 };
 use ::std::{
     env,
-    net::{
-        SocketAddr,
-        SocketAddrV4,
-    },
+    net::SocketAddr,
     slice,
     str::FromStr,
     u8,
@@ -124,7 +121,7 @@ fn accept_and_wait(libos: &mut LibOS, sockqd: QDesc) -> Result<QDesc> {
 //======================================================================================================================
 
 /// Connects to a remote socket and wait for the operation to complete.
-fn connect_and_wait(libos: &mut LibOS, sockqd: QDesc, remote: SocketAddrV4) -> Result<()> {
+fn connect_and_wait(libos: &mut LibOS, sockqd: QDesc, remote: SocketAddr) -> Result<()> {
     let qt: QToken = match libos.connect(sockqd, remote) {
         Ok(qt) => qt,
         Err(e) => anyhow::bail!("connect failed: {:?}", e),
@@ -233,8 +230,8 @@ impl TcpServer {
         });
     }
 
-    pub fn run(&mut self, local: SocketAddrV4, nrounds: usize) -> Result<()> {
-        if let Err(e) = self.libos.bind(self.sockqd, SocketAddr::V4(local)) {
+    pub fn run(&mut self, local: SocketAddr, nrounds: usize) -> Result<()> {
+        if let Err(e) = self.libos.bind(self.sockqd, local) {
             anyhow::bail!("bind failed: {:?}", e)
         };
 
@@ -345,7 +342,7 @@ impl TcpClient {
         });
     }
 
-    fn run(&mut self, remote: SocketAddrV4, nrounds: usize) -> Result<()> {
+    fn run(&mut self, remote: SocketAddr, nrounds: usize) -> Result<()> {
         if let Err(e) = connect_and_wait(&mut self.libos, self.sockqd, remote) {
             anyhow::bail!("connect and wait failed: {:?}", e);
         }
@@ -437,7 +434,7 @@ pub fn main() -> Result<()> {
             Ok(libos) => libos,
             Err(e) => anyhow::bail!("failed to initialize libos: {:?}", e),
         };
-        let sockaddr: SocketAddrV4 = SocketAddrV4::from_str(&args[2])?;
+        let sockaddr: SocketAddr = SocketAddr::from_str(&args[2])?;
 
         // Invoke the appropriate peer.
         if args[1] == "--server" {

--- a/examples/rust/tcp-pktgen.rs
+++ b/examples/rust/tcp-pktgen.rs
@@ -23,7 +23,7 @@ use ::demikernel::{
     QToken,
 };
 use ::std::{
-    net::SocketAddrV4,
+    net::SocketAddr,
     slice,
     str::FromStr,
     time::{
@@ -52,7 +52,7 @@ pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
 #[derive(Debug)]
 pub struct ProgramArguments {
     /// Remote socket IPv4 address.
-    remote: SocketAddrV4,
+    remote: SocketAddr,
     /// Buffer size (in bytes).
     bufsize: usize,
     /// Injection rate (in micro-seconds).
@@ -101,7 +101,7 @@ impl ProgramArguments {
 
         // Default arguments.
         let mut args: ProgramArguments = ProgramArguments {
-            remote: SocketAddrV4::from_str(Self::DEFAULT_REMOTE)?,
+            remote: SocketAddr::from_str(Self::DEFAULT_REMOTE)?,
             bufsize: Self::DEFAULT_BUFSIZE,
             injection_rate: Self::DEFAULT_INJECTION_RATE,
         };
@@ -125,7 +125,7 @@ impl ProgramArguments {
     }
 
     /// Returns the remote endpoint address parameter stored in the target program arguments.
-    pub fn get_remote(&self) -> SocketAddrV4 {
+    pub fn get_remote(&self) -> SocketAddr {
         self.remote
     }
 
@@ -141,7 +141,7 @@ impl ProgramArguments {
 
     /// Sets the remote address and port number parameters in the target program arguments.
     fn set_remote_addr(&mut self, addr: &str) -> Result<()> {
-        self.remote = SocketAddrV4::from_str(addr)?;
+        self.remote = SocketAddr::from_str(addr)?;
         Ok(())
     }
 
@@ -192,7 +192,7 @@ impl Application {
     /// Instantiates the application.
     pub fn new(mut libos: LibOS, args: &ProgramArguments) -> Result<Self> {
         // Extract arguments.
-        let remote: SocketAddrV4 = args.get_remote();
+        let remote: SocketAddr = args.get_remote();
         let bufsize: usize = args.get_bufsize();
         let injection_rate: u64 = args.get_injection_rate();
 

--- a/examples/rust/tcp-push-pop.rs
+++ b/examples/rust/tcp-push-pop.rs
@@ -16,10 +16,7 @@ use ::demikernel::{
 };
 use ::std::{
     env,
-    net::{
-        SocketAddr,
-        SocketAddrV4,
-    },
+    net::SocketAddr,
     slice,
     str::FromStr,
 };
@@ -136,10 +133,10 @@ impl TcpServer {
         });
     }
 
-    pub fn run(&mut self, local: SocketAddrV4, fill_char: u8, buffer_size: usize) -> Result<()> {
+    pub fn run(&mut self, local: SocketAddr, fill_char: u8, buffer_size: usize) -> Result<()> {
         let nbytes: usize = buffer_size * 1024;
 
-        if let Err(e) = self.libos.bind(self.sockqd, SocketAddr::V4(local)) {
+        if let Err(e) = self.libos.bind(self.sockqd, local) {
             anyhow::bail!("bind failed: {:?}", e.cause)
         };
 
@@ -245,7 +242,7 @@ impl TcpClient {
         });
     }
 
-    pub fn run(&mut self, remote: SocketAddrV4, fill_char: u8, buffer_size: usize) -> Result<()> {
+    pub fn run(&mut self, remote: SocketAddr, fill_char: u8, buffer_size: usize) -> Result<()> {
         let nbytes: usize = buffer_size * 1024;
 
         let qt: QToken = match self.libos.connect(self.sockqd, remote) {
@@ -339,7 +336,7 @@ pub fn main() -> Result<()> {
             Ok(libos) => libos,
             Err(e) => anyhow::bail!("failed to initialize libos: {:?}", e.cause),
         };
-        let sockaddr: SocketAddrV4 = SocketAddrV4::from_str(&args[2])?;
+        let sockaddr: SocketAddr = SocketAddr::from_str(&args[2])?;
 
         if args[1] == "--server" {
             let mut server: TcpServer = TcpServer::new(libos)?;

--- a/examples/rust/tcp-push-pop.rs
+++ b/examples/rust/tcp-push-pop.rs
@@ -16,7 +16,10 @@ use ::demikernel::{
 };
 use ::std::{
     env,
-    net::SocketAddrV4,
+    net::{
+        SocketAddr,
+        SocketAddrV4,
+    },
     slice,
     str::FromStr,
 };
@@ -136,7 +139,7 @@ impl TcpServer {
     pub fn run(&mut self, local: SocketAddrV4, fill_char: u8, buffer_size: usize) -> Result<()> {
         let nbytes: usize = buffer_size * 1024;
 
-        if let Err(e) = self.libos.bind(self.sockqd, local) {
+        if let Err(e) = self.libos.bind(self.sockqd, SocketAddr::V4(local)) {
             anyhow::bail!("bind failed: {:?}", e.cause)
         };
 

--- a/examples/rust/udp-dump.rs
+++ b/examples/rust/udp-dump.rs
@@ -23,10 +23,7 @@ use ::demikernel::{
     QToken,
 };
 use ::std::{
-    net::{
-        SocketAddr,
-        SocketAddrV4,
-    },
+    net::SocketAddr,
     str::FromStr,
     time::{
         Duration,
@@ -54,7 +51,7 @@ pub const SOCK_DGRAM: i32 = libc::SOCK_DGRAM;
 #[derive(Debug)]
 struct ProgramArguments {
     /// Local socket IPv4 address.
-    local: SocketAddrV4,
+    local: SocketAddr,
 }
 
 /// Associate functions for Program Arguments
@@ -79,7 +76,7 @@ impl ProgramArguments {
 
         // Default arguments.
         let mut args: ProgramArguments = ProgramArguments {
-            local: SocketAddrV4::from_str(Self::DEFAULT_LOCAL)?,
+            local: SocketAddr::from_str(Self::DEFAULT_LOCAL)?,
         };
 
         // Local address.
@@ -91,13 +88,13 @@ impl ProgramArguments {
     }
 
     /// Returns the local endpoint address parameter stored in the target program arguments.
-    pub fn get_local(&self) -> SocketAddrV4 {
+    pub fn get_local(&self) -> SocketAddr {
         self.local
     }
 
     /// Sets the local address and port number parameters in the target program arguments.
     fn set_local_addr(&mut self, addr: &str) -> Result<()> {
-        self.local = SocketAddrV4::from_str(addr)?;
+        self.local = SocketAddr::from_str(addr)?;
         Ok(())
     }
 }
@@ -122,7 +119,7 @@ impl Application {
     /// Instantiates the application.
     pub fn new(mut libos: LibOS, args: &ProgramArguments) -> Result<Self> {
         // Extract arguments.
-        let local: SocketAddrV4 = args.get_local();
+        let local: SocketAddr = args.get_local();
 
         // Create UDP socket.
         let sockqd: QDesc = match libos.socket(AF_INET, SOCK_DGRAM, 0) {
@@ -131,7 +128,7 @@ impl Application {
         };
 
         // Bind to local address.
-        match libos.bind(sockqd, SocketAddr::V4(local)) {
+        match libos.bind(sockqd, local) {
             Ok(()) => (),
             Err(e) => {
                 // If error, close socket.

--- a/examples/rust/udp-dump.rs
+++ b/examples/rust/udp-dump.rs
@@ -23,7 +23,10 @@ use ::demikernel::{
     QToken,
 };
 use ::std::{
-    net::SocketAddrV4,
+    net::{
+        SocketAddr,
+        SocketAddrV4,
+    },
     str::FromStr,
     time::{
         Duration,
@@ -128,7 +131,7 @@ impl Application {
         };
 
         // Bind to local address.
-        match libos.bind(sockqd, local) {
+        match libos.bind(sockqd, SocketAddr::V4(local)) {
             Ok(()) => (),
             Err(e) => {
                 // If error, close socket.

--- a/examples/rust/udp-echo.rs
+++ b/examples/rust/udp-echo.rs
@@ -65,7 +65,7 @@ pub const SOCK_DGRAM: i32 = libc::SOCK_DGRAM;
 #[derive(Debug)]
 pub struct ProgramArguments {
     /// Local socket IPv4 address.
-    local: SocketAddrV4,
+    local: SocketAddr,
 }
 
 /// Associate functions for Program Arguments
@@ -90,7 +90,7 @@ impl ProgramArguments {
 
         // Default arguments.
         let mut args: ProgramArguments = ProgramArguments {
-            local: SocketAddrV4::from_str(Self::DEFAULT_LOCAL)?,
+            local: SocketAddr::from_str(Self::DEFAULT_LOCAL)?,
         };
 
         // Local address.
@@ -102,13 +102,13 @@ impl ProgramArguments {
     }
 
     /// Returns the local endpoint address parameter stored in the target program arguments.
-    pub fn get_local(&self) -> SocketAddrV4 {
+    pub fn get_local(&self) -> SocketAddr {
         self.local
     }
 
     /// Sets the local address and port number parameters in the target program arguments.
     fn set_local_addr(&mut self, addr: &str) -> Result<()> {
-        self.local = SocketAddrV4::from_str(addr)?;
+        self.local = SocketAddr::from_str(addr)?;
         Ok(())
     }
 }
@@ -133,7 +133,7 @@ impl Application {
     /// Instantiates the application.
     pub fn new(mut libos: LibOS, args: &ProgramArguments) -> Result<Self> {
         // Extract arguments.
-        let local: SocketAddrV4 = args.get_local();
+        let local: SocketAddr = args.get_local();
 
         // Create UDP socket.
         let sockqd: QDesc = match libos.socket(AF_INET_VALUE, SOCK_DGRAM, 0) {
@@ -142,7 +142,7 @@ impl Application {
         };
 
         // Bind to local address.
-        match libos.bind(sockqd, SocketAddr::V4(local)) {
+        match libos.bind(sockqd, local) {
             Ok(()) => (),
             Err(e) => {
                 // If error, close socket.
@@ -193,9 +193,9 @@ impl Application {
                 demi_opcode_t::DEMI_OPC_POP => {
                     let sockqd: QDesc = qr.qr_qd.into();
                     let sga: demi_sgarray_t = unsafe { qr.qr_value.sga };
-                    let saddr: SocketAddrV4 = match Self::sockaddr_to_socketaddrv4(&unsafe { qr.qr_value.sga.sga_addr })
+                    let saddr: SocketAddr = match Self::sockaddr_to_socketaddrv4(&unsafe { qr.qr_value.sga.sga_addr })
                     {
-                        Ok(saddr) => saddr,
+                        Ok(saddr) => SocketAddr::V4(saddr),
                         Err(e) => {
                             // If error, free scatter-gather array.
                             if let Err(e) = self.libos.sgafree(sga) {

--- a/examples/rust/udp-echo.rs
+++ b/examples/rust/udp-echo.rs
@@ -27,6 +27,7 @@ use ::std::mem;
 use ::std::{
     net::{
         Ipv4Addr,
+        SocketAddr,
         SocketAddrV4,
     },
     str::FromStr,
@@ -141,7 +142,7 @@ impl Application {
         };
 
         // Bind to local address.
-        match libos.bind(sockqd, local) {
+        match libos.bind(sockqd, SocketAddr::V4(local)) {
             Ok(()) => (),
             Err(e) => {
                 // If error, close socket.

--- a/examples/rust/udp-ping-pong.rs
+++ b/examples/rust/udp-ping-pong.rs
@@ -19,7 +19,10 @@ use ::demikernel::{
 };
 use ::std::{
     env,
-    net::SocketAddrV4,
+    net::{
+        SocketAddr,
+        SocketAddrV4,
+    },
     slice,
     str::FromStr,
 };
@@ -129,7 +132,7 @@ impl UdpServer {
     }
 
     pub fn run(&mut self, local: SocketAddrV4, remote: SocketAddrV4, fill_char: u8) -> Result<()> {
-        if let Err(e) = self.libos.bind(self.sockqd, local) {
+        if let Err(e) = self.libos.bind(self.sockqd, SocketAddr::V4(local)) {
             anyhow::bail!("bind failed: {:?}", e)
         };
 
@@ -228,7 +231,7 @@ impl UdpClient {
     ) -> Result<()> {
         let mut qts: Vec<QToken> = Vec::new();
 
-        if let Err(e) = self.libos.bind(self.sockqd, local) {
+        if let Err(e) = self.libos.bind(self.sockqd, SocketAddr::V4(local)) {
             anyhow::bail!("bind failed: {:?}", e)
         };
 

--- a/examples/rust/udp-ping-pong.rs
+++ b/examples/rust/udp-ping-pong.rs
@@ -19,10 +19,7 @@ use ::demikernel::{
 };
 use ::std::{
     env,
-    net::{
-        SocketAddr,
-        SocketAddrV4,
-    },
+    net::SocketAddr,
     slice,
     str::FromStr,
 };
@@ -131,8 +128,8 @@ impl UdpServer {
         });
     }
 
-    pub fn run(&mut self, local: SocketAddrV4, remote: SocketAddrV4, fill_char: u8) -> Result<()> {
-        if let Err(e) = self.libos.bind(self.sockqd, SocketAddr::V4(local)) {
+    pub fn run(&mut self, local: SocketAddr, remote: SocketAddr, fill_char: u8) -> Result<()> {
+        if let Err(e) = self.libos.bind(self.sockqd, local) {
             anyhow::bail!("bind failed: {:?}", e)
         };
 
@@ -223,15 +220,15 @@ impl UdpClient {
 
     pub fn run(
         &mut self,
-        local: SocketAddrV4,
-        remote: SocketAddrV4,
+        local: SocketAddr,
+        remote: SocketAddr,
         fill_char: u8,
         buffer_size: usize,
         npings: usize,
     ) -> Result<()> {
         let mut qts: Vec<QToken> = Vec::new();
 
-        if let Err(e) = self.libos.bind(self.sockqd, SocketAddr::V4(local)) {
+        if let Err(e) = self.libos.bind(self.sockqd, local) {
             anyhow::bail!("bind failed: {:?}", e)
         };
 
@@ -354,8 +351,8 @@ pub fn main() -> Result<()> {
             Err(e) => anyhow::bail!("failed to initialize libos: {:?}", e),
         };
 
-        let local: SocketAddrV4 = SocketAddrV4::from_str(&args[2])?;
-        let remote: SocketAddrV4 = SocketAddrV4::from_str(&args[3])?;
+        let local: SocketAddr = SocketAddr::from_str(&args[2])?;
+        let remote: SocketAddr = SocketAddr::from_str(&args[3])?;
 
         if args[1] == "--server" {
             let mut server: UdpServer = UdpServer::new(libos)?;

--- a/examples/rust/udp-pktgen.rs
+++ b/examples/rust/udp-pktgen.rs
@@ -23,7 +23,10 @@ use ::demikernel::{
     QToken,
 };
 use ::std::{
-    net::SocketAddrV4,
+    net::{
+        SocketAddr,
+        SocketAddrV4,
+    },
     slice,
     str::FromStr,
     time::{
@@ -235,7 +238,7 @@ impl Application {
         };
 
         // Bind to local address.
-        match libos.bind(sockqd, local) {
+        match libos.bind(sockqd, SocketAddr::V4(local)) {
             Ok(()) => (),
             Err(e) => {
                 // If error, close socket.

--- a/examples/rust/udp-pktgen.rs
+++ b/examples/rust/udp-pktgen.rs
@@ -23,10 +23,7 @@ use ::demikernel::{
     QToken,
 };
 use ::std::{
-    net::{
-        SocketAddr,
-        SocketAddrV4,
-    },
+    net::SocketAddr,
     slice,
     str::FromStr,
     time::{
@@ -55,9 +52,9 @@ pub const SOCK_DGRAM: i32 = libc::SOCK_DGRAM;
 #[derive(Debug)]
 pub struct ProgramArguments {
     /// Local socket IPv4 address.
-    local: SocketAddrV4,
+    local: SocketAddr,
     /// Remote socket IPv4 address.
-    remote: SocketAddrV4,
+    remote: SocketAddr,
     /// Buffer size (in bytes).
     bufsize: usize,
     /// Injection rate (in micro-seconds).
@@ -116,8 +113,8 @@ impl ProgramArguments {
 
         // Default arguments.
         let mut args: ProgramArguments = ProgramArguments {
-            local: SocketAddrV4::from_str(Self::DEFAULT_LOCAL)?,
-            remote: SocketAddrV4::from_str(Self::DEFAULT_REMOTE)?,
+            local: SocketAddr::from_str(Self::DEFAULT_LOCAL)?,
+            remote: SocketAddr::from_str(Self::DEFAULT_REMOTE)?,
             bufsize: Self::DEFAULT_BUFSIZE,
             injection_rate: Self::DEFAULT_INJECTION_RATE,
         };
@@ -146,12 +143,12 @@ impl ProgramArguments {
     }
 
     /// Returns the local endpoint address parameter stored in the target program arguments.
-    pub fn get_local(&self) -> SocketAddrV4 {
+    pub fn get_local(&self) -> SocketAddr {
         self.local
     }
 
     /// Returns the remote endpoint address parameter stored in the target program arguments.
-    pub fn get_remote(&self) -> SocketAddrV4 {
+    pub fn get_remote(&self) -> SocketAddr {
         self.remote
     }
 
@@ -167,13 +164,13 @@ impl ProgramArguments {
 
     /// Sets the local address and port number parameters in the target program arguments.
     fn set_local_addr(&mut self, addr: &str) -> Result<()> {
-        self.local = SocketAddrV4::from_str(addr)?;
+        self.local = SocketAddr::from_str(addr)?;
         Ok(())
     }
 
     /// Sets the remote address and port number parameters in the target program arguments.
     fn set_remote_addr(&mut self, addr: &str) -> Result<()> {
-        self.remote = SocketAddrV4::from_str(addr)?;
+        self.remote = SocketAddr::from_str(addr)?;
         Ok(())
     }
 
@@ -211,7 +208,7 @@ struct Application {
     // Local socket descriptor.
     sockqd: QDesc,
     /// Remote endpoint.
-    remote: SocketAddrV4,
+    remote: SocketAddr,
     /// Buffer size.
     bufsize: usize,
     /// Injection rate
@@ -226,8 +223,8 @@ impl Application {
     /// Instantiates the application.
     pub fn new(mut libos: LibOS, args: &ProgramArguments) -> Result<Self> {
         // Extract arguments.
-        let local: SocketAddrV4 = args.get_local();
-        let remote: SocketAddrV4 = args.get_remote();
+        let local: SocketAddr = args.get_local();
+        let remote: SocketAddr = args.get_remote();
         let bufsize: usize = args.get_bufsize();
         let injection_rate: u64 = args.get_injection_rate();
 
@@ -238,7 +235,7 @@ impl Application {
         };
 
         // Bind to local address.
-        match libos.bind(sockqd, SocketAddr::V4(local)) {
+        match libos.bind(sockqd, local) {
             Ok(()) => (),
             Err(e) => {
                 // If error, close socket.

--- a/examples/rust/udp-push-pop.rs
+++ b/examples/rust/udp-push-pop.rs
@@ -16,7 +16,10 @@ use ::demikernel::{
 };
 use ::std::{
     env,
-    net::SocketAddrV4,
+    net::{
+        SocketAddr,
+        SocketAddrV4,
+    },
     slice,
     str::FromStr,
 };
@@ -133,7 +136,7 @@ impl UdpServer {
     fn run(&mut self, local: SocketAddrV4, fill_char: u8, nsends: usize) -> Result<()> {
         let nreceives: usize = (8 * nsends) / 128;
 
-        match self.libos.bind(self.sockqd, local) {
+        match self.libos.bind(self.sockqd, SocketAddr::V4(local)) {
             Ok(()) => (),
             Err(e) => anyhow::bail!("bind failed: {:?}", e),
         };
@@ -223,7 +226,7 @@ impl UdpClient {
         buffer_size: usize,
         nsends: usize,
     ) -> Result<()> {
-        match self.libos.bind(self.sockqd, local) {
+        match self.libos.bind(self.sockqd, SocketAddr::V4(local)) {
             Ok(()) => (),
             Err(e) => anyhow::bail!("bind failed: {:?}", e),
         };

--- a/examples/rust/udp-push-pop.rs
+++ b/examples/rust/udp-push-pop.rs
@@ -16,10 +16,7 @@ use ::demikernel::{
 };
 use ::std::{
     env,
-    net::{
-        SocketAddr,
-        SocketAddrV4,
-    },
+    net::SocketAddr,
     slice,
     str::FromStr,
 };
@@ -133,10 +130,10 @@ impl UdpServer {
         });
     }
 
-    fn run(&mut self, local: SocketAddrV4, fill_char: u8, nsends: usize) -> Result<()> {
+    fn run(&mut self, local: SocketAddr, fill_char: u8, nsends: usize) -> Result<()> {
         let nreceives: usize = (8 * nsends) / 128;
 
-        match self.libos.bind(self.sockqd, SocketAddr::V4(local)) {
+        match self.libos.bind(self.sockqd, local) {
             Ok(()) => (),
             Err(e) => anyhow::bail!("bind failed: {:?}", e),
         };
@@ -220,13 +217,13 @@ impl UdpClient {
 
     fn run(
         &mut self,
-        local: SocketAddrV4,
-        remote: SocketAddrV4,
+        local: SocketAddr,
+        remote: SocketAddr,
         fill_char: u8,
         buffer_size: usize,
         nsends: usize,
     ) -> Result<()> {
-        match self.libos.bind(self.sockqd, SocketAddr::V4(local)) {
+        match self.libos.bind(self.sockqd, local) {
             Ok(()) => (),
             Err(e) => anyhow::bail!("bind failed: {:?}", e),
         };
@@ -307,12 +304,12 @@ pub fn main() -> Result<()> {
             Ok(libos) => libos,
             Err(e) => anyhow::bail!("failed to initialize libos: {:?}", e),
         };
-        let local: SocketAddrV4 = SocketAddrV4::from_str(&args[2])?;
+        let local: SocketAddr = SocketAddr::from_str(&args[2])?;
         if args[1] == "--server" {
             let mut server: UdpServer = UdpServer::new(libos)?;
             return server.run(local, FILL_CHAR, NSENDS);
         } else if args[1] == "--client" && args.len() == 4 {
-            let remote: SocketAddrV4 = SocketAddrV4::from_str(&args[3])?;
+            let remote: SocketAddr = SocketAddr::from_str(&args[3])?;
             let mut client: UdpClient = UdpClient::new(libos)?;
             return client.run(local, remote, FILL_CHAR, BUFFER_SIZE, NSENDS);
         }

--- a/examples/rust/udp-relay.rs
+++ b/examples/rust/udp-relay.rs
@@ -23,10 +23,7 @@ use ::demikernel::{
     QToken,
 };
 use ::std::{
-    net::{
-        SocketAddr,
-        SocketAddrV4,
-    },
+    net::SocketAddr,
     str::FromStr,
     time::{
         Duration,
@@ -53,10 +50,10 @@ pub const SOCK_DGRAM: i32 = libc::SOCK_DGRAM;
 /// Program Arguments
 #[derive(Debug)]
 pub struct ProgramArguments {
-    /// Local socket IPv4 address.
-    local: SocketAddrV4,
-    /// Remote socket IPv4 address.
-    remote: SocketAddrV4,
+    /// Local socket address.
+    local: SocketAddr,
+    /// Remote socket address.
+    remote: SocketAddr,
 }
 
 /// Associate functions for Program Arguments
@@ -91,8 +88,8 @@ impl ProgramArguments {
 
         // Default arguments.
         let mut args: ProgramArguments = ProgramArguments {
-            local: SocketAddrV4::from_str(Self::DEFAULT_LOCAL)?,
-            remote: SocketAddrV4::from_str(Self::DEFAULT_REMOTE)?,
+            local: SocketAddr::from_str(Self::DEFAULT_LOCAL)?,
+            remote: SocketAddr::from_str(Self::DEFAULT_REMOTE)?,
         };
 
         // Local address.
@@ -109,24 +106,24 @@ impl ProgramArguments {
     }
 
     /// Returns the local endpoint address parameter stored in the target program arguments.
-    pub fn get_local(&self) -> SocketAddrV4 {
+    pub fn get_local(&self) -> SocketAddr {
         self.local
     }
 
     /// Returns the remote endpoint address parameter stored in the target program arguments.
-    pub fn get_remote(&self) -> SocketAddrV4 {
+    pub fn get_remote(&self) -> SocketAddr {
         self.remote
     }
 
     /// Sets the local address and port number parameters in the target program arguments.
     fn set_local_addr(&mut self, addr: &str) -> Result<()> {
-        self.local = SocketAddrV4::from_str(addr)?;
+        self.local = SocketAddr::from_str(addr)?;
         Ok(())
     }
 
     /// Sets the remote address and port number parameters in the target program arguments.
     fn set_remote_addr(&mut self, addr: &str) -> Result<()> {
-        self.remote = SocketAddrV4::from_str(addr)?;
+        self.remote = SocketAddr::from_str(addr)?;
         Ok(())
     }
 }
@@ -142,7 +139,7 @@ struct Application {
     // Local socket descriptor.
     sockqd: QDesc,
     /// Remote endpoint.
-    remote: SocketAddrV4,
+    remote: SocketAddr,
 }
 
 /// Associated Functions for the Application
@@ -153,8 +150,8 @@ impl Application {
     /// Instantiates the application.
     pub fn new(mut libos: LibOS, args: &ProgramArguments) -> Result<Self> {
         // Extract arguments.
-        let local: SocketAddrV4 = args.get_local();
-        let remote: SocketAddrV4 = args.get_remote();
+        let local: SocketAddr = args.get_local();
+        let remote: SocketAddr = args.get_remote();
 
         // Create UDP socket.
         let sockqd: QDesc = match libos.socket(AF_INET, SOCK_DGRAM, 0) {
@@ -163,7 +160,7 @@ impl Application {
         };
 
         // Bind to local address.
-        match libos.bind(sockqd, SocketAddr::V4(local)) {
+        match libos.bind(sockqd, local) {
             Ok(()) => (),
             Err(e) => {
                 // If error, close socket.

--- a/examples/rust/udp-relay.rs
+++ b/examples/rust/udp-relay.rs
@@ -23,7 +23,10 @@ use ::demikernel::{
     QToken,
 };
 use ::std::{
-    net::SocketAddrV4,
+    net::{
+        SocketAddr,
+        SocketAddrV4,
+    },
     str::FromStr,
     time::{
         Duration,
@@ -160,7 +163,7 @@ impl Application {
         };
 
         // Bind to local address.
-        match libos.bind(sockqd, local) {
+        match libos.bind(sockqd, SocketAddr::V4(local)) {
             Ok(()) => (),
             Err(e) => {
                 // If error, close socket.

--- a/examples/tcp-close/args.rs
+++ b/examples/tcp-close/args.rs
@@ -11,10 +11,7 @@ use clap::{
     ArgMatches,
     Command,
 };
-use std::{
-    net::SocketAddrV4,
-    str::FromStr,
-};
+use std::net::SocketAddr;
 
 //======================================================================================================================
 // Program Arguments
@@ -25,8 +22,8 @@ use std::{
 pub struct ProgramArguments {
     /// Run mode.
     run_mode: String,
-    /// Socket IPv4 address.
-    addr: SocketAddrV4,
+    /// Socket address.
+    addr: SocketAddr,
     /// Number of clients
     nclients: Option<usize>,
     /// Peer type.
@@ -100,9 +97,9 @@ impl ProgramArguments {
             .to_string();
 
         // Socket address.
-        let addr: SocketAddrV4 = {
+        let addr: SocketAddr = {
             let addr: &String = matches.get_one::<String>("addr").expect("missing address");
-            SocketAddrV4::from_str(addr)?
+            addr.parse()?
         };
 
         let mut args: ProgramArguments = Self {
@@ -150,7 +147,7 @@ impl ProgramArguments {
     }
 
     /// Returns the `addr` command line argument.
-    pub fn addr(&self) -> SocketAddrV4 {
+    pub fn addr(&self) -> SocketAddr {
         self.addr
     }
 

--- a/examples/tcp-close/client.rs
+++ b/examples/tcp-close/client.rs
@@ -21,7 +21,7 @@ use std::{
         HashMap,
         HashSet,
     },
-    net::SocketAddrV4,
+    net::SocketAddr,
 };
 
 //======================================================================================================================
@@ -49,7 +49,7 @@ pub struct TcpClient {
     /// Underlying libOS.
     libos: LibOS,
     /// Address of remote peer.
-    remote: SocketAddrV4,
+    remote: SocketAddr,
     /// Open queue descriptors.
     qds: HashSet<QDesc>,
     /// Number of clients that established a connection.
@@ -66,7 +66,7 @@ pub struct TcpClient {
 
 impl TcpClient {
     /// Creates a new TCP client.
-    pub fn new(libos: LibOS, remote: SocketAddrV4, should_async_close: bool) -> Result<Self> {
+    pub fn new(libos: LibOS, remote: SocketAddr, should_async_close: bool) -> Result<Self> {
         println!("Connecting to: {:?}", remote);
         Ok(Self {
             libos,

--- a/examples/tcp-close/server.rs
+++ b/examples/tcp-close/server.rs
@@ -21,10 +21,7 @@ use std::{
         HashMap,
         HashSet,
     },
-    net::{
-        SocketAddr,
-        SocketAddrV4,
-    },
+    net::SocketAddr,
 };
 
 //======================================================================================================================
@@ -75,12 +72,12 @@ pub struct TcpServer {
 
 impl TcpServer {
     /// Creates a new TCP server.
-    pub fn new(mut libos: LibOS, local: SocketAddrV4, should_async_close: bool) -> Result<Self> {
+    pub fn new(mut libos: LibOS, local: SocketAddr, should_async_close: bool) -> Result<Self> {
         // Create TCP socket.
         let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
 
         // Bind to local address.
-        libos.bind(sockqd, SocketAddr::V4(local))?;
+        libos.bind(sockqd, local)?;
 
         println!("Listening to: {:?}", local);
 

--- a/examples/tcp-close/server.rs
+++ b/examples/tcp-close/server.rs
@@ -21,7 +21,10 @@ use std::{
         HashMap,
         HashSet,
     },
-    net::SocketAddrV4,
+    net::{
+        SocketAddr,
+        SocketAddrV4,
+    },
 };
 
 //======================================================================================================================
@@ -77,7 +80,7 @@ impl TcpServer {
         let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
 
         // Bind to local address.
-        libos.bind(sockqd, local)?;
+        libos.bind(sockqd, SocketAddr::V4(local))?;
 
         println!("Listening to: {:?}", local);
 

--- a/examples/tcp-echo/client.rs
+++ b/examples/tcp-echo/client.rs
@@ -18,7 +18,7 @@ use demikernel::{
 };
 use std::{
     collections::HashMap,
-    net::SocketAddrV4,
+    net::SocketAddr,
     slice,
     time::{
         Duration,
@@ -57,7 +57,7 @@ pub struct TcpEchoClient {
     /// Set of connected clients.
     clients: HashMap<QDesc, (Vec<u8>, usize)>,
     /// Address of remote peer.
-    remote: SocketAddrV4,
+    remote: SocketAddr,
     /// List of pending operations.
     qts: Vec<QToken>,
     /// Reverse lookup table of pending operations.
@@ -70,7 +70,7 @@ pub struct TcpEchoClient {
 
 impl TcpEchoClient {
     /// Instantiates a new TCP echo client.
-    pub fn new(libos: LibOS, bufsize: usize, remote: SocketAddrV4) -> Result<Self> {
+    pub fn new(libos: LibOS, bufsize: usize, remote: SocketAddr) -> Result<Self> {
         return Ok(Self {
             libos,
             bufsize,

--- a/examples/tcp-echo/main.rs
+++ b/examples/tcp-echo/main.rs
@@ -23,7 +23,7 @@ use demikernel::{
 };
 use server::TcpEchoServer;
 use std::{
-    net::SocketAddrV4,
+    net::SocketAddr,
     str::FromStr,
 };
 
@@ -52,7 +52,7 @@ pub struct ProgramArguments {
     /// Run mode.
     run_mode: Option<String>,
     /// Socket IPv4 address.
-    addr: SocketAddrV4,
+    addr: SocketAddr,
     /// Buffer size (in bytes).
     bufsize: Option<usize>,
     /// Number of requests.
@@ -132,9 +132,9 @@ impl ProgramArguments {
             .get_matches();
 
         // Socket address.
-        let addr: SocketAddrV4 = {
+        let addr: SocketAddr = {
             let addr: &String = matches.get_one::<String>("addr").expect("missing address");
-            SocketAddrV4::from_str(addr)?
+            SocketAddr::from_str(addr)?
         };
 
         // Default arguments.

--- a/examples/tcp-echo/server.rs
+++ b/examples/tcp-echo/server.rs
@@ -21,7 +21,10 @@ use std::{
         HashMap,
         HashSet,
     },
-    net::SocketAddrV4,
+    net::{
+        SocketAddr,
+        SocketAddrV4,
+    },
     time::{
         Duration,
         Instant,
@@ -69,7 +72,7 @@ impl TcpEchoServer {
         let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
 
         // Bind the socket to a local address.
-        if let Err(e) = libos.bind(sockqd, local) {
+        if let Err(e) = libos.bind(sockqd, SocketAddr::V4(local)) {
             println!("ERROR: {:?}", e);
             libos.close(sockqd)?;
             anyhow::bail!("{:?}", e);

--- a/examples/tcp-echo/server.rs
+++ b/examples/tcp-echo/server.rs
@@ -21,10 +21,7 @@ use std::{
         HashMap,
         HashSet,
     },
-    net::{
-        SocketAddr,
-        SocketAddrV4,
-    },
+    net::SocketAddr,
     time::{
         Duration,
         Instant,
@@ -67,12 +64,12 @@ pub struct TcpEchoServer {
 
 impl TcpEchoServer {
     /// Instantiates a new TCP echo server.
-    pub fn new(mut libos: LibOS, local: SocketAddrV4) -> Result<Self> {
+    pub fn new(mut libos: LibOS, local: SocketAddr) -> Result<Self> {
         // Create a TCP socket.
         let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
 
         // Bind the socket to a local address.
-        if let Err(e) = libos.bind(sockqd, SocketAddr::V4(local)) {
+        if let Err(e) = libos.bind(sockqd, local) {
             println!("ERROR: {:?}", e);
             libos.close(sockqd)?;
             anyhow::bail!("{:?}", e);

--- a/examples/tcp-wait/args.rs
+++ b/examples/tcp-wait/args.rs
@@ -8,14 +8,14 @@ use clap::{
     Command,
 };
 use std::{
-    net::SocketAddrV4,
+    net::SocketAddr,
     str::FromStr,
 };
 
 #[derive(Debug)]
 pub struct ProgramArguments {
     /// Socket IPv4 address.
-    addr: SocketAddrV4,
+    addr: SocketAddr,
     /// Peer type.
     peer_type: Option<String>,
     /// Number of clients.
@@ -64,9 +64,9 @@ impl ProgramArguments {
             )
             .get_matches();
 
-        let addr: SocketAddrV4 = {
+        let addr: SocketAddr = {
             let addr: &String = matches.get_one::<String>("addr").expect("missing address");
-            SocketAddrV4::from_str(addr)?
+            SocketAddr::from_str(addr)?
         };
 
         let scenario = matches
@@ -98,7 +98,7 @@ impl ProgramArguments {
         Ok(args)
     }
 
-    pub fn addr(&self) -> SocketAddrV4 {
+    pub fn addr(&self) -> SocketAddr {
         self.addr
     }
 

--- a/examples/tcp-wait/client.rs
+++ b/examples/tcp-wait/client.rs
@@ -17,7 +17,7 @@ use ::demikernel::{
     QToken,
 };
 use ::std::{
-    net::SocketAddrV4,
+    net::SocketAddr,
     slice,
 };
 
@@ -45,7 +45,7 @@ pub struct TcpClient {
     /// Underlying libOS.
     libos: LibOS,
     /// Address of remote peer.
-    remote: SocketAddrV4,
+    remote: SocketAddr,
     /// Number of clients.
     nclients: usize,
     /// Socket queue descriptor.
@@ -57,7 +57,7 @@ pub struct TcpClient {
 //======================================================================================================================
 
 impl TcpClient {
-    pub fn new(libos: LibOS, remote: SocketAddrV4, nclients: usize) -> Result<Self> {
+    pub fn new(libos: LibOS, remote: SocketAddr, nclients: usize) -> Result<Self> {
         println!("Connecting to: {:?}", remote);
         Ok(Self {
             libos,

--- a/examples/tcp-wait/server.rs
+++ b/examples/tcp-wait/server.rs
@@ -21,10 +21,7 @@ use ::std::{
         HashMap,
         HashSet,
     },
-    net::{
-        SocketAddr,
-        SocketAddrV4,
-    },
+    net::SocketAddr,
 };
 
 //======================================================================================================================
@@ -71,12 +68,12 @@ pub struct TcpServer {
 //======================================================================================================================
 
 impl TcpServer {
-    pub fn new(mut libos: LibOS, local: SocketAddrV4, nclients: usize) -> Result<Self> {
+    pub fn new(mut libos: LibOS, local: SocketAddr, nclients: usize) -> Result<Self> {
         // Create TCP socket.
         let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
 
         // Bind to local address.
-        libos.bind(sockqd, SocketAddr::V4(local))?;
+        libos.bind(sockqd, local)?;
 
         println!("Listening to: {:?}", local);
 

--- a/examples/tcp-wait/server.rs
+++ b/examples/tcp-wait/server.rs
@@ -21,7 +21,10 @@ use ::std::{
         HashMap,
         HashSet,
     },
-    net::SocketAddrV4,
+    net::{
+        SocketAddr,
+        SocketAddrV4,
+    },
 };
 
 //======================================================================================================================
@@ -73,7 +76,7 @@ impl TcpServer {
         let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
 
         // Bind to local address.
-        libos.bind(sockqd, local)?;
+        libos.bind(sockqd, SocketAddr::V4(local))?;
 
         println!("Listening to: {:?}", local);
 

--- a/src/rust/catcollar/mod.rs
+++ b/src/rust/catcollar/mod.rs
@@ -161,7 +161,8 @@ impl CatcollarLibOS {
     pub fn bind(&mut self, qd: QDesc, local: SocketAddr) -> Result<(), Fail> {
         trace!("bind() qd={:?}, local={:?}", qd, local);
 
-        let local = unwrap_socketaddr(local)?;
+        // FIXME: add IPv6 support; https://github.com/microsoft/demikernel/issues/935
+        let local: SockAddrV4 = unwrap_socketaddr(local)?;
 
         // Check if we are binding to the wildcard port.
         if local.port() == 0 {
@@ -306,7 +307,8 @@ impl CatcollarLibOS {
         trace!("connect() qd={:?}, remote={:?}", qd, remote);
 
         // Issue connect operation.
-        let remote = unwrap_socketaddr(remote)?;
+        // FIXME: add IPv6 support; https://github.com/microsoft/demikernel/issues/935
+        let remote: SocketAddrV4 = unwrap_socketaddr(remote)?;
         let fd: RawFd = self.get_queue_fd(&qd)?;
         let yielder: Yielder = Yielder::new();
         let coroutine: Pin<Box<Operation>> = Box::pin(Self::connect_coroutine(qd, fd, remote, yielder));
@@ -515,7 +517,8 @@ impl CatcollarLibOS {
     pub fn pushto(&mut self, qd: QDesc, sga: &demi_sgarray_t, remote: SocketAddr) -> Result<QToken, Fail> {
         trace!("pushto() qd={:?}", qd);
 
-        let remote = unwrap_socketaddr(remote)?;
+        // FIXME: add IPv6 support; https://github.com/microsoft/demikernel/issues/935
+        let remote: SocketAddrV4 = unwrap_socketaddr(remote)?;
 
         match self.runtime.clone_sgarray(sga) {
             Ok(buf) => {

--- a/src/rust/catloop/mod.rs
+++ b/src/rust/catloop/mod.rs
@@ -63,6 +63,7 @@ use ::std::{
     net::{
         Ipv4Addr,
         SocketAddrV4,
+        SocketAddr,
     },
     pin::Pin,
     rc::Rc,
@@ -141,14 +142,23 @@ impl CatloopLibOS {
 
     /// Binds a socket to a local endpoint. This function contains the libOS-level functionality needed to bind a
     /// CatloopQueue to a local address.
-    pub fn bind(&mut self, qd: QDesc, local: SocketAddrV4) -> Result<(), Fail> {
+    pub fn bind(&mut self, qd: QDesc, local: SocketAddr) -> Result<(), Fail> {
         #[cfg(feature = "profiler")]
         timer!("catloop::bind");
         trace!("bind() qd={:?}, local={:?}", qd, local);
 
+        let localv4 = match local {
+            SocketAddr::V4(sin) => sin,
+            _ => {
+                let cause: String = format!("unsupported address family (qd={:?})", qd);
+                error!("bind(): {}", cause);
+                return Err(Fail::new(libc::ENOTSUP, &cause));
+            }
+        };
+
         // Check if we are binding to the wildcard address.
         // FIXME: https://github.com/demikernel/demikernel/issues/189
-        if local.ip() == &Ipv4Addr::UNSPECIFIED {
+        if localv4.ip() == &Ipv4Addr::UNSPECIFIED {
             let cause: String = format!("cannot bind to wildcard address (qd={:?})", qd);
             error!("bind(): {}", cause);
             return Err(Fail::new(libc::ENOTSUP, &cause));
@@ -156,36 +166,36 @@ impl CatloopLibOS {
 
         // Check if we are binding to the wildcard port.
         // FIXME: https://github.com/demikernel/demikernel/issues/582
-        if local.port() == 0 {
+        if localv4.port() == 0 {
             let cause: String = format!("cannot bind to port 0 (qd={:?})", qd);
             error!("bind(): {}", cause);
             return Err(Fail::new(libc::ENOTSUP, &cause));
         }
 
         // Check if we are binding to a non-local address.
-        if &self.config.local_ipv4_addr() != local.ip() {
+        if &self.config.local_ipv4_addr() != localv4.ip() {
             let cause: String = format!("cannot bind to non-local address (qd={:?})", qd);
             error!("bind(): {}", cause);
             return Err(Fail::new(libc::EADDRNOTAVAIL, &cause));
         }
 
         // Check whether the address is in use.
-        if self.addr_in_use(local) {
+        if self.addr_in_use(localv4) {
             let cause: String = format!("address is already bound to a socket (qd={:?}", qd);
             error!("bind(): {}", cause);
             return Err(Fail::new(libc::EADDRINUSE, &cause));
         }
         // Check if this is an ephemeral port.
-        if EphemeralPorts::is_private(local.port()) {
+        if EphemeralPorts::is_private(localv4.port()) {
             // Allocate ephemeral port from the pool, to leave ephemeral port allocator in a consistent state.
-            self.state.borrow_mut().alloc_ephemeral_port(Some(local.port()))?;
+            self.state.borrow_mut().alloc_ephemeral_port(Some(localv4.port()))?;
         }
 
         // Check if queue descriptor is valid.
         let queue: CatloopQueue = self.get_queue(&qd)?;
 
         // Check that the socket associated with the queue is not listening.
-        queue.bind(local)
+        queue.bind(localv4)
     }
 
     /// Sets a CatloopQueue and as a passive one. This function contains the libOS-level

--- a/src/rust/catloop/mod.rs
+++ b/src/rust/catloop/mod.rs
@@ -148,7 +148,8 @@ impl CatloopLibOS {
         timer!("catloop::bind");
         trace!("bind() qd={:?}, local={:?}", qd, local);
 
-        let local = unwrap_socketaddr(local)?;
+        // FIXME: add IPv6 support; https://github.com/microsoft/demikernel/issues/935
+        let local: SocketAddrV4 = unwrap_socketaddr(local)?;
 
         // Check if we are binding to the wildcard address.
         // FIXME: https://github.com/demikernel/demikernel/issues/189
@@ -285,11 +286,14 @@ impl CatloopLibOS {
     /// Synchronous code to establish a connection to a remote endpoint. This function schedules the asynchronous
     /// coroutine and performs any necessary synchronous, multi-queue operations at the libOS-level before beginning
     /// the connect.
-    pub fn connect(&mut self, qd: QDesc, remote: SocketAddrV4) -> Result<QToken, Fail> {
+    pub fn connect(&mut self, qd: QDesc, remote: SocketAddr) -> Result<QToken, Fail> {
         #[cfg(feature = "profiler")]
         timer!("catloop::connect");
         trace!("connect() qd={:?}, remote={:?}", qd, remote);
         let queue: CatloopQueue = self.get_queue(&qd)?;
+
+        // FIXME: add IPv6 support; https://github.com/microsoft/demikernel/issues/935
+        let remote: SocketAddrV4 = unwrap_socketaddr(remote)?;
 
         // Create connect coroutine.
         let coroutine = |yielder: Yielder| -> Result<TaskHandle, Fail> {

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -504,8 +504,6 @@ impl SharedCatnapLibOS {
         self.runtime.free_sgarray(sga)
     }
 
-    /// Unwrap the V4
-
     /// Takes out the result from the [OperationTask] associated with the target [TaskHandle].
     fn take_result(&mut self, handle: TaskHandle) -> (QDesc, OperationResult) {
         #[cfg(feature = "take_result")]

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -143,8 +143,8 @@ impl SharedCatnapLibOS {
         timer!("catnap::bind");
         trace!("bind() qd={:?}, local={:?}", qd, local);
 
-        // FIXME: IPv6 support
-        let local = unwrap_socketaddr(local)?;
+        // FIXME: add IPv6 support; https://github.com/microsoft/demikernel/issues/935
+        let local: SocketAddrV4 = unwrap_socketaddr(local)?;
 
         // Check if we are binding to the wildcard address.
         // FIXME: https://github.com/demikernel/demikernel/issues/189
@@ -244,7 +244,9 @@ impl SharedCatnapLibOS {
         #[cfg(feature = "profiler")]
         timer!("catnap::connect");
         trace!("connect() qd={:?}, remote={:?}", qd, remote);
-        let remote = unwrap_socketaddr(remote)?;
+
+        // FIXME: add IPv6 support; https://github.com/microsoft/demikernel/issues/935
+        let remote: SocketAddrV4 = unwrap_socketaddr(remote)?;
         let me: Self = self.clone();
         let coroutine = |yielder: Yielder| -> Result<TaskHandle, Fail> {
             // Clone the self reference and move into the coroutine.
@@ -386,7 +388,8 @@ impl SharedCatnapLibOS {
         timer!("catnap::pushto");
         trace!("pushto() qd={:?}", qd);
 
-        let remote = unwrap_socketaddr(remote)?;
+        // FIXME: add IPv6 support; https://github.com/microsoft/demikernel/issues/935
+        let remote: SocketAddrV4 = unwrap_socketaddr(remote)?;
 
         let buf: DemiBuffer = self.runtime.clone_sgarray(sga)?;
         if buf.len() == 0 {

--- a/src/rust/catnip/mod.rs
+++ b/src/rust/catnip/mod.rs
@@ -39,7 +39,7 @@ use crate::{
     },
 };
 use ::std::{
-    net::SocketAddrV4,
+    net::SocketAddr,
     ops::{
         Deref,
         DerefMut,
@@ -128,7 +128,7 @@ impl CatnipLibOS {
         }
     }
 
-    pub fn pushto(&mut self, qd: QDesc, sga: &demi_sgarray_t, to: SocketAddrV4) -> Result<QToken, Fail> {
+    pub fn pushto(&mut self, qd: QDesc, sga: &demi_sgarray_t, to: SocketAddr) -> Result<QToken, Fail> {
         #[cfg(feature = "profiler")]
         timer!("catnip::pushto");
         trace!("pushto2(): qd={:?}", qd);

--- a/src/rust/catpowder/mod.rs
+++ b/src/rust/catpowder/mod.rs
@@ -39,7 +39,7 @@ use crate::{
 };
 use ::std::{
     collections::HashMap,
-    net::SocketAddrV4,
+    net::SocketAddr,
     ops::{
         Deref,
         DerefMut,
@@ -123,7 +123,7 @@ impl CatpowderLibOS {
         }
     }
 
-    pub fn pushto(&mut self, qd: QDesc, sga: &demi_sgarray_t, to: SocketAddrV4) -> Result<QToken, Fail> {
+    pub fn pushto(&mut self, qd: QDesc, sga: &demi_sgarray_t, to: SocketAddr) -> Result<QToken, Fail> {
         #[cfg(feature = "profiler")]
         timer!("catnip::pushto");
         trace!("pushto2(): qd={:?}", qd);

--- a/src/rust/demikernel/bindings.rs
+++ b/src/rust/demikernel/bindings.rs
@@ -344,7 +344,7 @@ pub extern "C" fn demi_connect(
     }
 
     // Get socket address.
-    let endpoint: SocketAddrV4 = match sockaddr_to_socketaddrv4(saddr, size) {
+    let endpoint: SocketAddr = match sockaddr_to_socketaddr(saddr, size) {
         Ok(endpoint) => endpoint,
         Err(e) => {
             trace!("demi_connect() failed: {:?}", e);
@@ -426,7 +426,7 @@ pub extern "C" fn demi_pushto(
     let sga: &demi_sgarray_t = unsafe { &*sga };
 
     // Get socket address.
-    let endpoint: SocketAddrV4 = match sockaddr_to_socketaddrv4(saddr, size) {
+    let endpoint: SocketAddr = match sockaddr_to_socketaddr(saddr, size) {
         Ok(endpoint) => endpoint,
         Err(e) => {
             trace!("demi_pushto() failed: {:?}", e);
@@ -807,15 +807,6 @@ fn do_syscall<T>(f: impl FnOnce(&mut LibOS) -> T) -> Result<T, Fail> {
             None => Err(Fail::new(libc::ENOSYS, "Demikernel is not initialized")),
         },
         Err(_) => Err(Fail::new(libc::EBUSY, "Demikernel is busy")),
-    }
-}
-
-/// Converts a [sockaddr] into a [SocketAddrV4].
-fn sockaddr_to_socketaddrv4(saddr: *const sockaddr, size: Socklen) -> Result<SocketAddrV4, Fail> {
-    return match sockaddr_to_socketaddr(saddr, size) {
-        Ok(SocketAddr::V4(result)) => Ok(result),
-        Ok(_) => Err(Fail::new(libc::ENOTSUP, "communication domain not supported")),
-        Err(e) => Err(e),
     }
 }
 

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -32,7 +32,6 @@ use crate::{
 };
 use ::std::{
     env,
-    net::SocketAddrV4,
     net::SocketAddr,
     time::{
         Duration,
@@ -193,7 +192,7 @@ impl LibOS {
     }
 
     /// Initiates a connection with a remote TCP socket.
-    pub fn connect(&mut self, sockqd: QDesc, remote: SocketAddrV4) -> Result<QToken, Fail> {
+    pub fn connect(&mut self, sockqd: QDesc, remote: SocketAddr) -> Result<QToken, Fail> {
         let result: Result<QToken, Fail> = match self {
             LibOS::NetworkLibOS(libos) => libos.connect(sockqd, remote),
             LibOS::MemoryLibOS(_) => Err(Fail::new(libc::ENOTSUP, "connect() is not supported on memory liboses")),
@@ -240,7 +239,7 @@ impl LibOS {
     }
 
     /// Pushes a scatter-gather array to a UDP socket.
-    pub fn pushto(&mut self, qd: QDesc, sga: &demi_sgarray_t, to: SocketAddrV4) -> Result<QToken, Fail> {
+    pub fn pushto(&mut self, qd: QDesc, sga: &demi_sgarray_t, to: SocketAddr) -> Result<QToken, Fail> {
         let result: Result<QToken, Fail> = match self {
             LibOS::NetworkLibOS(libos) => libos.pushto(qd, sga, to),
             LibOS::MemoryLibOS(_) => Err(Fail::new(libc::ENOTSUP, "pushto() is not supported on memory liboses")),

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -33,6 +33,7 @@ use crate::{
 use ::std::{
     env,
     net::SocketAddrV4,
+    net::SocketAddr,
     time::{
         Duration,
         Instant,
@@ -156,7 +157,7 @@ impl LibOS {
     }
 
     /// Binds a socket to a local address.
-    pub fn bind(&mut self, sockqd: QDesc, local: SocketAddrV4) -> Result<(), Fail> {
+    pub fn bind(&mut self, sockqd: QDesc, local: SocketAddr) -> Result<(), Fail> {
         let result: Result<(), Fail> = match self {
             LibOS::NetworkLibOS(libos) => libos.bind(sockqd, local),
             LibOS::MemoryLibOS(_) => Err(Fail::new(libc::ENOTSUP, "bind() is not supported on memory liboses")),

--- a/src/rust/demikernel/libos/network.rs
+++ b/src/rust/demikernel/libos/network.rs
@@ -18,10 +18,7 @@ use crate::{
     },
     scheduler::TaskHandle,
 };
-use ::std::net::{
-    SocketAddrV4,
-    SocketAddr,
-};
+use ::std::net::SocketAddr;
 
 #[cfg(feature = "catcollar-libos")]
 use crate::catcollar::CatcollarLibOS;
@@ -143,7 +140,7 @@ impl NetworkLibOS {
     }
 
     /// Initiates a connection with a remote TCP peer.
-    pub fn connect(&mut self, sockqd: QDesc, remote: SocketAddrV4) -> Result<QToken, Fail> {
+    pub fn connect(&mut self, sockqd: QDesc, remote: SocketAddr) -> Result<QToken, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
             NetworkLibOS::Catpowder(libos) => libos.connect(sockqd, remote),
@@ -206,7 +203,7 @@ impl NetworkLibOS {
     }
 
     /// Pushes a scatter-gather array to a UDP socket.
-    pub fn pushto(&mut self, sockqd: QDesc, sga: &demi_sgarray_t, to: SocketAddrV4) -> Result<QToken, Fail> {
+    pub fn pushto(&mut self, sockqd: QDesc, sga: &demi_sgarray_t, to: SocketAddr) -> Result<QToken, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
             NetworkLibOS::Catpowder(libos) => libos.pushto(sockqd, sga, to),

--- a/src/rust/demikernel/libos/network.rs
+++ b/src/rust/demikernel/libos/network.rs
@@ -18,7 +18,10 @@ use crate::{
     },
     scheduler::TaskHandle,
 };
-use ::std::net::SocketAddrV4;
+use ::std::net::{
+    SocketAddrV4,
+    SocketAddr,
+};
 
 #[cfg(feature = "catcollar-libos")]
 use crate::catcollar::CatcollarLibOS;
@@ -77,7 +80,7 @@ impl NetworkLibOS {
     }
 
     /// Binds a socket to a local address.
-    pub fn bind(&mut self, sockqd: QDesc, local: SocketAddrV4) -> Result<(), Fail> {
+    pub fn bind(&mut self, sockqd: QDesc, local: SocketAddr) -> Result<(), Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
             NetworkLibOS::Catpowder(libos) => libos.bind(sockqd, local),

--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -228,7 +228,8 @@ impl<const N: usize> InetStack<N> {
         timer!("inetstack::bind");
         trace!("bind(): qd={:?} local={:?}", qd, local);
 
-        let local = unwrap_socketaddr(local)?;
+        // FIXME: add IPv6 support; https://github.com/microsoft/demikernel/issues/935
+        let local: SocketAddrV4 = unwrap_socketaddr(local)?;
 
         match self.lookup_qtype(&qd) {
             Some(QType::TcpSocket) => self.ipv4.tcp.bind(qd, local),
@@ -344,7 +345,8 @@ impl<const N: usize> InetStack<N> {
         timer!("inetstack::connect");
         trace!("connect(): qd={:?} remote={:?}", qd, remote);
 
-        let remote = unwrap_socketaddr(remote)?;
+        // FIXME: add IPv6 support; https://github.com/microsoft/demikernel/issues/935
+        let remote: SocketAddrV4 = unwrap_socketaddr(remote)?;
 
         let task: OperationTask = match self.lookup_qtype(&qd) {
             Some(QType::TcpSocket) => {
@@ -511,7 +513,8 @@ impl<const N: usize> InetStack<N> {
     /// Pushes a buffer to a UDP socket.
     /// TODO: Rename this function to pushto() once we have a common buffer representation across all libOSes.
     pub fn do_pushto(&mut self, qd: QDesc, buf: DemiBuffer, to: SocketAddr) -> Result<OperationTask, Fail> {
-        let to = unwrap_socketaddr(to)?;
+        // FIXME: add IPv6 support; https://github.com/microsoft/demikernel/issues/935
+        let to: SocketAddrV4 = unwrap_socketaddr(to)?;
 
         match self.lookup_qtype(&qd) {
             Some(QType::UdpSocket) => {

--- a/src/rust/pal/constants.rs
+++ b/src/rust/pal/constants.rs
@@ -12,13 +12,7 @@ use windows::Win32::Networking::WinSock;
 pub const AF_INET: WinSock::ADDRESS_FAMILY = WinSock::AF_INET;
 
 #[cfg(target_os = "windows")]
-pub const AF_INET6: WinSock::ADDRESS_FAMILY = WinSock::AF_INET6;
-
-#[cfg(target_os = "windows")]
 pub const AF_INET_VALUE: i32 = AF_INET.0 as i32;
-
-#[cfg(target_os = "windows")]
-pub const AF_INET6_VALUE: i32 = AF_INET6.0 as i32;
 
 #[cfg(target_os = "windows")]
 pub const SOCK_STREAM: i32 = WinSock::SOCK_STREAM as i32;
@@ -37,13 +31,7 @@ pub const SOMAXCONN: i32 = WinSock::SOMAXCONN as i32;
 pub const AF_INET: u16 = libc::AF_INET as u16;
 
 #[cfg(target_os = "linux")]
-pub const AF_INET6: u16 = libc::AF_INET6 as u16;
-
-#[cfg(target_os = "linux")]
 pub const AF_INET_VALUE: i32 = AF_INET as i32;
-
-#[cfg(target_os = "linux")]
-pub const AF_INET6_VALUE: i32 = AF_INET6 as i32;
 
 #[cfg(target_os = "linux")]
 pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;

--- a/src/rust/pal/constants.rs
+++ b/src/rust/pal/constants.rs
@@ -12,7 +12,13 @@ use windows::Win32::Networking::WinSock;
 pub const AF_INET: WinSock::ADDRESS_FAMILY = WinSock::AF_INET;
 
 #[cfg(target_os = "windows")]
+pub const AF_INET6: WinSock::ADDRESS_FAMILY = WinSock::AF_INET6;
+
+#[cfg(target_os = "windows")]
 pub const AF_INET_VALUE: i32 = AF_INET.0 as i32;
+
+#[cfg(target_os = "windows")]
+pub const AF_INET6_VALUE: i32 = AF_INET6.0 as i32;
 
 #[cfg(target_os = "windows")]
 pub const SOCK_STREAM: i32 = WinSock::SOCK_STREAM as i32;
@@ -31,7 +37,13 @@ pub const SOMAXCONN: i32 = WinSock::SOMAXCONN as i32;
 pub const AF_INET: u16 = libc::AF_INET as u16;
 
 #[cfg(target_os = "linux")]
+pub const AF_INET6: u16 = libc::AF_INET6 as u16;
+
+#[cfg(target_os = "linux")]
 pub const AF_INET_VALUE: i32 = AF_INET as i32;
+
+#[cfg(target_os = "linux")]
+pub const AF_INET6_VALUE: i32 = AF_INET6 as i32;
 
 #[cfg(target_os = "linux")]
 pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;

--- a/src/rust/pal/constants.rs
+++ b/src/rust/pal/constants.rs
@@ -34,7 +34,7 @@ pub const SOMAXCONN: i32 = WinSock::SOMAXCONN as i32;
 pub const AF_INET: libc::sa_family_t = libc::AF_INET as u16;
 
 #[cfg(target_os = "linux")]
-pub const AF_INET6: libc::sa_family_t = libc::AF_INET as u16;
+pub const AF_INET6: libc::sa_family_t = libc::AF_INET6 as u16;
 
 #[cfg(target_os = "linux")]
 pub const AF_INET_VALUE: i32 = AF_INET as i32;

--- a/src/rust/pal/constants.rs
+++ b/src/rust/pal/constants.rs
@@ -12,6 +12,9 @@ use windows::Win32::Networking::WinSock;
 pub const AF_INET: WinSock::ADDRESS_FAMILY = WinSock::AF_INET;
 
 #[cfg(target_os = "windows")]
+pub const AF_INET6: WinSock::ADDRESS_FAMILY = WinSock::AF_INET6;
+
+#[cfg(target_os = "windows")]
 pub const AF_INET_VALUE: i32 = AF_INET.0 as i32;
 
 #[cfg(target_os = "windows")]
@@ -28,7 +31,10 @@ pub const SOMAXCONN: i32 = WinSock::SOMAXCONN as i32;
 //==============================================================================
 
 #[cfg(target_os = "linux")]
-pub const AF_INET: u16 = libc::AF_INET as u16;
+pub const AF_INET: libc::sa_family_t = libc::AF_INET as u16;
+
+#[cfg(target_os = "linux")]
+pub const AF_INET6: libc::sa_family_t = libc::AF_INET as u16;
 
 #[cfg(target_os = "linux")]
 pub const AF_INET_VALUE: i32 = AF_INET as i32;

--- a/src/rust/pal/data_structures.rs
+++ b/src/rust/pal/data_structures.rs
@@ -20,6 +20,12 @@ pub type SockAddrIn6 = WinSock::SOCKADDR_IN6;
 #[cfg(target_os = "windows")]
 pub type Socklen = i32;
 
+#[cfg(target_os = "windows")]
+pub type SockAddrStorage = WinSock::SOCKADDR_STORAGE;
+
+#[cfg(target_os = "windows")]
+pub type AddressFamily = WinSock::ADDRESS_FAMILY;
+
 //==============================================================================
 // Linux data structures
 //==============================================================================
@@ -35,3 +41,9 @@ pub type SockAddrIn6 = libc::sockaddr_in6;
 
 #[cfg(target_os = "linux")]
 pub type Socklen = libc::socklen_t;
+
+#[cfg(target_os = "linux")]
+pub type SockAddrStorage = libc::sockaddr_storage;
+
+#[cfg(target_os = "linux")]
+pub type AddressFamily = libc::sa_family_t;

--- a/src/rust/pal/data_structures.rs
+++ b/src/rust/pal/data_structures.rs
@@ -9,9 +9,6 @@ use windows::Win32::Networking::WinSock;
 //==============================================================================
 
 #[cfg(target_os = "windows")]
-pub type AddressFamily = WinSock::ADDRESS_FAMILY;
-
-#[cfg(target_os = "windows")]
 pub type SockAddr = windows::Win32::Networking::WinSock::SOCKADDR;
 
 #[cfg(target_os = "windows")]
@@ -26,9 +23,6 @@ pub type Socklen = i32;
 //==============================================================================
 // Linux data structures
 //==============================================================================
-
-#[cfg(target_os = "linux")]
-pub type AddressFamily = u16;
 
 #[cfg(target_os = "linux")]
 pub type SockAddr = libc::sockaddr;

--- a/src/rust/pal/data_structures.rs
+++ b/src/rust/pal/data_structures.rs
@@ -9,10 +9,16 @@ use windows::Win32::Networking::WinSock;
 //==============================================================================
 
 #[cfg(target_os = "windows")]
+pub type AddressFamily = WinSock::ADDRESS_FAMILY;
+
+#[cfg(target_os = "windows")]
 pub type SockAddr = windows::Win32::Networking::WinSock::SOCKADDR;
 
 #[cfg(target_os = "windows")]
 pub type SockAddrIn = WinSock::SOCKADDR_IN;
+
+#[cfg(target_os = "windows")]
+pub type SockAddrIn6 = WinSock::SOCKADDR_IN6;
 
 #[cfg(target_os = "windows")]
 pub type Socklen = i32;
@@ -22,10 +28,16 @@ pub type Socklen = i32;
 //==============================================================================
 
 #[cfg(target_os = "linux")]
+pub type AddressFamily = u16;
+
+#[cfg(target_os = "linux")]
 pub type SockAddr = libc::sockaddr;
 
 #[cfg(target_os = "linux")]
 pub type SockAddrIn = libc::sockaddr_in;
+
+#[cfg(target_os = "linux")]
+pub type SockAddrIn6 = libc::sockaddr_in6;
 
 #[cfg(target_os = "linux")]
 pub type Socklen = libc::socklen_t;

--- a/src/rust/pal/functions.rs
+++ b/src/rust/pal/functions.rs
@@ -1,13 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use crate::pal::data_structures::{
-    SockAddrIn,
-    SockAddrIn6,
-};
-
-const NUM_OCTETS_IN_IPV6: usize = 16;
-
 #[cfg(feature = "catnip-libos")]
 const NUM_OCTETS_IN_IPV4: usize = 4;
 
@@ -43,21 +36,6 @@ pub fn create_sin_addr(octets: &[u8; NUM_OCTETS_IN_IPV4]) -> IN_ADDR {
 #[cfg(all(feature = "catnip-libos", target_os = "windows"))]
 pub fn create_sin_zero() -> [CHAR; NUM_SIN_ZERO_BYTES] {
     [CHAR(0); 8]
-}
-
-#[cfg(target_os = "windows")]
-pub fn get_addr_from_sock_addr_in(sock_addr_in: &SockAddrIn) -> u32 {
-    unsafe { sock_addr_in.sin_addr.S_un.S_addr }
-}
-
-#[cfg(target_os = "windows")]
-pub fn get_addr_from_sock_addr_in6(sock_addr_in: &SockAddrIn6) -> [u8; NUM_OCTETS_IN_IPV6] {
-    unsafe { sock_addr_in.sin6_addr.u.Byte }
-}
-
-#[cfg(target_os = "windows")]
-pub fn get_scope_id_from_sock_addr_in6(sock_addr_in: &SockAddrIn6) -> u32 {
-    unsafe { sock_addr_in.Anonymous.sin6_scope_id }
 }
 
 #[cfg(target_os = "windows")]
@@ -97,19 +75,4 @@ pub fn create_sin_addr(octets: &[u8; NUM_OCTETS_IN_IPV4]) -> in_addr {
 #[cfg(all(feature = "catnip-libos", target_os = "linux"))]
 pub fn create_sin_zero() -> [u8; NUM_SIN_ZERO_BYTES] {
     [0; 8]
-}
-
-#[cfg(target_os = "linux")]
-pub fn get_addr_from_sock_addr_in(sock_addr_in: &SockAddrIn) -> u32 {
-    sock_addr_in.sin_addr.s_addr
-}
-
-#[cfg(target_os = "linux")]
-pub fn get_addr_from_sock_addr_in6(sock_addr_in: &SockAddrIn6) -> [u8; NUM_OCTETS_IN_IPV6] {
-    sock_addr_in.sin6_addr.s6_addr
-}
-
-#[cfg(target_os = "linux")]
-pub fn get_scope_id_from_sock_addr_in6(sock_addr_in: &SockAddrIn6) -> u32 {
-    sock_addr_in.sin6_scope_id
 }

--- a/src/rust/pal/functions.rs
+++ b/src/rust/pal/functions.rs
@@ -6,7 +6,7 @@ use crate::pal::data_structures::{
     SockAddrIn6,
 };
 
-const NUM_OCTETS_IN_IPV4: usize = 16;
+const NUM_OCTETS_IN_IPV6: usize = 16;
 
 #[cfg(feature = "catnip-libos")]
 const NUM_OCTETS_IN_IPV4: usize = 4;
@@ -51,7 +51,7 @@ pub fn get_addr_from_sock_addr_in(sock_addr_in: &SockAddrIn) -> u32 {
 }
 
 #[cfg(target_os = "windows")]
-pub fn get_addr_from_sock_addr_in6(sock_addr_in: &SockAddrIn6) -> [u8; NUM_OCTETS_IN_IPV4] {
+pub fn get_addr_from_sock_addr_in6(sock_addr_in: &SockAddrIn6) -> [u8; NUM_OCTETS_IN_IPV6] {
     unsafe { sock_addr_in.sin6_addr.u.Byte }
 }
 
@@ -105,7 +105,7 @@ pub fn get_addr_from_sock_addr_in(sock_addr_in: &SockAddrIn) -> u32 {
 }
 
 #[cfg(target_os = "linux")]
-pub fn get_addr_from_sock_addr_in6(sock_addr_in: &SockAddrIn6) -> [u8; NUM_OCTETS_IN_IPV4] {
+pub fn get_addr_from_sock_addr_in6(sock_addr_in: &SockAddrIn6) -> [u8; NUM_OCTETS_IN_IPV6] {
     sock_addr_in.sin6_addr.s6_addr
 }
 

--- a/src/rust/pal/functions.rs
+++ b/src/rust/pal/functions.rs
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use crate::pal::data_structures::SockAddrIn;
+use crate::pal::data_structures::{
+    SockAddrIn,
+    SockAddrIn6,
+};
+
+const NUM_OCTETS_IN_IPV4: usize = 16;
 
 #[cfg(feature = "catnip-libos")]
 const NUM_OCTETS_IN_IPV4: usize = 4;
@@ -46,6 +51,16 @@ pub fn get_addr_from_sock_addr_in(sock_addr_in: &SockAddrIn) -> u32 {
 }
 
 #[cfg(target_os = "windows")]
+pub fn get_addr_from_sock_addr_in6(sock_addr_in: &SockAddrIn6) -> [u8; NUM_OCTETS_IN_IPV4] {
+    unsafe { sock_addr_in.sin6_addr.u.Byte }
+}
+
+#[cfg(target_os = "windows")]
+pub fn get_scope_id_from_sock_addr_in6(sock_addr_in: &SockAddrIn6) -> u32 {
+    unsafe { sock_addr_in.Anonymous.sin6_scope_id }
+}
+
+#[cfg(target_os = "windows")]
 use std::net::SocketAddrV4;
 
 #[cfg(target_os = "windows")]
@@ -87,4 +102,14 @@ pub fn create_sin_zero() -> [u8; NUM_SIN_ZERO_BYTES] {
 #[cfg(target_os = "linux")]
 pub fn get_addr_from_sock_addr_in(sock_addr_in: &SockAddrIn) -> u32 {
     sock_addr_in.sin_addr.s_addr
+}
+
+#[cfg(target_os = "linux")]
+pub fn get_addr_from_sock_addr_in6(sock_addr_in: &SockAddrIn6) -> [u8; NUM_OCTETS_IN_IPV4] {
+    sock_addr_in.sin6_addr.s6_addr
+}
+
+#[cfg(target_os = "linux")]
+pub fn get_scope_id_from_sock_addr_in6(sock_addr_in: &SockAddrIn6) -> u32 {
+    sock_addr_in.sin6_scope_id
 }

--- a/src/rust/runtime/network/mod.rs
+++ b/src/rust/runtime/network/mod.rs
@@ -5,8 +5,15 @@
 // Imports
 //==============================================================================
 
-use crate::runtime::memory::DemiBuffer;
+use crate::runtime::{
+    Fail,
+    memory::DemiBuffer
+};
 use ::arrayvec::ArrayVec;
+use ::std::net::{
+    SocketAddr,
+    SocketAddrV4
+};
 
 //==============================================================================
 // Exports
@@ -21,6 +28,19 @@ pub mod types;
 //==============================================================================
 // Traits
 //==============================================================================
+
+///
+/// **Brief**
+///
+/// Since IPv6 is not supported, this method simply unwraps a SocketAddr into a SocketAddrV4
+/// or returns an error indicating the address family is not supported.
+///
+pub fn unwrap_socketaddr(addr: SocketAddr) -> Result<SocketAddrV4, Fail> {
+    match addr {
+        SocketAddr::V4(addr) => Ok(addr),
+        _ => Err(Fail::new(libc::EINVAL, "bad address family"))
+    }
+}
 
 /// Packet Buffer
 pub trait PacketBuf {

--- a/src/rust/runtime/network/mod.rs
+++ b/src/rust/runtime/network/mod.rs
@@ -32,8 +32,10 @@ pub mod types;
 ///
 /// **Brief**
 ///
-/// Since IPv6 is not supported, this method simply unwraps a SocketAddr into a SocketAddrV4
-/// or returns an error indicating the address family is not supported.
+/// Since IPv6 is not supported, this method simply unwraps a SocketAddr into a 
+/// SocketAddrV4 or returns an error indicating the address family is not 
+/// supported. This method should be removed when IPv6 support is added; see 
+/// https://github.com/microsoft/demikernel/issues/935
 ///
 pub fn unwrap_socketaddr(addr: SocketAddr) -> Result<SocketAddrV4, Fail> {
     match addr {

--- a/tests/rust/common/mod.rs
+++ b/tests/rust/common/mod.rs
@@ -7,15 +7,20 @@ pub mod runtime;
 use ::demikernel::runtime::network::types::MacAddress;
 use ::std::{
     collections::HashMap,
-    net::Ipv4Addr,
+    net::{
+        IpAddr,
+        Ipv4Addr
+    },
 };
 
 // Alice Address
 pub const ALICE_IPV4: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 1);
+pub const ALICE_IP: IpAddr = IpAddr::V4(ALICE_IPV4);
 pub const ALICE_MAC: MacAddress = MacAddress::new([0x12, 0x23, 0x45, 0x67, 0x89, 0xab]);
 
 // Bob Address
 pub const BOB_IPV4: Ipv4Addr = Ipv4Addr::new(192, 168, 1, 2);
+pub const BOB_IP: IpAddr = IpAddr::V4(BOB_IPV4);
 pub const BOB_MAC: MacAddress = MacAddress::new([0xab, 0x89, 0x67, 0x45, 0x23, 0x12]);
 
 // Port Number used for Tests

--- a/tests/rust/tcp-test/accept/mod.rs
+++ b/tests/rust/tcp-test/accept/mod.rs
@@ -13,10 +13,7 @@ use demikernel::{
     QToken,
 };
 use std::{
-    net::{
-        SocketAddr,
-        SocketAddrV4,
-    },
+    net::SocketAddr,
     time::Duration,
 };
 
@@ -41,7 +38,7 @@ pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
 //======================================================================================================================
 
 /// Runs standalone tests.
-pub fn run(libos: &mut LibOS, addr: &SocketAddrV4) -> Vec<(String, String, Result<(), anyhow::Error>)> {
+pub fn run(libos: &mut LibOS, addr: &SocketAddr) -> Vec<(String, String, Result<(), anyhow::Error>)> {
     let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
     crate::collect!(result, crate::test!(accept_invalid_queue_descriptor(libos)));
@@ -86,10 +83,10 @@ fn accept_unbound_socket(libos: &mut LibOS) -> Result<()> {
 }
 
 /// Attempts to accept connections on a TCP socket that is not listening.
-fn accept_active_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+fn accept_active_socket(libos: &mut LibOS, local: &SocketAddr) -> Result<()> {
     // Create a bound socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
+    libos.bind(sockqd, local.to_owned())?;
 
     // Fail to accept() connections.
     match libos.accept(sockqd) {
@@ -105,10 +102,10 @@ fn accept_active_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
 }
 
 /// Attempts to accept connections on a TCP socket that is listening.
-fn accept_listening_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+fn accept_listening_socket(libos: &mut LibOS, local: &SocketAddr) -> Result<()> {
     // Create an accepting socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
+    libos.bind(sockqd, local.to_owned())?;
     libos.listen(sockqd, 16)?;
 
     // Succeed to accept() connections.
@@ -142,7 +139,7 @@ fn accept_listening_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()
 }
 
 /// Attempts to accept connections on a TCP socket that is connecting.
-fn accept_connecting_socket(libos: &mut LibOS, remote: &SocketAddrV4) -> Result<()> {
+fn accept_connecting_socket(libos: &mut LibOS, remote: &SocketAddr) -> Result<()> {
     // Create a connecting socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
     let qt: QToken = libos.connect(sockqd, remote.to_owned())?;
@@ -188,10 +185,10 @@ fn accept_connecting_socket(libos: &mut LibOS, remote: &SocketAddrV4) -> Result<
 
 /// Attempts to accept connections on a TCP socket that is already accepting connections.
 /// TODO: Check if this is actually not allowed.
-fn accept_accepting_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+fn accept_accepting_socket(libos: &mut LibOS, local: &SocketAddr) -> Result<()> {
     // Create an accepting socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
+    libos.bind(sockqd, local.to_owned())?;
     libos.listen(sockqd, 16)?;
     let qt: QToken = libos.accept(sockqd)?;
 
@@ -231,10 +228,10 @@ fn accept_accepting_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()
 }
 
 /// Attempts to accept connections on a TCP socket that is closed.
-fn accept_closed_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+fn accept_closed_socket(libos: &mut LibOS, local: &SocketAddr) -> Result<()> {
     // Create a closed socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
+    libos.bind(sockqd, local.to_owned())?;
     libos.listen(sockqd, 16)?;
     libos.close(sockqd)?;
 

--- a/tests/rust/tcp-test/accept/mod.rs
+++ b/tests/rust/tcp-test/accept/mod.rs
@@ -13,7 +13,10 @@ use demikernel::{
     QToken,
 };
 use std::{
-    net::SocketAddrV4,
+    net::{
+        SocketAddr,
+        SocketAddrV4,
+    },
     time::Duration,
 };
 
@@ -86,7 +89,7 @@ fn accept_unbound_socket(libos: &mut LibOS) -> Result<()> {
 fn accept_active_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
     // Create a bound socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, local.to_owned())?;
+    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
 
     // Fail to accept() connections.
     match libos.accept(sockqd) {
@@ -105,7 +108,7 @@ fn accept_active_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
 fn accept_listening_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
     // Create an accepting socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, local.to_owned())?;
+    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
     libos.listen(sockqd, 16)?;
 
     // Succeed to accept() connections.
@@ -188,7 +191,7 @@ fn accept_connecting_socket(libos: &mut LibOS, remote: &SocketAddrV4) -> Result<
 fn accept_accepting_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
     // Create an accepting socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, local.to_owned())?;
+    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
     libos.listen(sockqd, 16)?;
     let qt: QToken = libos.accept(sockqd)?;
 
@@ -231,7 +234,7 @@ fn accept_accepting_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()
 fn accept_closed_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
     // Create a closed socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, local.to_owned())?;
+    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
     libos.listen(sockqd, 16)?;
     libos.close(sockqd)?;
 

--- a/tests/rust/tcp-test/args.rs
+++ b/tests/rust/tcp-test/args.rs
@@ -12,7 +12,10 @@ use clap::{
     Command,
 };
 use std::{
-    net::SocketAddrV4,
+    net::{
+        SocketAddr,
+        SocketAddrV4,
+    },
     str::FromStr,
 };
 
@@ -24,9 +27,9 @@ use std::{
 #[derive(Debug)]
 pub struct ProgramArguments {
     /// Address of local.
-    local: SocketAddrV4,
+    local: SocketAddr,
     /// Address of remote socket.
-    remote: SocketAddrV4,
+    remote: SocketAddr,
 }
 
 impl ProgramArguments {
@@ -54,27 +57,27 @@ impl ProgramArguments {
             .get_matches();
 
         // Address of local socket.
-        let local: SocketAddrV4 = {
+        let local: SocketAddr = SocketAddr::V4({
             let local: &String = matches.get_one::<String>("local").expect("missing address");
             SocketAddrV4::from_str(local)?
-        };
+        });
 
         // Address of remote socket.
-        let remote: SocketAddrV4 = {
+        let remote: SocketAddr = SocketAddr::V4({
             let remote: &String = matches.get_one::<String>("remote").expect("missing address");
             SocketAddrV4::from_str(remote)?
-        };
+        });
 
         Ok(Self { local, remote })
     }
 
     /// Returns the `local` command line argument.
-    pub fn local(&self) -> SocketAddrV4 {
+    pub fn local(&self) -> SocketAddr {
         self.local
     }
 
     /// Returns the `remote` command line argument.
-    pub fn remote(&self) -> SocketAddrV4 {
+    pub fn remote(&self) -> SocketAddr {
         self.remote
     }
 }

--- a/tests/rust/tcp-test/async_close/mod.rs
+++ b/tests/rust/tcp-test/async_close/mod.rs
@@ -13,10 +13,7 @@ use ::demikernel::{
     QToken,
 };
 use ::std::{
-    net::{
-        SocketAddr,
-        SocketAddrV4,
-    },
+    net::SocketAddr,
     time::Duration,
 };
 
@@ -41,7 +38,7 @@ pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
 //======================================================================================================================
 
 /// Drives integration tests for async_close() on TCP sockets.
-pub fn run(libos: &mut LibOS, addr: &SocketAddrV4) -> Vec<(String, String, Result<(), anyhow::Error>)> {
+pub fn run(libos: &mut LibOS, addr: &SocketAddr) -> Vec<(String, String, Result<(), anyhow::Error>)> {
     let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
     crate::collect!(result, crate::test!(async_close_invalid_queue_descriptor(libos)));
@@ -159,10 +156,10 @@ fn async_close_unbound_socket(libos: &mut LibOS) -> Result<()> {
 }
 
 /// Attempts to close a TCP socket that is bound.
-fn async_close_bound_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+fn async_close_bound_socket(libos: &mut LibOS, local: &SocketAddr) -> Result<()> {
     // Create a bound socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, SocketAddr::V4(*local))?;
+    libos.bind(sockqd, *local)?;
 
     // Succeed to close socket.
     let qt: QToken = libos.async_close(sockqd)?;
@@ -176,10 +173,10 @@ fn async_close_bound_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<(
 }
 
 /// Attempts to close a TCP socket that is listening.
-fn async_close_listening_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+fn async_close_listening_socket(libos: &mut LibOS, local: &SocketAddr) -> Result<()> {
     // Create a listening socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, SocketAddr::V4(*local))?;
+    libos.bind(sockqd, *local)?;
     libos.listen(sockqd, 16)?;
 
     // Succeed to close socket.

--- a/tests/rust/tcp-test/async_close/mod.rs
+++ b/tests/rust/tcp-test/async_close/mod.rs
@@ -13,7 +13,10 @@ use ::demikernel::{
     QToken,
 };
 use ::std::{
-    net::SocketAddrV4,
+    net::{
+        SocketAddr,
+        SocketAddrV4,
+    },
     time::Duration,
 };
 
@@ -159,7 +162,7 @@ fn async_close_unbound_socket(libos: &mut LibOS) -> Result<()> {
 fn async_close_bound_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
     // Create a bound socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, *local)?;
+    libos.bind(sockqd, SocketAddr::V4(*local))?;
 
     // Succeed to close socket.
     let qt: QToken = libos.async_close(sockqd)?;
@@ -176,7 +179,7 @@ fn async_close_bound_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<(
 fn async_close_listening_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
     // Create a listening socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, *local)?;
+    libos.bind(sockqd, SocketAddr::V4(*local))?;
     libos.listen(sockqd, 16)?;
 
     // Succeed to close socket.

--- a/tests/rust/tcp-test/bind/mod.rs
+++ b/tests/rust/tcp-test/bind/mod.rs
@@ -12,6 +12,7 @@ use demikernel::{
 };
 use std::net::{
     Ipv4Addr,
+    SocketAddr,
     SocketAddrV4,
 };
 
@@ -67,7 +68,7 @@ fn bind_addr_to_invalid_queue_descriptor(libos: &mut LibOS, local: &Ipv4Addr) ->
     };
 
     // Fail to bind socket.
-    match libos.bind(QDesc::from(0), addr) {
+    match libos.bind(QDesc::from(0), SocketAddr::V4(addr)) {
         Err(e) if e.errno == libc::EBADF => (),
         Err(e) => anyhow::bail!("bind() failed with {}", e),
         Ok(()) => anyhow::bail!("bind() an address to an invalid queue descriptor should fail"),
@@ -88,7 +89,7 @@ fn bind_multiple_addresses_to_same_socket(libos: &mut LibOS, local: &Ipv4Addr) -
     };
 
     // Bind socket.
-    libos.bind(sockqd, addr)?;
+    libos.bind(sockqd, SocketAddr::V4(addr))?;
 
     // Bind address.
     let addr: SocketAddrV4 = {
@@ -97,7 +98,7 @@ fn bind_multiple_addresses_to_same_socket(libos: &mut LibOS, local: &Ipv4Addr) -
     };
 
     // Fail to bind socket.
-    match libos.bind(sockqd, addr) {
+    match libos.bind(sockqd, SocketAddr::V4(addr)) {
         Err(e) if e.errno == libc::EINVAL => (),
         Err(e) => anyhow::bail!("bind() failed with {}", e),
         Ok(()) => anyhow::bail!("bind() a sockeet multiple times should fail"),
@@ -122,9 +123,9 @@ fn bind_same_address_to_two_sockets(libos: &mut LibOS, local: &Ipv4Addr) -> Resu
     };
 
     // Bind first socket.
-    libos.bind(sockqd1, addr)?;
+    libos.bind(sockqd1, SocketAddr::V4(addr))?;
 
-    match libos.bind(sockqd2, addr) {
+    match libos.bind(sockqd2, SocketAddr::V4(addr)) {
         Err(e) if e.errno == libc::EADDRINUSE => (),
         Err(e) => anyhow::bail!("bind() failed with {}", e),
         Ok(()) => anyhow::bail!("bind() the same address to two sockets should fail"),
@@ -146,7 +147,7 @@ fn bind_to_private_ports(libos: &mut LibOS, local: &Ipv4Addr) -> Result<()> {
 
         // Bind socket.
         let addr: SocketAddrV4 = SocketAddrV4::new(*local, port);
-        match libos.bind(sockqd, addr) {
+        match libos.bind(sockqd, SocketAddr::V4(addr)) {
             Ok(()) => (),
             Err(e) if e.errno == libc::EADDRINUSE => (),
             Err(e) => anyhow::bail!("bind() failed with {}", e),
@@ -169,7 +170,7 @@ fn bind_to_wildcard_port(libos: &mut LibOS, ipv4: &Ipv4Addr) -> Result<()> {
 
     // Fail to bind socket.
     // FIXME: https://github.com/demikernel/demikernel/issues/582
-    match libos.bind(sockqd, addr) {
+    match libos.bind(sockqd, SocketAddr::V4(addr)) {
         Err(e) if e.errno == libc::ENOTSUP => (),
         Err(e) => anyhow::bail!("bind() failed with {}", e),
         Ok(()) => anyhow::bail!("bind() to the wildcard address port should fail"),
@@ -194,7 +195,7 @@ fn bind_to_wildcard_address(libos: &mut LibOS) -> Result<()> {
 
     // Fail to bind socket.
     // FIXME: https://github.com/demikernel/demikernel/issues/189
-    match libos.bind(sockqd, addr) {
+    match libos.bind(sockqd, SocketAddr::V4(addr)) {
         Err(e) if e.errno == libc::ENOTSUP => (),
         Err(e) => anyhow::bail!("bind() failed with {}", e),
         Ok(()) => anyhow::bail!("bind() to the wildcard address should fail"),
@@ -217,7 +218,7 @@ fn bind_to_wildcard_address_and_port(libos: &mut LibOS) -> Result<()> {
     // Fail to bind socket.
     // FIXME: https://github.com/demikernel/demikernel/issues/582
     // FIXME: https://github.com/demikernel/demikernel/issues/189
-    match libos.bind(sockqd, addr) {
+    match libos.bind(sockqd, SocketAddr::V4(addr)) {
         Err(e) if e.errno == libc::ENOTSUP => (),
         Err(e) => anyhow::bail!("bind() failed with {}", e),
         Ok(()) => anyhow::bail!("bind() to the wildcard address port should fail"),
@@ -242,7 +243,7 @@ fn bind_to_non_local_address(libos: &mut LibOS) -> Result<()> {
     };
 
     // Fail to bind socket.
-    match libos.bind(sockqd, addr) {
+    match libos.bind(sockqd, SocketAddr::V4(addr)) {
         Err(e) if e.errno == libc::EADDRNOTAVAIL => (),
         Err(e) => anyhow::bail!("bind() failed with {}", e),
         Ok(()) => anyhow::bail!("bind() a non-local address should fail"),
@@ -269,7 +270,7 @@ fn bind_to_closed_socket(libos: &mut LibOS, ipv4: &Ipv4Addr) -> Result<()> {
     libos.close(sockqd)?;
 
     // Fail to bind socket.
-    match libos.bind(sockqd, addr) {
+    match libos.bind(sockqd, SocketAddr::V4(addr)) {
         Err(e) if e.errno == libc::EBADF => Ok(()),
         Err(e) => anyhow::bail!("bind() failed with {}", e),
         Ok(()) => anyhow::bail!("bind() a closed socket should fail"),

--- a/tests/rust/tcp-test/bind/mod.rs
+++ b/tests/rust/tcp-test/bind/mod.rs
@@ -11,6 +11,7 @@ use demikernel::{
     QDesc,
 };
 use std::net::{
+    IpAddr,
     Ipv4Addr,
     SocketAddr,
     SocketAddrV4,
@@ -37,7 +38,7 @@ pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
 //======================================================================================================================
 
 /// Drives integration tests for bind() on TCP sockets.
-pub fn run(libos: &mut LibOS, local: &Ipv4Addr) -> Vec<(String, String, Result<(), anyhow::Error>)> {
+pub fn run(libos: &mut LibOS, local: &IpAddr) -> Vec<(String, String, Result<(), anyhow::Error>)> {
     let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
     crate::collect!(
@@ -60,15 +61,15 @@ pub fn run(libos: &mut LibOS, local: &Ipv4Addr) -> Vec<(String, String, Result<(
 }
 
 /// Attempts to bind an address to an invalid queue_descriptor.
-fn bind_addr_to_invalid_queue_descriptor(libos: &mut LibOS, local: &Ipv4Addr) -> Result<()> {
+fn bind_addr_to_invalid_queue_descriptor(libos: &mut LibOS, local: &IpAddr) -> Result<()> {
     // Bind address.
-    let addr: SocketAddrV4 = {
+    let addr: SocketAddr = { 
         let http_port: u16 = 6379;
-        SocketAddrV4::new(*local, http_port)
+        SocketAddr::new(*local, http_port)
     };
 
     // Fail to bind socket.
-    match libos.bind(QDesc::from(0), SocketAddr::V4(addr)) {
+    match libos.bind(QDesc::from(0), addr) {
         Err(e) if e.errno == libc::EBADF => (),
         Err(e) => anyhow::bail!("bind() failed with {}", e),
         Ok(()) => anyhow::bail!("bind() an address to an invalid queue descriptor should fail"),
@@ -78,27 +79,27 @@ fn bind_addr_to_invalid_queue_descriptor(libos: &mut LibOS, local: &Ipv4Addr) ->
 }
 
 /// Attempts to bind multiple addresses to the same socket.
-fn bind_multiple_addresses_to_same_socket(libos: &mut LibOS, local: &Ipv4Addr) -> Result<()> {
+fn bind_multiple_addresses_to_same_socket(libos: &mut LibOS, local: &IpAddr) -> Result<()> {
     // Create a TCP socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
 
     // Bind address.
-    let addr: SocketAddrV4 = {
+    let addr: SocketAddr = {
         let any_port: u16 = 6739;
-        SocketAddrV4::new(*local, any_port)
+        SocketAddr::new(*local, any_port)
     };
 
     // Bind socket.
-    libos.bind(sockqd, SocketAddr::V4(addr))?;
+    libos.bind(sockqd, addr)?;
 
     // Bind address.
-    let addr: SocketAddrV4 = {
+    let addr: SocketAddr = {
         let any_port: u16 = 6780;
-        SocketAddrV4::new(*local, any_port)
+        SocketAddr::new(*local, any_port)
     };
 
     // Fail to bind socket.
-    match libos.bind(sockqd, SocketAddr::V4(addr)) {
+    match libos.bind(sockqd, addr) {
         Err(e) if e.errno == libc::EINVAL => (),
         Err(e) => anyhow::bail!("bind() failed with {}", e),
         Ok(()) => anyhow::bail!("bind() a sockeet multiple times should fail"),
@@ -111,21 +112,21 @@ fn bind_multiple_addresses_to_same_socket(libos: &mut LibOS, local: &Ipv4Addr) -
 }
 
 /// Attempts to bind the same address to two sockets.
-fn bind_same_address_to_two_sockets(libos: &mut LibOS, local: &Ipv4Addr) -> Result<()> {
+fn bind_same_address_to_two_sockets(libos: &mut LibOS, local: &IpAddr) -> Result<()> {
     // Create two TCP sockets.
     let sockqd1: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
     let sockqd2: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
 
     // Bind address.
-    let addr: SocketAddrV4 = {
+    let addr: SocketAddr = {
         let http_port: u16 = 8080;
-        SocketAddrV4::new(*local, http_port)
+        SocketAddr::new(*local, http_port)
     };
 
     // Bind first socket.
-    libos.bind(sockqd1, SocketAddr::V4(addr))?;
+    libos.bind(sockqd1, addr)?;
 
-    match libos.bind(sockqd2, SocketAddr::V4(addr)) {
+    match libos.bind(sockqd2, addr) {
         Err(e) if e.errno == libc::EADDRINUSE => (),
         Err(e) => anyhow::bail!("bind() failed with {}", e),
         Ok(()) => anyhow::bail!("bind() the same address to two sockets should fail"),
@@ -139,15 +140,15 @@ fn bind_same_address_to_two_sockets(libos: &mut LibOS, local: &Ipv4Addr) -> Resu
 }
 
 /// Attempts to bind to all private ports.
-fn bind_to_private_ports(libos: &mut LibOS, local: &Ipv4Addr) -> Result<()> {
+fn bind_to_private_ports(libos: &mut LibOS, local: &IpAddr) -> Result<()> {
     // Traverse all ports in the private range.
     for port in 49152..65535 {
         // Create a TCP socket.
         let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
 
         // Bind socket.
-        let addr: SocketAddrV4 = SocketAddrV4::new(*local, port);
-        match libos.bind(sockqd, SocketAddr::V4(addr)) {
+        let addr: SocketAddr = SocketAddr::new(*local, port);
+        match libos.bind(sockqd, addr) {
             Ok(()) => (),
             Err(e) if e.errno == libc::EADDRINUSE => (),
             Err(e) => anyhow::bail!("bind() failed with {}", e),
@@ -161,16 +162,16 @@ fn bind_to_private_ports(libos: &mut LibOS, local: &Ipv4Addr) -> Result<()> {
 }
 
 /// Attempts to bind to the wildcard port.
-fn bind_to_wildcard_port(libos: &mut LibOS, ipv4: &Ipv4Addr) -> Result<()> {
+fn bind_to_wildcard_port(libos: &mut LibOS, ip: &IpAddr) -> Result<()> {
     // Create a TCP socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
 
     // Bind address.
-    let addr: SocketAddrV4 = SocketAddrV4::new(*ipv4, 0);
+    let addr: SocketAddr = SocketAddr::new(*ip, 0);
 
     // Fail to bind socket.
     // FIXME: https://github.com/demikernel/demikernel/issues/582
-    match libos.bind(sockqd, SocketAddr::V4(addr)) {
+    match libos.bind(sockqd, addr) {
         Err(e) if e.errno == libc::ENOTSUP => (),
         Err(e) => anyhow::bail!("bind() failed with {}", e),
         Ok(()) => anyhow::bail!("bind() to the wildcard address port should fail"),
@@ -188,14 +189,14 @@ fn bind_to_wildcard_address(libos: &mut LibOS) -> Result<()> {
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
 
     // Bind address.
-    let addr: SocketAddrV4 = {
+    let addr: SocketAddr = SocketAddr::V4({
         let port: u16 = 8080;
         SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port)
-    };
+    });
 
     // Fail to bind socket.
     // FIXME: https://github.com/demikernel/demikernel/issues/189
-    match libos.bind(sockqd, SocketAddr::V4(addr)) {
+    match libos.bind(sockqd, addr) {
         Err(e) if e.errno == libc::ENOTSUP => (),
         Err(e) => anyhow::bail!("bind() failed with {}", e),
         Ok(()) => anyhow::bail!("bind() to the wildcard address should fail"),
@@ -213,12 +214,12 @@ fn bind_to_wildcard_address_and_port(libos: &mut LibOS) -> Result<()> {
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
 
     // Bind address.
-    let addr: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
+    let addr: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
 
     // Fail to bind socket.
     // FIXME: https://github.com/demikernel/demikernel/issues/582
     // FIXME: https://github.com/demikernel/demikernel/issues/189
-    match libos.bind(sockqd, SocketAddr::V4(addr)) {
+    match libos.bind(sockqd, addr) {
         Err(e) if e.errno == libc::ENOTSUP => (),
         Err(e) => anyhow::bail!("bind() failed with {}", e),
         Ok(()) => anyhow::bail!("bind() to the wildcard address port should fail"),
@@ -236,14 +237,14 @@ fn bind_to_non_local_address(libos: &mut LibOS) -> Result<()> {
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
 
     // Bind address.
-    let addr: SocketAddrV4 = {
+    let addr: SocketAddr = {
         let ip: Ipv4Addr = Ipv4Addr::new(192, 0, 2, 1);
         let port: u16 = 8080;
-        SocketAddrV4::new(ip, port)
+        SocketAddr::V4(SocketAddrV4::new(ip, port))
     };
 
     // Fail to bind socket.
-    match libos.bind(sockqd, SocketAddr::V4(addr)) {
+    match libos.bind(sockqd, addr) {
         Err(e) if e.errno == libc::EADDRNOTAVAIL => (),
         Err(e) => anyhow::bail!("bind() failed with {}", e),
         Ok(()) => anyhow::bail!("bind() a non-local address should fail"),
@@ -256,21 +257,21 @@ fn bind_to_non_local_address(libos: &mut LibOS) -> Result<()> {
 }
 
 /// Attempts to bind to a closed socket.
-fn bind_to_closed_socket(libos: &mut LibOS, ipv4: &Ipv4Addr) -> Result<()> {
+fn bind_to_closed_socket(libos: &mut LibOS, ip: &IpAddr) -> Result<()> {
     // Create a TCP socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
 
     // Bind address.
-    let addr: SocketAddrV4 = {
+    let addr: SocketAddr = {
         let port: u16 = 8080;
-        SocketAddrV4::new(*ipv4, port)
+        SocketAddr::new(*ip, port)
     };
 
     // Close socket.
     libos.close(sockqd)?;
 
     // Fail to bind socket.
-    match libos.bind(sockqd, SocketAddr::V4(addr)) {
+    match libos.bind(sockqd, addr) {
         Err(e) if e.errno == libc::EBADF => Ok(()),
         Err(e) => anyhow::bail!("bind() failed with {}", e),
         Ok(()) => anyhow::bail!("bind() a closed socket should fail"),

--- a/tests/rust/tcp-test/close/mod.rs
+++ b/tests/rust/tcp-test/close/mod.rs
@@ -10,10 +10,7 @@ use ::demikernel::{
     LibOS,
     QDesc,
 };
-use ::std::net::{
-    SocketAddr,
-    SocketAddrV4,
-};
+use ::std::net::SocketAddr;
 
 //======================================================================================================================
 // Constants
@@ -36,7 +33,7 @@ pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
 //======================================================================================================================
 
 /// Drives integration tests for close() on TCP sockets.
-pub fn run(libos: &mut LibOS, addr: &SocketAddrV4) -> Vec<(String, String, Result<(), anyhow::Error>)> {
+pub fn run(libos: &mut LibOS, addr: &SocketAddr) -> Vec<(String, String, Result<(), anyhow::Error>)> {
     let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
     crate::collect!(result, crate::test!(close_invalid_queue_descriptor(libos)));
@@ -86,10 +83,10 @@ fn close_unbound_socket(libos: &mut LibOS) -> Result<()> {
 }
 
 /// Attempts to close a TCP socket that is bound.
-fn close_bound_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+fn close_bound_socket(libos: &mut LibOS, local: &SocketAddr) -> Result<()> {
     // Create a bound socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, SocketAddr::V4(*local))?;
+    libos.bind(sockqd, *local)?;
 
     // Succeed to close socket.
     libos.close(sockqd)?;
@@ -98,10 +95,10 @@ fn close_bound_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
 }
 
 /// Attempts to close a TCP socket that is listening.
-fn close_listening_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+fn close_listening_socket(libos: &mut LibOS, local: &SocketAddr) -> Result<()> {
     // Create a listening socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, SocketAddr::V4(*local))?;
+    libos.bind(sockqd, *local)?;
     libos.listen(sockqd, 16)?;
 
     // Succeed to close socket.

--- a/tests/rust/tcp-test/close/mod.rs
+++ b/tests/rust/tcp-test/close/mod.rs
@@ -10,7 +10,10 @@ use ::demikernel::{
     LibOS,
     QDesc,
 };
-use ::std::net::SocketAddrV4;
+use ::std::net::{
+    SocketAddr,
+    SocketAddrV4,
+};
 
 //======================================================================================================================
 // Constants
@@ -86,7 +89,7 @@ fn close_unbound_socket(libos: &mut LibOS) -> Result<()> {
 fn close_bound_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
     // Create a bound socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, *local)?;
+    libos.bind(sockqd, SocketAddr::V4(*local))?;
 
     // Succeed to close socket.
     libos.close(sockqd)?;
@@ -98,7 +101,7 @@ fn close_bound_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
 fn close_listening_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
     // Create a listening socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, *local)?;
+    libos.bind(sockqd, SocketAddr::V4(*local))?;
     libos.listen(sockqd, 16)?;
 
     // Succeed to close socket.

--- a/tests/rust/tcp-test/connect/mod.rs
+++ b/tests/rust/tcp-test/connect/mod.rs
@@ -44,8 +44,8 @@ pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
 /// Drives integration tests for connect() on TCP sockets.
 pub fn run(
     libos: &mut LibOS,
-    local: &SocketAddrV4,
-    remote: &SocketAddrV4,
+    local: &SocketAddr,
+    remote: &SocketAddr,
 ) -> Vec<(String, String, Result<(), anyhow::Error>)> {
     let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
@@ -62,7 +62,7 @@ pub fn run(
 }
 
 /// Attempts to connect an invalid queue descriptor.
-fn connect_invalid_queue_descriptor(libos: &mut LibOS, remote: &SocketAddrV4) -> Result<()> {
+fn connect_invalid_queue_descriptor(libos: &mut LibOS, remote: &SocketAddr) -> Result<()> {
     // Fail to connect().
     match libos.connect(QDesc::from(0), remote.to_owned()) {
         Err(e) if e.errno == libc::EBADF => Ok(()),
@@ -72,7 +72,7 @@ fn connect_invalid_queue_descriptor(libos: &mut LibOS, remote: &SocketAddrV4) ->
 }
 
 /// Attempts to connect a TCP socket that is not bound.
-fn connect_unbound_socket(libos: &mut LibOS, remote: &SocketAddrV4) -> Result<()> {
+fn connect_unbound_socket(libos: &mut LibOS, remote: &SocketAddr) -> Result<()> {
     // Create an unbound socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
 
@@ -123,10 +123,10 @@ fn connect_to_bad_remote(libos: &mut LibOS) -> Result<()> {
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
 
     // Bad remote address (any localhost port).
-    let remote: SocketAddrV4 = {
+    let remote: SocketAddr = SocketAddr::V4({
         let ipv4: Ipv4Addr = Ipv4Addr::UNSPECIFIED;
         SocketAddrV4::new(ipv4, 0)
-    };
+    });
 
     // Succeed to connect socket.
     let qt: QToken = libos.connect(sockqd, remote)?;
@@ -150,10 +150,10 @@ fn connect_to_bad_remote(libos: &mut LibOS) -> Result<()> {
 }
 
 /// Attempts to connect a TCP socket that is bound.
-fn connect_bound_socket(libos: &mut LibOS, local: &SocketAddrV4, remote: &SocketAddrV4) -> Result<()> {
+fn connect_bound_socket(libos: &mut LibOS, local: &SocketAddr, remote: &SocketAddr) -> Result<()> {
     // Create a bound socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
+    libos.bind(sockqd, local.to_owned())?;
 
     // Succeed to connect socket.
     let qt: QToken = libos.connect(sockqd, remote.to_owned())?;
@@ -197,10 +197,10 @@ fn connect_bound_socket(libos: &mut LibOS, local: &SocketAddrV4, remote: &Socket
 }
 
 /// Attempts to connect a TCP socket that is listening.
-fn connect_listening_socket(libos: &mut LibOS, local: &SocketAddrV4, remote: &SocketAddrV4) -> Result<()> {
+fn connect_listening_socket(libos: &mut LibOS, local: &SocketAddr, remote: &SocketAddr) -> Result<()> {
     // Create a listening socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
+    libos.bind(sockqd, local.to_owned())?;
     libos.listen(sockqd, 16)?;
 
     // Fail to connect().
@@ -217,7 +217,7 @@ fn connect_listening_socket(libos: &mut LibOS, local: &SocketAddrV4, remote: &So
 }
 
 /// Attempts to connect a TCP socket that is already connecting.
-fn connect_connecting_socket(libos: &mut LibOS, remote: &SocketAddrV4) -> Result<()> {
+fn connect_connecting_socket(libos: &mut LibOS, remote: &SocketAddr) -> Result<()> {
     // Create a connecting socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
     let qt: QToken = libos.connect(sockqd, remote.to_owned())?;
@@ -270,10 +270,10 @@ fn connect_connecting_socket(libos: &mut LibOS, remote: &SocketAddrV4) -> Result
 }
 
 /// Attempts to connect a TCP socket that is accepting connections.
-fn connect_accepting_socket(libos: &mut LibOS, local: &SocketAddrV4, remote: &SocketAddrV4) -> Result<()> {
+fn connect_accepting_socket(libos: &mut LibOS, local: &SocketAddr, remote: &SocketAddr) -> Result<()> {
     // Create an accepting socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
+    libos.bind(sockqd, local.to_owned())?;
     libos.listen(sockqd, 16)?;
     let qt: QToken = libos.accept(sockqd)?;
 
@@ -314,7 +314,7 @@ fn connect_accepting_socket(libos: &mut LibOS, local: &SocketAddrV4, remote: &So
 }
 
 /// Attempts to connect a TCP socket that is closed.
-fn connect_closed_socket(libos: &mut LibOS, remote: &SocketAddrV4) -> Result<()> {
+fn connect_closed_socket(libos: &mut LibOS, remote: &SocketAddr) -> Result<()> {
     // Create a closed socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
     libos.close(sockqd)?;

--- a/tests/rust/tcp-test/connect/mod.rs
+++ b/tests/rust/tcp-test/connect/mod.rs
@@ -15,6 +15,7 @@ use demikernel::{
 use std::{
     net::{
         Ipv4Addr,
+        SocketAddr,
         SocketAddrV4,
     },
     time::Duration,
@@ -152,7 +153,7 @@ fn connect_to_bad_remote(libos: &mut LibOS) -> Result<()> {
 fn connect_bound_socket(libos: &mut LibOS, local: &SocketAddrV4, remote: &SocketAddrV4) -> Result<()> {
     // Create a bound socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, local.to_owned())?;
+    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
 
     // Succeed to connect socket.
     let qt: QToken = libos.connect(sockqd, remote.to_owned())?;
@@ -199,7 +200,7 @@ fn connect_bound_socket(libos: &mut LibOS, local: &SocketAddrV4, remote: &Socket
 fn connect_listening_socket(libos: &mut LibOS, local: &SocketAddrV4, remote: &SocketAddrV4) -> Result<()> {
     // Create a listening socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, local.to_owned())?;
+    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
     libos.listen(sockqd, 16)?;
 
     // Fail to connect().
@@ -272,7 +273,7 @@ fn connect_connecting_socket(libos: &mut LibOS, remote: &SocketAddrV4) -> Result
 fn connect_accepting_socket(libos: &mut LibOS, local: &SocketAddrV4, remote: &SocketAddrV4) -> Result<()> {
     // Create an accepting socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, local.to_owned())?;
+    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
     libos.listen(sockqd, 16)?;
     let qt: QToken = libos.accept(sockqd)?;
 

--- a/tests/rust/tcp-test/connect/mod.rs
+++ b/tests/rust/tcp-test/connect/mod.rs
@@ -123,10 +123,10 @@ fn connect_to_bad_remote(libos: &mut LibOS) -> Result<()> {
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
 
     // Bad remote address (any localhost port).
-    let remote: SocketAddr = SocketAddr::V4({
+    let remote: SocketAddr = {
         let ipv4: Ipv4Addr = Ipv4Addr::UNSPECIFIED;
-        SocketAddrV4::new(ipv4, 0)
-    });
+        SocketAddr::V4(SocketAddrV4::new(ipv4, 0))
+    };
 
     // Succeed to connect socket.
     let qt: QToken = libos.connect(sockqd, remote)?;

--- a/tests/rust/tcp-test/listen/mod.rs
+++ b/tests/rust/tcp-test/listen/mod.rs
@@ -13,10 +13,7 @@ use demikernel::{
     QToken,
 };
 use std::{
-    net::{
-        SocketAddr,
-        SocketAddrV4,
-    },
+    net::SocketAddr,
     time::Duration,
 };
 
@@ -49,8 +46,8 @@ pub const SOMAXCONN: i32 = libc::SOMAXCONN;
 /// Drives integration tests for listen() on TCP sockets.
 pub fn run(
     libos: &mut LibOS,
-    local: &SocketAddrV4,
-    remote: &SocketAddrV4,
+    local: &SocketAddr,
+    remote: &SocketAddr,
 ) -> Vec<(String, String, Result<(), anyhow::Error>)> {
     let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
@@ -96,10 +93,10 @@ fn listen_unbound_socket(libos: &mut LibOS) -> Result<()> {
 }
 
 /// Attempts to listen for connections on a TCP socket that is bound.
-fn listen_bound_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+fn listen_bound_socket(libos: &mut LibOS, local: &SocketAddr) -> Result<()> {
     // Create a bound socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
+    libos.bind(sockqd, local.to_owned())?;
 
     // Succeed to listen().
     libos.listen(sockqd, 16)?;
@@ -111,10 +108,10 @@ fn listen_bound_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
 }
 
 /// Attempts to listen for connections on a TCP socket with a zero backlog length.
-fn listen_invalid_zero_backlog_length(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+fn listen_invalid_zero_backlog_length(libos: &mut LibOS, local: &SocketAddr) -> Result<()> {
     // Create a bound socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
+    libos.bind(sockqd, local.to_owned())?;
 
     // Backlog length.
     let backlog: usize = 0;
@@ -129,10 +126,10 @@ fn listen_invalid_zero_backlog_length(libos: &mut LibOS, local: &SocketAddrV4) -
 }
 
 /// Attempts to listen for connections on a TCP socket with a large backlog length.
-fn listen_large_backlog_length(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+fn listen_large_backlog_length(libos: &mut LibOS, local: &SocketAddr) -> Result<()> {
     // Create a bound socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
+    libos.bind(sockqd, local.to_owned())?;
 
     // Backlog length.
     let backlog: usize = (SOMAXCONN + 1) as usize;
@@ -147,10 +144,10 @@ fn listen_large_backlog_length(libos: &mut LibOS, local: &SocketAddrV4) -> Resul
 }
 
 /// Attempts to listen for connections on a TCP socket that is already listening for connections.
-fn listen_listening_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+fn listen_listening_socket(libos: &mut LibOS, local: &SocketAddr) -> Result<()> {
     // Create a bound socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
+    libos.bind(sockqd, local.to_owned())?;
 
     // Succeed to listen().
     libos.listen(sockqd, 16)?;
@@ -169,10 +166,10 @@ fn listen_listening_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()
 }
 
 /// Attempts to listen for connections on a TCP socket that is connecting.
-fn listen_connecting_socket(libos: &mut LibOS, local: &SocketAddrV4, remote: &SocketAddrV4) -> Result<()> {
+fn listen_connecting_socket(libos: &mut LibOS, local: &SocketAddr, remote: &SocketAddr) -> Result<()> {
     // Create a connecting socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
+    libos.bind(sockqd, local.to_owned())?;
     let qt: QToken = libos.connect(sockqd, remote.to_owned())?;
     let mut connect_finished: bool = false;
 
@@ -224,10 +221,10 @@ fn listen_connecting_socket(libos: &mut LibOS, local: &SocketAddrV4, remote: &So
 }
 
 /// Attempts to listen for connections on a TCP socket that is accepting connections.
-fn listen_accepting_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+fn listen_accepting_socket(libos: &mut LibOS, local: &SocketAddr) -> Result<()> {
     // Create an accepting socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
+    libos.bind(sockqd, local.to_owned())?;
     libos.listen(sockqd, 16)?;
     let qt: QToken = libos.accept(sockqd)?;
 
@@ -267,10 +264,10 @@ fn listen_accepting_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()
 }
 
 /// Attempts to listen for connections on a TCP socket that is closed.
-fn listen_closed_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+fn listen_closed_socket(libos: &mut LibOS, local: &SocketAddr) -> Result<()> {
     // Create a bound socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
+    libos.bind(sockqd, local.to_owned())?;
 
     // Succeed to listen().
     libos.listen(sockqd, 16)?;

--- a/tests/rust/tcp-test/listen/mod.rs
+++ b/tests/rust/tcp-test/listen/mod.rs
@@ -13,7 +13,10 @@ use demikernel::{
     QToken,
 };
 use std::{
-    net::SocketAddrV4,
+    net::{
+        SocketAddr,
+        SocketAddrV4,
+    },
     time::Duration,
 };
 
@@ -96,7 +99,7 @@ fn listen_unbound_socket(libos: &mut LibOS) -> Result<()> {
 fn listen_bound_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
     // Create a bound socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, local.to_owned())?;
+    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
 
     // Succeed to listen().
     libos.listen(sockqd, 16)?;
@@ -111,7 +114,7 @@ fn listen_bound_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
 fn listen_invalid_zero_backlog_length(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
     // Create a bound socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, local.to_owned())?;
+    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
 
     // Backlog length.
     let backlog: usize = 0;
@@ -129,7 +132,7 @@ fn listen_invalid_zero_backlog_length(libos: &mut LibOS, local: &SocketAddrV4) -
 fn listen_large_backlog_length(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
     // Create a bound socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, local.to_owned())?;
+    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
 
     // Backlog length.
     let backlog: usize = (SOMAXCONN + 1) as usize;
@@ -147,7 +150,7 @@ fn listen_large_backlog_length(libos: &mut LibOS, local: &SocketAddrV4) -> Resul
 fn listen_listening_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
     // Create a bound socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, local.to_owned())?;
+    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
 
     // Succeed to listen().
     libos.listen(sockqd, 16)?;
@@ -169,7 +172,7 @@ fn listen_listening_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()
 fn listen_connecting_socket(libos: &mut LibOS, local: &SocketAddrV4, remote: &SocketAddrV4) -> Result<()> {
     // Create a connecting socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, local.to_owned())?;
+    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
     let qt: QToken = libos.connect(sockqd, remote.to_owned())?;
     let mut connect_finished: bool = false;
 
@@ -224,7 +227,7 @@ fn listen_connecting_socket(libos: &mut LibOS, local: &SocketAddrV4, remote: &So
 fn listen_accepting_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
     // Create an accepting socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, local.to_owned())?;
+    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
     libos.listen(sockqd, 16)?;
     let qt: QToken = libos.accept(sockqd)?;
 
@@ -267,7 +270,7 @@ fn listen_accepting_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()
 fn listen_closed_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
     // Create a bound socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, local.to_owned())?;
+    libos.bind(sockqd, SocketAddr::V4(local.to_owned()))?;
 
     // Succeed to listen().
     libos.listen(sockqd, 16)?;

--- a/tests/rust/tcp-test/wait/mod.rs
+++ b/tests/rust/tcp-test/wait/mod.rs
@@ -13,10 +13,7 @@ use ::demikernel::{
     QToken,
 };
 use ::std::{
-    net::{
-        SocketAddr,
-        SocketAddrV4,
-    },
+    net::SocketAddr,
     time::Duration,
 };
 
@@ -41,7 +38,7 @@ pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
 //======================================================================================================================
 
 /// Drives integration tests for close() on TCP sockets.
-pub fn run(libos: &mut LibOS, addr: &SocketAddrV4) -> Vec<(String, String, Result<(), anyhow::Error>)> {
+pub fn run(libos: &mut LibOS, addr: &SocketAddr) -> Vec<(String, String, Result<(), anyhow::Error>)> {
     let mut result: Vec<(String, String, Result<(), anyhow::Error>)> = Vec::new();
 
     crate::collect!(result, crate::test!(wait_after_close_accepting_socket(libos, addr)));
@@ -68,10 +65,10 @@ pub fn run(libos: &mut LibOS, addr: &SocketAddrV4) -> Vec<(String, String, Resul
 }
 
 // Attempts to close a TCP socket that is accepting and then waits on the qtoken.
-fn wait_after_close_accepting_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+fn wait_after_close_accepting_socket(libos: &mut LibOS, local: &SocketAddr) -> Result<()> {
     // Create an accepting socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, SocketAddr::V4(*local))?;
+    libos.bind(sockqd, *local)?;
     libos.listen(sockqd, 16)?;
     let qt: QToken = libos.accept(sockqd)?;
 
@@ -104,7 +101,7 @@ fn wait_after_close_accepting_socket(libos: &mut LibOS, local: &SocketAddrV4) ->
 }
 
 /// Attempts to close a TCP socket that is connecting and then waits on the qtoken.
-fn wait_after_close_connecting_socket(libos: &mut LibOS, remote: &SocketAddrV4) -> Result<()> {
+fn wait_after_close_connecting_socket(libos: &mut LibOS, remote: &SocketAddr) -> Result<()> {
     // Create a connecting socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
     let qt: QToken = libos.connect(sockqd, *remote)?;
@@ -146,10 +143,10 @@ fn wait_after_close_connecting_socket(libos: &mut LibOS, remote: &SocketAddrV4) 
 }
 
 // Attempts to close a TCP socket that is accepting and then waits on the queue token.
-fn wait_after_async_close_accepting_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+fn wait_after_async_close_accepting_socket(libos: &mut LibOS, local: &SocketAddr) -> Result<()> {
     // Create an accepting socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, SocketAddr::V4(*local))?;
+    libos.bind(sockqd, *local)?;
     libos.listen(sockqd, 16)?;
     let qt: QToken = libos.accept(sockqd)?;
 
@@ -190,7 +187,7 @@ fn wait_after_async_close_accepting_socket(libos: &mut LibOS, local: &SocketAddr
 }
 
 /// Attempts to close a TCP socket that is connecting and then waits on the queue token.
-fn wait_after_async_close_connecting_socket(libos: &mut LibOS, remote: &SocketAddrV4) -> Result<()> {
+fn wait_after_async_close_connecting_socket(libos: &mut LibOS, remote: &SocketAddr) -> Result<()> {
     // Create a connecting socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
     let qt: QToken = libos.connect(sockqd, *remote)?;
@@ -259,10 +256,10 @@ fn wait_on_invalid_queue_token_returns_einval(libos: &mut LibOS) -> Result<()> {
 }
 
 // Attempt to wait for an accept() operation to complete after issuing an asynchronous close on a socket.
-fn wait_for_accept_after_issuing_async_close(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
+fn wait_for_accept_after_issuing_async_close(libos: &mut LibOS, local: &SocketAddr) -> Result<()> {
     // Create an accepting socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, SocketAddr::V4(*local))?;
+    libos.bind(sockqd, *local)?;
     libos.listen(sockqd, 16)?;
     let qt: QToken = libos.accept(sockqd)?;
     let mut accepted_completed: bool = false;
@@ -324,7 +321,7 @@ fn wait_for_accept_after_issuing_async_close(libos: &mut LibOS, local: &SocketAd
 }
 
 // Attempt to wait for a connect() operation to complete complete after asynchronous close on a socket.
-fn wait_for_connect_after_issuing_async_close(libos: &mut LibOS, remote: &SocketAddrV4) -> Result<()> {
+fn wait_for_connect_after_issuing_async_close(libos: &mut LibOS, remote: &SocketAddr) -> Result<()> {
     // Create a connecting socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
     let qt: QToken = libos.connect(sockqd, *remote)?;

--- a/tests/rust/tcp-test/wait/mod.rs
+++ b/tests/rust/tcp-test/wait/mod.rs
@@ -13,7 +13,10 @@ use ::demikernel::{
     QToken,
 };
 use ::std::{
-    net::SocketAddrV4,
+    net::{
+        SocketAddr,
+        SocketAddrV4,
+    },
     time::Duration,
 };
 
@@ -68,7 +71,7 @@ pub fn run(libos: &mut LibOS, addr: &SocketAddrV4) -> Vec<(String, String, Resul
 fn wait_after_close_accepting_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
     // Create an accepting socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, *local)?;
+    libos.bind(sockqd, SocketAddr::V4(*local))?;
     libos.listen(sockqd, 16)?;
     let qt: QToken = libos.accept(sockqd)?;
 
@@ -146,7 +149,7 @@ fn wait_after_close_connecting_socket(libos: &mut LibOS, remote: &SocketAddrV4) 
 fn wait_after_async_close_accepting_socket(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
     // Create an accepting socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, *local)?;
+    libos.bind(sockqd, SocketAddr::V4(*local))?;
     libos.listen(sockqd, 16)?;
     let qt: QToken = libos.accept(sockqd)?;
 
@@ -259,7 +262,7 @@ fn wait_on_invalid_queue_token_returns_einval(libos: &mut LibOS) -> Result<()> {
 fn wait_for_accept_after_issuing_async_close(libos: &mut LibOS, local: &SocketAddrV4) -> Result<()> {
     // Create an accepting socket.
     let sockqd: QDesc = libos.socket(AF_INET, SOCK_STREAM, 0)?;
-    libos.bind(sockqd, *local)?;
+    libos.bind(sockqd, SocketAddr::V4(*local))?;
     libos.listen(sockqd, 16)?;
     let qt: QToken = libos.accept(sockqd)?;
     let mut accepted_completed: bool = false;

--- a/tests/rust/tcp.rs
+++ b/tests/rust/tcp.rs
@@ -998,7 +998,7 @@ fn tcp_bad_pop() -> Result<()> {
         };
 
         let port: u16 = PORT_BASE;
-        let remote: SocketAddr = SocketAddr::V4(SocketAddrV4::new(ALICE_IPV4, port));
+        let remote: SocketAddr = SocketAddr::new(ALICE_IP, port);
 
         // Open connection.
         let sockqd: QDesc = safe_socket(&mut libos)?;

--- a/tests/rust/tcp.rs
+++ b/tests/rust/tcp.rs
@@ -20,8 +20,10 @@ use ::demikernel::{
 use common::{
     arp,
     libos::*,
+    ALICE_IP,
     ALICE_IPV4,
     ALICE_MAC,
+    BOB_IP,
     BOB_IPV4,
     BOB_MAC,
     PORT_BASE,
@@ -47,7 +49,9 @@ pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
 
 use std::{
     net::{
+        IpAddr,
         Ipv4Addr,
+        SocketAddr,
         SocketAddrV4,
     },
     thread::{
@@ -64,7 +68,7 @@ use windows::Win32::Networking::WinSock;
 
 /// Opens and closes a passive socket using a non-ephemeral port.
 fn do_passive_connection_setup<const N: usize>(mut libos: &mut InetStack<N>) -> Result<()> {
-    let local: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, PORT_BASE);
+    let local: SocketAddr = SocketAddr::new(ALICE_IP, PORT_BASE);
     let sockqd: QDesc = safe_socket(&mut libos)?;
     safe_bind(&mut libos, sockqd, local)?;
     safe_listen(&mut libos, sockqd)?;
@@ -76,7 +80,7 @@ fn do_passive_connection_setup<const N: usize>(mut libos: &mut InetStack<N>) -> 
 /// Opens and closes a passive socket using an ephemeral port.
 fn do_passive_connection_setup_ephemeral<const N: usize>(mut libos: &mut InetStack<N>) -> Result<()> {
     pub const PORT_EPHEMERAL_BASE: u16 = 49152;
-    let local: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, PORT_EPHEMERAL_BASE);
+    let local: SocketAddr = SocketAddr::new(ALICE_IP, PORT_EPHEMERAL_BASE);
     let sockqd: QDesc = safe_socket(&mut libos)?;
     safe_bind(&mut libos, sockqd, local)?;
     safe_listen(&mut libos, sockqd)?;
@@ -87,7 +91,7 @@ fn do_passive_connection_setup_ephemeral<const N: usize>(mut libos: &mut InetSta
 
 /// Opens and closes a passive socket using wildcard ephemeral port.
 fn do_passive_connection_setup_wildcard_ephemeral<const N: usize>(mut libos: &mut InetStack<N>) -> Result<()> {
-    let local: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, 0);
+    let local: SocketAddr = SocketAddr::new(ALICE_IP, 0);
     let sockqd: QDesc = safe_socket(&mut libos)?;
     safe_bind(&mut libos, sockqd, local)?;
     safe_listen(&mut libos, sockqd)?;
@@ -126,7 +130,7 @@ fn tcp_establish_connection_unbound() -> Result<()> {
                 Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
             };
 
-        let local: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, PORT_BASE);
+        let local: SocketAddr = SocketAddr::new(ALICE_IP, PORT_BASE);
 
         // Open connection.
         let sockqd: QDesc = safe_socket(&mut libos)?;
@@ -158,7 +162,7 @@ fn tcp_establish_connection_unbound() -> Result<()> {
             Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
         };
 
-        let remote: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, PORT_BASE);
+        let remote: SocketAddr = SocketAddr::new(ALICE_IP, PORT_BASE);
 
         // Open connection.
         let sockqd: QDesc = safe_socket(&mut libos)?;
@@ -200,7 +204,7 @@ fn tcp_establish_connection_bound() -> Result<()> {
                 Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
             };
 
-        let local: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, PORT_BASE);
+        let local: SocketAddr = SocketAddr::new(ALICE_IP, PORT_BASE);
 
         // Open connection.
         let sockqd: QDesc = safe_socket(&mut libos)?;
@@ -232,8 +236,8 @@ fn tcp_establish_connection_bound() -> Result<()> {
             Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
         };
 
-        let local: SocketAddrV4 = SocketAddrV4::new(BOB_IPV4, PORT_BASE);
-        let remote: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, PORT_BASE);
+        let local: SocketAddr = SocketAddr::new(BOB_IP, PORT_BASE);
+        let remote: SocketAddr = SocketAddr::new(ALICE_IP, PORT_BASE);
 
         // Open connection.
         let sockqd: QDesc = safe_socket(&mut libos)?;
@@ -281,7 +285,7 @@ fn tcp_push_remote() -> Result<()> {
             };
 
         let port: u16 = PORT_BASE;
-        let local: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, port);
+        let local: SocketAddr = SocketAddr::new(ALICE_IP, port);
 
         // Open connection.
         let sockqd: QDesc = safe_socket(&mut libos)?;
@@ -325,7 +329,7 @@ fn tcp_push_remote() -> Result<()> {
         };
 
         let port: u16 = PORT_BASE;
-        let remote: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, port);
+        let remote: SocketAddr = SocketAddr::new(ALICE_IP, port);
 
         // Open connection.
         let sockqd: QDesc = safe_socket(&mut libos)?;
@@ -495,7 +499,7 @@ fn tcp_bad_listen() -> Result<()> {
     };
 
     let port: u16 = PORT_BASE;
-    let local: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, port);
+    let local: SocketAddr = SocketAddr::new(ALICE_IP, port);
 
     // Invalid queue descriptor.
     match libos.listen(QDesc::from(0), 8) {
@@ -599,7 +603,7 @@ fn tcp_bad_connect() -> Result<()> {
                 Err(e) => anyhow::bail!("Could not create inetstack: {:?}", e),
             };
         let port: u16 = PORT_BASE;
-        let local: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, port);
+        let local: SocketAddr = SocketAddr::new(ALICE_IP, port);
 
         // Open connection.
         let sockqd: QDesc = safe_socket(&mut libos)?;
@@ -631,7 +635,7 @@ fn tcp_bad_connect() -> Result<()> {
         };
 
         let port: u16 = PORT_BASE;
-        let remote: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, port);
+        let remote: SocketAddr = SocketAddr::new(ALICE_IP, port);
 
         // Bad queue descriptor.
         match libos.connect(QDesc::from(0), remote) {
@@ -644,7 +648,7 @@ fn tcp_bad_connect() -> Result<()> {
         };
 
         // Bad endpoint.
-        let bad_remote: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), port);
+        let bad_remote: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port);
         let sockqd: QDesc = safe_socket(&mut libos)?;
         let qt: QToken = safe_connect(&mut libos, sockqd, bad_remote)?;
         let (_, qr): (QDesc, OperationResult) = safe_wait2(&mut libos, qt)?;
@@ -658,7 +662,7 @@ fn tcp_bad_connect() -> Result<()> {
         }
 
         // Close connection.
-        let remote: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, port);
+        let remote: SocketAddr = SocketAddr::new(ALICE_IP, port);
         let sockqd: QDesc = safe_socket(&mut libos)?;
         let qt: QToken = safe_connect(&mut libos, sockqd, remote)?;
         let (_, qr): (QDesc, OperationResult) = safe_wait2(&mut libos, qt)?;
@@ -703,7 +707,7 @@ fn tcp_bad_close() -> Result<()> {
             };
 
         let port: u16 = PORT_BASE;
-        let local: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, port);
+        let local: SocketAddr = SocketAddr::new(ALICE_IP, port);
 
         // Open connection.
         let sockqd: QDesc = safe_socket(&mut libos)?;
@@ -747,7 +751,7 @@ fn tcp_bad_close() -> Result<()> {
         };
 
         let port: u16 = PORT_BASE;
-        let remote: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, port);
+        let remote: SocketAddr = SocketAddr::new(ALICE_IP, port);
 
         // Open connection.
         let sockqd: QDesc = safe_socket(&mut libos)?;
@@ -808,7 +812,7 @@ fn tcp_bad_push() -> Result<()> {
             };
 
         let port: u16 = PORT_BASE;
-        let local: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, port);
+        let local: SocketAddr = SocketAddr::new(ALICE_IP, port);
 
         // Open connection.
         let sockqd: QDesc = safe_socket(&mut libos)?;
@@ -852,7 +856,7 @@ fn tcp_bad_push() -> Result<()> {
         };
 
         let port: u16 = PORT_BASE;
-        let remote: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, port);
+        let remote: SocketAddr = SocketAddr::new(ALICE_IP, port);
 
         // Open connection.
         let sockqd: QDesc = safe_socket(&mut libos)?;
@@ -940,7 +944,7 @@ fn tcp_bad_pop() -> Result<()> {
             };
 
         let port: u16 = PORT_BASE;
-        let local: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, port);
+        let local: SocketAddr = SocketAddr::new(ALICE_IP, port);
 
         // Open connection.
         let sockqd: QDesc = safe_socket(&mut libos)?;
@@ -994,7 +998,7 @@ fn tcp_bad_pop() -> Result<()> {
         };
 
         let port: u16 = PORT_BASE;
-        let remote: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, port);
+        let remote: SocketAddr = SocketAddr::V4(SocketAddrV4::new(ALICE_IPV4, port));
 
         // Open connection.
         let sockqd: QDesc = safe_socket(&mut libos)?;
@@ -1051,7 +1055,7 @@ fn safe_socket<const N: usize>(libos: &mut InetStack<N>) -> Result<QDesc> {
 }
 
 /// Safe call to `connect()`.
-fn safe_connect<const N: usize>(libos: &mut InetStack<N>, sockqd: QDesc, remote: SocketAddrV4) -> Result<QToken> {
+fn safe_connect<const N: usize>(libos: &mut InetStack<N>, sockqd: QDesc, remote: SocketAddr) -> Result<QToken> {
     match libos.connect(sockqd, remote) {
         Ok(qt) => Ok(qt),
         Err(e) => {
@@ -1063,7 +1067,7 @@ fn safe_connect<const N: usize>(libos: &mut InetStack<N>, sockqd: QDesc, remote:
 }
 
 /// Safe call to `bind()`.
-fn safe_bind<const N: usize>(libos: &mut InetStack<N>, sockqd: QDesc, local: SocketAddrV4) -> Result<()> {
+fn safe_bind<const N: usize>(libos: &mut InetStack<N>, sockqd: QDesc, local: SocketAddr) -> Result<()> {
     match libos.bind(sockqd, local) {
         Ok(_) => Ok(()),
         Err(e) => {

--- a/tests/rust/udp.rs
+++ b/tests/rust/udp.rs
@@ -20,8 +20,10 @@ use ::demikernel::{
 use common::{
     arp,
     libos::*,
+    ALICE_IP,
     ALICE_IPV4,
     ALICE_MAC,
+    BOB_IP,
     BOB_IPV4,
     BOB_MAC,
     PORT_BASE,
@@ -46,7 +48,7 @@ pub const AF_INET: i32 = libc::AF_INET;
 pub const SOCK_DGRAM: i32 = libc::SOCK_DGRAM;
 
 use std::{
-    net::SocketAddrV4,
+    net::SocketAddr,
     thread::{
         self,
         JoinHandle,
@@ -59,7 +61,7 @@ use std::{
 
 /// Opens and closes a socket using a non-ephemeral port.
 fn do_udp_setup<const N: usize>(libos: &mut InetStack<N>) -> Result<()> {
-    let local: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, PORT_BASE);
+    let local: SocketAddr = SocketAddr::new(ALICE_IP, PORT_BASE);
     let sockfd: QDesc = match libos.socket(AF_INET, SOCK_DGRAM, 0) {
         Ok(qd) => qd,
         Err(e) => anyhow::bail!("failed to create socket: {:?}", e),
@@ -82,7 +84,7 @@ fn do_udp_setup<const N: usize>(libos: &mut InetStack<N>) -> Result<()> {
 /// Opens and closes a socket using an ephemeral port.
 fn do_udp_setup_ephemeral<const N: usize>(libos: &mut InetStack<N>) -> Result<()> {
     const PORT_EPHEMERAL_BASE: u16 = 49152;
-    let local: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, PORT_EPHEMERAL_BASE);
+    let local: SocketAddr = SocketAddr::new(ALICE_IP, PORT_EPHEMERAL_BASE);
     let sockfd: QDesc = match libos.socket(AF_INET, SOCK_DGRAM, 0) {
         Ok(qd) => qd,
         Err(e) => anyhow::bail!("failed to create socket: {:?}", e),
@@ -104,7 +106,7 @@ fn do_udp_setup_ephemeral<const N: usize>(libos: &mut InetStack<N>) -> Result<()
 
 /// Opens and closes a socket using wildcard ephemeral port.
 fn do_udp_setup_wildcard_ephemeral<const N: usize>(libos: &mut InetStack<N>) -> Result<()> {
-    let local: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, 0);
+    let local: SocketAddr = SocketAddr::new(ALICE_IP, 0);
     let sockfd: QDesc = match libos.socket(AF_INET, SOCK_DGRAM, 0) {
         Ok(qd) => qd,
         Err(e) => anyhow::bail!("failed to create socket: {:?}", e),
@@ -150,7 +152,7 @@ fn udp_connect_loopback() -> Result<()> {
     };
 
     let port: u16 = PORT_BASE;
-    let local: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, port);
+    let local: SocketAddr = SocketAddr::new(ALICE_IP, port);
 
     // Open and close a connection.
     let sockfd: QDesc = match libos.socket(AF_INET, SOCK_DGRAM, 0) {
@@ -184,9 +186,9 @@ fn udp_push_remote() -> Result<()> {
     let (bob_tx, bob_rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
 
     let bob_port: u16 = PORT_BASE;
-    let bob_addr: SocketAddrV4 = SocketAddrV4::new(BOB_IPV4, bob_port);
+    let bob_addr: SocketAddr = SocketAddr::new(BOB_IP, bob_port);
     let alice_port: u16 = PORT_BASE;
-    let alice_addr: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, alice_port);
+    let alice_addr: SocketAddr = SocketAddr::new(ALICE_IP, alice_port);
 
     let alice: JoinHandle<Result<()>> = thread::spawn(move || {
         let mut libos: InetStack<RECEIVE_BATCH_SIZE> =
@@ -338,9 +340,9 @@ fn udp_loopback() -> Result<()> {
     let (bob_tx, bob_rx): (Sender<DemiBuffer>, Receiver<DemiBuffer>) = crossbeam_channel::unbounded();
 
     let bob_port: u16 = PORT_BASE;
-    let bob_addr: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, bob_port);
+    let bob_addr: SocketAddr = SocketAddr::new(ALICE_IP, bob_port);
     let alice_port: u16 = PORT_BASE;
-    let alice_addr: SocketAddrV4 = SocketAddrV4::new(ALICE_IPV4, alice_port);
+    let alice_addr: SocketAddr = SocketAddr::new(ALICE_IP, alice_port);
 
     let alice: JoinHandle<Result<()>> = thread::spawn(move || {
         let mut libos: InetStack<RECEIVE_BATCH_SIZE> =


### PR DESCRIPTION
This PR is a largely mechanical change for libOS APIs and C bindings to generalize from `SocketAddrV4` to `SocketAddr`, as described in #204 and elaborated in other places such as #413. The non-mechanical portions of this PR include:
- Updating bindings.rs to use socket2 to convert between C `sockaddr`s and `SocketAddr`; see new method `sockaddr_to_socketaddr` to replace `sockaddr_to_socketaddr4` (note latest socket2 has updated this code to be more performant)
- Adding a test case to the bindings.rs test
- Adding the method `crate::runtime::network::unwrap_socketaddr`, as well as call sites in all libOSes, to provide standard error semantics when expecting IPv4 (as all libOSes currently do)
- Removing unused platform abstractions
- Adding the TCP test `tcp_bad_bind`, to test IPv6 binding, as well as a few other cases.
- Updating examples to parse full SocketAddrs (which will fail for now if an IPv6 is parsed)
- Adding .gitignore for Visual Studio (because some habits die hard)