### PR TITLE
[catloop] Warn Backlog Length Listen

### DIFF
--- a/src/rust/catloop/mod.rs
+++ b/src/rust/catloop/mod.rs
@@ -220,7 +220,6 @@ impl SharedCatloopLibOS {
 
     /// Sets a SharedCatloopQueue and as a passive one. This function contains the libOS-level
     /// functionality to move the SharedCatloopQueue into a listening state.
-    // FIXME: https://github.com/demikernel/demikernel/issues/697
     pub fn listen(&mut self, qd: QDesc, backlog: usize) -> Result<(), Fail> {
         #[cfg(feature = "profiler")]
         timer!("catloop::listen");
@@ -231,7 +230,7 @@ impl SharedCatloopLibOS {
 
         // Check if the queue descriptor is registered in the sockets table.
         let mut queue: SharedCatloopQueue = self.get_queue(&qd)?;
-        queue.listen()
+        queue.listen(backlog)
     }
 
     /// Synchronous cross-queue code to start accepting a connection. This function schedules the asynchronous

--- a/src/rust/catloop/queue.rs
+++ b/src/rust/catloop/queue.rs
@@ -8,6 +8,7 @@
 use crate::{
     catloop::socket::Socket,
     catmem::SharedCatmemLibOS,
+    pal,
     runtime::{
         fail::Fail,
         memory::DemiBuffer,
@@ -103,8 +104,11 @@ impl SharedCatloopQueue {
     }
 
     /// Sets the target queue to listen for incoming connections.
-    pub fn listen(&mut self) -> Result<(), Fail> {
-        self.socket.listen()
+    pub fn listen(&mut self, backlog: usize) -> Result<(), Fail> {
+        // We just assert backlog here, because it was previously checked at PDPIX layer.
+        debug_assert!((backlog > 0) && (backlog <= pal::constants::SOMAXCONN as usize));
+
+        self.socket.listen(backlog)
     }
 
     /// Starts a coroutine to begin accepting on this queue. This function contains all of the single-queue,


### PR DESCRIPTION
## Description

This PR closes #697.

We currently ignore the backlog length and this PR improves existing code by keeping track of pending connections and triggering logging if a passive socket is too busy.

Ideally we would send `ECONNREFUSED` back to clients, but the current connection handshake protocol does not support that. It will keep queueing requests anyways.