### PR TITLE
[catloop] Rollback If Close Fails

### DIFF
--- a/src/rust/catloop/socket.rs
+++ b/src/rust/catloop/socket.rs
@@ -181,8 +181,13 @@ impl Socket {
                 // Invalid response.
                 Ok(false) => {
                     // Clean up newly allocated duplex pipe.
-                    catmem.close(new_qd)?;
-                    continue;
+                    match catmem.close(new_qd) {
+                        Ok(()) => continue,
+                        Err(e) => {
+                            self.state.rollback();
+                            return Err(e);
+                        },
+                    }
                 },
                 // Some error.
                 Err(e) => {


### PR DESCRIPTION
## Description

This PR fixes the buggy scenario where we should rollback the socket state if accept fails. Before we wouldn't do that, leaving the socket in a bad state.