### PR TITLE
[runtime] Remove all Refcell from scheduler

### DIFF
--- a/src/rust/catcollar/runtime/mod.rs
+++ b/src/rust/catcollar/runtime/mod.rs
@@ -22,7 +22,7 @@ use crate::{
         },
         Operation,
         OperationTask,
-        Runtime,
+        SharedObject,
     },
     scheduler::{
         scheduler::Scheduler,
@@ -30,15 +30,17 @@ use crate::{
     },
 };
 use ::std::{
-    cell::RefCell,
     collections::{
         HashMap,
         HashSet,
     },
     net::SocketAddrV4,
+    ops::{
+        Deref,
+        DerefMut,
+    },
     os::unix::prelude::RawFd,
     pin::Pin,
-    rc::Rc,
 };
 
 //==============================================================================
@@ -57,38 +59,29 @@ const CATCOLLAR_NUM_RINGS: u32 = 128;
 pub struct RequestId(pub *const liburing::msghdr);
 
 /// I/O User Ring Runtime
-#[derive(Clone)]
 pub struct IoUringRuntime {
     /// Scheduler
     pub scheduler: Scheduler,
     /// Underlying io_uring.
-    io_uring: Rc<RefCell<IoUring>>,
+    io_uring: IoUring,
     /// Pending requests.
     pending: HashSet<RequestId>,
     /// Completed requests.
     completed: HashMap<RequestId, (Option<SocketAddrV4>, i32)>,
 }
 
+#[derive(Clone)]
+pub struct SharedIoUringRuntime(SharedObject<IoUringRuntime>);
+
 //==============================================================================
 // Associate Functions
 //==============================================================================
 
 /// Associate Functions for I/O User Ring Runtime
-impl IoUringRuntime {
-    /// Creates an I/O user ring runtime.
-    pub fn new() -> Self {
-        let io_uring: IoUring = IoUring::new(CATCOLLAR_NUM_RINGS).expect("cannot create io_uring");
-        Self {
-            scheduler: Scheduler::default(),
-            io_uring: Rc::new(RefCell::new(io_uring)),
-            pending: HashSet::new(),
-            completed: HashMap::new(),
-        }
-    }
-
+impl SharedIoUringRuntime {
     /// Pushes a buffer to the target I/O user ring.
     pub fn push(&mut self, sockfd: RawFd, buf: DemiBuffer) -> Result<RequestId, Fail> {
-        let msg_ptr: *const liburing::msghdr = self.io_uring.borrow_mut().push(sockfd, buf)?;
+        let msg_ptr: *const liburing::msghdr = self.io_uring.push(sockfd, buf)?;
         let request_id: RequestId = RequestId(msg_ptr);
         self.pending.insert(request_id);
         Ok(request_id)
@@ -96,7 +89,7 @@ impl IoUringRuntime {
 
     /// Pushes a buffer to the target I/O user ring.
     pub fn pushto(&mut self, sockfd: i32, addr: SocketAddrV4, buf: DemiBuffer) -> Result<RequestId, Fail> {
-        let msg_ptr: *const liburing::msghdr = self.io_uring.borrow_mut().pushto(sockfd, addr, buf)?;
+        let msg_ptr: *const liburing::msghdr = self.io_uring.pushto(sockfd, addr, buf)?;
         let request_id: RequestId = RequestId(msg_ptr);
         self.pending.insert(request_id);
         Ok(request_id)
@@ -104,7 +97,7 @@ impl IoUringRuntime {
 
     /// Pops a buffer from the target I/O user ring.
     pub fn pop(&mut self, sockfd: RawFd, buf: DemiBuffer) -> Result<RequestId, Fail> {
-        let msg_ptr: *const liburing::msghdr = self.io_uring.borrow_mut().pop(sockfd, buf)?;
+        let msg_ptr: *const liburing::msghdr = self.io_uring.pop(sockfd, buf)?;
         let request_id: RequestId = RequestId(msg_ptr);
         self.pending.insert(request_id);
         Ok(request_id)
@@ -119,7 +112,7 @@ impl IoUringRuntime {
             // The target request may not be completed.
             None => {
                 // Peek the underlying io_uring.
-                match self.io_uring.borrow_mut().wait() {
+                match self.io_uring.wait() {
                     // Some operation has completed.
                     Ok((other_request_id, size)) => {
                         let msg: Box<liburing::msghdr> = unsafe { Box::from_raw(other_request_id) };
@@ -152,7 +145,7 @@ impl IoUringRuntime {
     }
 
     /// Inserts the `coroutine` named `task_name` into the scheduler.
-    pub fn insert_coroutine(&self, task_name: &str, coroutine: Pin<Box<Operation>>) -> Result<TaskHandle, Fail> {
+    pub fn insert_coroutine(&mut self, task_name: &str, coroutine: Pin<Box<Operation>>) -> Result<TaskHandle, Fail> {
         let task: OperationTask = OperationTask::new(task_name.to_string(), coroutine);
         match self.scheduler.insert(task) {
             Some(handle) => Ok(handle),
@@ -172,5 +165,29 @@ impl IoUringRuntime {
 /// Memory Runtime Trait Implementation for IoUring Runtime
 impl MemoryRuntime for IoUringRuntime {}
 
-/// Runtime Trait Implementation for I/O User Ring Runtime
-impl Runtime for IoUringRuntime {}
+impl Default for SharedIoUringRuntime {
+    /// Creates an I/O user ring runtime.
+    fn default() -> Self {
+        let io_uring: IoUring = IoUring::new(CATCOLLAR_NUM_RINGS).expect("cannot create io_uring");
+        Self(SharedObject::<IoUringRuntime>::new(IoUringRuntime {
+            scheduler: Scheduler::default(),
+            io_uring: io_uring,
+            pending: HashSet::new(),
+            completed: HashMap::new(),
+        }))
+    }
+}
+
+impl Deref for SharedIoUringRuntime {
+    type Target = IoUringRuntime;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl DerefMut for SharedIoUringRuntime {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.deref_mut()
+    }
+}

--- a/src/rust/catloop/mod.rs
+++ b/src/rust/catloop/mod.rs
@@ -531,7 +531,7 @@ impl SharedCatloopLibOS {
     }
 
     /// Polls scheduling queues.
-    pub fn poll(&self) {
+    pub fn poll(&mut self) {
         #[cfg(feature = "profiler")]
         timer!("catloop::poll");
         self.runtime.poll()

--- a/src/rust/catmem/mod.rs
+++ b/src/rust/catmem/mod.rs
@@ -341,7 +341,7 @@ impl SharedCatmemLibOS {
         Ok(qr)
     }
 
-    pub fn poll(&self) {
+    pub fn poll(&mut self) {
         #[cfg(feature = "profiler")]
         timer!("catmem::poll");
         self.runtime.poll()

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -33,6 +33,7 @@ use crate::{
             DemiBuffer,
             MemoryRuntime,
         },
+        network::unwrap_socketaddr,
         queue::{
             downcast_queue,
             downcast_queue_ptr,
@@ -48,7 +49,6 @@ use crate::{
             demi_qresult_t,
             demi_sgarray_t,
         },
-        network::unwrap_socketaddr,
         QDesc,
         QToken,
         SharedDemiRuntime,
@@ -63,8 +63,8 @@ use ::std::{
     mem,
     net::{
         Ipv4Addr,
-        SocketAddrV4,
         SocketAddr,
+        SocketAddrV4,
     },
     ops::{
         Deref,
@@ -472,7 +472,7 @@ impl SharedCatnapLibOS {
         }
     }
 
-    pub fn poll(&self) {
+    pub fn poll(&mut self) {
         #[cfg(feature = "profiler")]
         timer!("catnap::poll");
         self.runtime.poll()

--- a/src/rust/inetstack/test_helpers/runtime.rs
+++ b/src/rust/inetstack/test_helpers/runtime.rs
@@ -108,8 +108,7 @@ impl SharedTestRuntime {
         self.incoming.push_back(buf);
     }
 
-    /// Poll the runtime's scheduler for one iteration.
-    pub fn poll_scheduler(&self) {
+    pub fn poll_scheduler(&mut self) {
         self.runtime.poll();
     }
 

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -160,7 +160,7 @@ impl DemiRuntime {
     }
 
     /// Performs a single pool on the underlying scheduler.
-    pub fn poll(&self) {
+    pub fn poll(&mut self) {
         self.scheduler.poll()
     }
 


### PR DESCRIPTION
This PR removes all refcells from the scheduler, as the scheduler is always part of a shared object now and no longer needs to be cloneable.