### PR TITLE
[catnip] Update pointer to dpdk-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ x86 = "0.52.0"
 
 # Demikernel Organization
 liburing = { git = "https://github.com/demikernel/liburing-rs", rev = "780827ee3f805d94f9909bd47cd925ee8476a64b", optional = true }
-dpdk-rs = { git = "https://github.com/demikernel/dpdk-rs", rev = "5a339766b6f64c2b09c2e4089c62013bfb48297e", optional = true }
+dpdk-rs = { git = "https://github.com/demikernel/dpdk-rs", rev = "a0bb97920560e978ce0991d6e0c3267fd8f0baa2", optional = true }
 
 # Windows-specific dependencies.
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
This PR updates the commit ID that the Demikernel repo points to in the dpdk-rs repo. The updated commit has changes required to build on Windows.