### PR TITLE
[catnip] Remove inner construct from memory management runtime

### DIFF
--- a/src/rust/catnip/interop.rs
+++ b/src/rust/catnip/interop.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 use crate::{
-    catnip::DPDKRuntime,
+    catnip::SharedDPDKRuntime,
     pal::{
         constants::AF_INET,
         data_structures::{
@@ -25,7 +25,7 @@ use crate::{
 };
 use ::std::mem;
 
-pub fn pack_result(rt: &DPDKRuntime, result: OperationResult, qd: QDesc, qt: u64) -> demi_qresult_t {
+pub fn pack_result(rt: &SharedDPDKRuntime, result: OperationResult, qd: QDesc, qt: u64) -> demi_qresult_t {
     match result {
         OperationResult::Connect => demi_qresult_t {
             qr_opcode: demi_opcode_t::DEMI_OPC_CONNECT,

--- a/src/rust/catnip/mod.rs
+++ b/src/rust/catnip/mod.rs
@@ -11,7 +11,7 @@ pub mod runtime;
 
 use self::{
     interop::pack_result,
-    runtime::DPDKRuntime,
+    runtime::SharedDPDKRuntime,
 };
 use crate::{
     demikernel::config::Config,
@@ -66,7 +66,7 @@ use crate::timer;
 pub struct CatnipLibOS {
     runtime: SharedDemiRuntime,
     inetstack: InetStack<RECEIVE_BATCH_SIZE>,
-    transport: DPDKRuntime,
+    transport: SharedDPDKRuntime,
 }
 
 //==============================================================================
@@ -77,7 +77,7 @@ pub struct CatnipLibOS {
 impl CatnipLibOS {
     pub fn new(config: &Config, runtime: SharedDemiRuntime) -> Self {
         load_mlx_driver();
-        let transport: DPDKRuntime = DPDKRuntime::new(
+        let transport: SharedDPDKRuntime = SharedDPDKRuntime::new(
             config.local_ipv4_addr(),
             &config.eal_init_args(),
             config.arp_table(),

--- a/src/rust/catnip/runtime/network.rs
+++ b/src/rust/catnip/runtime/network.rs
@@ -5,7 +5,7 @@
 // Imports
 //==============================================================================
 
-use super::DPDKRuntime;
+use super::SharedDPDKRuntime;
 use crate::{
     inetstack::protocols::ethernet2::MIN_PAYLOAD_SIZE,
     runtime::{
@@ -33,7 +33,7 @@ use crate::timer;
 //==============================================================================
 
 /// Network Runtime Trait Implementation for DPDK Runtime
-impl<const N: usize> NetworkRuntime<N> for DPDKRuntime {
+impl<const N: usize> NetworkRuntime<N> for SharedDPDKRuntime {
     fn transmit(&mut self, buf: Box<dyn PacketBuf>) {
         // TODO: Consider an important optimization here: If there is data in this packet (i.e. not just headers), and
         // that data is in a DPDK-owned mbuf, and there is "headroom" in that mbuf to hold the packet headers, just


### PR DESCRIPTION
This PR removes the remaining inner construct from Catnip. It was originally used to share the DPDK memory manager in Catnip but I have moved the entire DPDKRuntime to a shared object instead.