### PR TITLE
[demikernel] Enhancement: Remove refs to CHAR type

### DIFF
--- a/src/rust/catnip/interop.rs
+++ b/src/rust/catnip/interop.rs
@@ -9,10 +9,7 @@ use crate::{
             SockAddr,
             SockAddrIn,
         },
-        functions::{
-            create_sin_addr,
-            create_sin_zero,
-        },
+        functions::create_sin_addr,
     },
     runtime::{
         memory::MemoryRuntime,
@@ -46,7 +43,7 @@ pub fn pack_result(rt: Rc<DPDKRuntime>, result: OperationResult, qd: QDesc, qt: 
                     sin_family: AF_INET,
                     sin_port: addr.port().into(),
                     sin_addr: create_sin_addr(&addr.ip().octets()),
-                    sin_zero: create_sin_zero(),
+                    sin_zero: [0; 8],
                 }
             };
             let qr_value: demi_qr_value_t = demi_qr_value_t {
@@ -78,7 +75,7 @@ pub fn pack_result(rt: Rc<DPDKRuntime>, result: OperationResult, qd: QDesc, qt: 
                             sin_family: AF_INET,
                             sin_port: endpoint.port().into(),
                             sin_addr: create_sin_addr(&endpoint.ip().octets()),
-                            sin_zero: create_sin_zero(),
+                            sin_zero: [0; 8],
                         }
                     };
                     sga.sga_addr = unsafe { mem::transmute::<SockAddrIn, SockAddr>(saddr) };

--- a/src/rust/pal/functions.rs
+++ b/src/rust/pal/functions.rs
@@ -4,12 +4,6 @@
 #[cfg(feature = "catnip-libos")]
 const NUM_OCTETS_IN_IPV4: usize = 4;
 
-#[cfg(feature = "catnip-libos")]
-const NUM_SIN_ZERO_BYTES: usize = 8;
-
-#[cfg(all(feature = "catnip-libos", target_os = "windows"))]
-use windows::Win32::Foundation::CHAR;
-
 #[cfg(all(feature = "catnip-libos", target_os = "windows"))]
 use windows::Win32::Networking::WinSock::IN_ADDR;
 
@@ -31,11 +25,6 @@ pub fn create_sin_addr(octets: &[u8; NUM_OCTETS_IN_IPV4]) -> IN_ADDR {
             S_addr: u32::from_ne_bytes(*octets),
         }),
     }
-}
-
-#[cfg(all(feature = "catnip-libos", target_os = "windows"))]
-pub fn create_sin_zero() -> [CHAR; NUM_SIN_ZERO_BYTES] {
-    [CHAR(0); 8]
 }
 
 #[cfg(target_os = "windows")]
@@ -70,9 +59,4 @@ pub fn create_sin_addr(octets: &[u8; NUM_OCTETS_IN_IPV4]) -> in_addr {
         // Always create a big-endian u32 from the given 4 bytes (in big-endian order), regardless of architecture.
         s_addr: u32::from_ne_bytes(*octets),
     }
-}
-
-#[cfg(all(feature = "catnip-libos", target_os = "linux"))]
-pub fn create_sin_zero() -> [u8; NUM_SIN_ZERO_BYTES] {
-    [0; 8]
 }


### PR DESCRIPTION
Removed reference to the CHAR type on Windows. This also allows to unify the sin_zero initialization for Linux and Windows.