### PR TITLE
[demikernel] Localize packing compiler directives for Windows builds

### DIFF
--- a/include/demi/types.h
+++ b/include/demi/types.h
@@ -35,7 +35,7 @@ extern "C"
      * @brief A segment of a scatter-gather array.
      */
     #ifdef _WIN32
-    #pragma pack(1)
+    #pragma pack(push, 1)
     typedef struct demi_sgaseg
     #endif
     #ifdef __linux__
@@ -45,12 +45,15 @@ extern "C"
         void *sgaseg_buf;    /**< Underlying data.       */
         uint32_t sgaseg_len; /**< Size in bytes of data. */
     } demi_sgaseg_t;
+    #ifdef _WIN32
+    #pragma pack(pop)
+    #endif
 
     /**
      * @brief A scatter-gather array.
      */
     #ifdef _WIN32
-    #pragma pack(1)
+    #pragma pack(push, 1)
     typedef struct demi_sgarray
     #endif
     #ifdef __linux__
@@ -62,6 +65,9 @@ extern "C"
         demi_sgaseg_t sga_segs[DEMI_SGARRAY_MAXSIZE]; /**< Scatter-gather array segments.                  */
         struct sockaddr_in sga_addr;                  /**< Source address of scatter-gather array.         */
     } demi_sgarray_t;
+    #ifdef _WIN32
+    #pragma pack(pop)
+    #endif
 
     /**
      * @brief Opcodes for an asynchronous I/O operation.
@@ -81,7 +87,7 @@ extern "C"
      * @brief Result value for an accept operation.
      */
     #ifdef _WIN32
-    #pragma pack(1)
+    #pragma pack(push, 1)
     typedef struct demi_accept_result
     #endif
     #ifdef __linux__
@@ -91,12 +97,15 @@ extern "C"
         int32_t qd;                  /**< Socket I/O queue descriptor of accepted connection. */
         struct sockaddr_in addr; /**< Remote address of accepted connection.              */
     } demi_accept_result_t;
+    #ifdef _WIN32
+    #pragma pack(pop)
+    #endif
 
     /**
      * @brief Result value for an asynchronous I/O operation.
      */
     #ifdef _WIN32
-    #pragma pack(1)
+    #pragma pack(push, 1)
     typedef struct demi_qresult
     #endif
     #ifdef __linux__
@@ -117,7 +126,9 @@ extern "C"
             demi_accept_result_t ares; /**< Accept result.                      */
         } qr_value;
     } demi_qresult_t;
-
+    #ifdef _WIN32
+    #pragma pack(pop)
+    #endif
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Localize packing compiler directives for Windows builds. If this is not done, the packing directives will remain active for other build targets as well. So, to avoid this in integration builds (e.g., Bing), localizing the directives is the best option.