### PR TITLE
[runtime] Enhancement: Move ephemeral port allocator into shared runtime

### DIFF
--- a/src/rust/inetstack/protocols/ip/mod.rs
+++ b/src/rust/inetstack/protocols/ip/mod.rs
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-mod ephemeral;
 mod protocol;
 
-pub use self::{
-    ephemeral::EphemeralPorts,
-    protocol::IpProtocol,
-};
+pub use self::protocol::IpProtocol;

--- a/src/rust/inetstack/protocols/peer.rs
+++ b/src/rust/inetstack/protocols/peer.rs
@@ -58,7 +58,6 @@ impl<const N: usize> Peer<N> {
         let udp: SharedUdpPeer<N> = SharedUdpPeer::new(
             runtime.clone(),
             transport.clone(),
-            rng_seed,
             local_link_addr,
             local_ipv4_addr,
             udp_offload_checksum,

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -38,6 +38,7 @@ use crate::{
     runtime::{
         fail::Fail,
         memory::MemoryRuntime,
+        network::ephemeral::EphemeralPorts,
         queue::{
             IoQueue,
             IoQueueTable,
@@ -78,6 +79,8 @@ pub struct DemiRuntime {
     scheduler: Scheduler,
     /// Shared IoQueueTable.
     qtable: IoQueueTable,
+    /// Shared ephemeral port allocator.
+    ephemeral_ports: EphemeralPorts,
 }
 
 #[derive(Clone)]
@@ -215,8 +218,29 @@ impl SharedDemiRuntime {
         Ok(self.qtable.get::<T>(qd)?.clone())
     }
 
+    /// Returns the type for the queue that matches [qd].
     pub fn get_queue_type(&self, qd: &QDesc) -> Result<QType, Fail> {
         self.qtable.get_type(qd)
+    }
+
+    /// Allocates a port from the shared ephemeral port allocator.
+    pub fn alloc_ephemeral_port(&mut self) -> Result<u16, Fail> {
+        self.ephemeral_ports.alloc()
+    }
+
+    /// Reserves a specific port if it is free.
+    pub fn reserve_ephemeral_port(&mut self, port: u16) -> Result<(), Fail> {
+        self.ephemeral_ports.reserve(port)
+    }
+
+    /// Frees an ephemeral port.
+    pub fn free_ephemeral_port(&mut self, port: u16) -> Result<(), Fail> {
+        self.ephemeral_ports.free(port)
+    }
+
+    /// Checks if a port is private.
+    pub fn is_private_ephemeral_port(port: u16) -> bool {
+        EphemeralPorts::is_private(port)
     }
 }
 

--- a/src/rust/runtime/network/ephemeral.rs
+++ b/src/rust/runtime/network/ephemeral.rs
@@ -3,28 +3,31 @@
 
 use crate::runtime::fail::Fail;
 use ::rand::prelude::{
+    SeedableRng,
     SliceRandom,
     SmallRng,
 };
 
-//==============================================================================
+//======================================================================================================================
 // Constants
-//==============================================================================
+//======================================================================================================================
 
 const FIRST_PRIVATE_PORT: u16 = 49152;
 const LAST_PRIVATE_PORT: u16 = 65535;
+/// Seed number of ephemeral port allocator.
+const EPHEMERAL_PORT_SEED: u64 = 12345;
 
-//==============================================================================
+//======================================================================================================================
 // Structures
-//==============================================================================
+//======================================================================================================================
 
 pub struct EphemeralPorts {
     ports: Vec<u16>,
 }
 
-//==============================================================================
-// Associate Functions
-//==============================================================================
+//======================================================================================================================
+// Associated Functions
+//======================================================================================================================
 
 impl EphemeralPorts {
     /// Creates a new ephemeral port allocator.
@@ -43,7 +46,7 @@ impl EphemeralPorts {
     }
 
     /// Allocates any ephemeral port from the pool.
-    pub fn alloc_any(&mut self) -> Result<u16, Fail> {
+    pub fn alloc(&mut self) -> Result<u16, Fail> {
         self.ports.pop().ok_or(Fail::new(
             libc::EADDRINUSE,
             "all port numbers in the ephemeral port range are currently in use",
@@ -51,7 +54,7 @@ impl EphemeralPorts {
     }
 
     /// Allocates the specified port from the pool.
-    pub fn alloc_port(&mut self, port: u16) -> Result<(), Fail> {
+    pub fn reserve(&mut self, port: u16) -> Result<(), Fail> {
         // Check if port is not in the pool.
         if !self.ports.contains(&port) {
             return Err(Fail::new(libc::ENOENT, "port number not found"));
@@ -85,6 +88,36 @@ impl EphemeralPorts {
     }
 }
 
+//======================================================================================================================
+// Trait Implementations
+//======================================================================================================================
+
+impl Default for EphemeralPorts {
+    /// Creates a new ephemeral port allocator.
+    fn default() -> Self {
+        let mut rng: SmallRng = {
+            #[cfg(debug_assertions)]
+            {
+                SmallRng::seed_from_u64(EPHEMERAL_PORT_SEED)
+            }
+            #[cfg(not(debug_assertions))]
+            {
+                SmallRng::from_entropy()
+            }
+        };
+        let mut ports: Vec<u16> = Vec::<u16>::new();
+        for port in FIRST_PRIVATE_PORT..LAST_PRIVATE_PORT {
+            ports.push(port);
+        }
+        ports.shuffle(&mut rng);
+        Self { ports }
+    }
+}
+
+//======================================================================================================================
+// Unit Tests
+//======================================================================================================================
+
 #[cfg(test)]
 mod test {
     use super::{
@@ -93,17 +126,14 @@ mod test {
         LAST_PRIVATE_PORT,
     };
     use ::anyhow::Result;
-    use ::rand::SeedableRng;
-    use rand::prelude::SmallRng;
 
     /// Attempts to allocate any ephemeral port and then release it.
     #[test]
     fn test_alloc_any_and_free() -> Result<()> {
-        let mut rng: SmallRng = SmallRng::seed_from_u64(0);
-        let mut ports: EphemeralPorts = EphemeralPorts::new(&mut rng);
+        let mut ports: EphemeralPorts = EphemeralPorts::default();
 
         // Allocate a port.
-        let port: u16 = match ports.alloc_any() {
+        let port: u16 = match ports.alloc() {
             Ok(port) => port,
             Err(e) => anyhow::bail!("failed to allocate an ephemeral port ({:?})", &e),
         };
@@ -119,11 +149,10 @@ mod test {
     /// Attempts to allocate a specific ephemeral port and then release it.
     #[test]
     fn test_alloc_port_and_free() -> Result<()> {
-        let mut rng: SmallRng = SmallRng::seed_from_u64(0);
-        let mut ports: EphemeralPorts = EphemeralPorts::new(&mut rng);
+        let mut ports: EphemeralPorts = EphemeralPorts::default();
 
         // Attempt to allocate a port.
-        if let Err(e) = ports.alloc_port(FIRST_PRIVATE_PORT) {
+        if let Err(e) = ports.reserve(FIRST_PRIVATE_PORT) {
             anyhow::bail!("failed to allocate an ephemeral port (error={:?})", &e);
         }
 
@@ -138,18 +167,17 @@ mod test {
     /// Attempts to allocate all ephemeral ports using [`EphemeralPorts::alloc_any`] and then release them.
     #[test]
     fn test_alloc_any_all() -> Result<()> {
-        let mut rng: SmallRng = SmallRng::seed_from_u64(0);
-        let mut ports: EphemeralPorts = EphemeralPorts::new(&mut rng);
+        let mut ports: EphemeralPorts = EphemeralPorts::default();
 
         // Allocate all ports.
         for _ in FIRST_PRIVATE_PORT..LAST_PRIVATE_PORT {
-            if let Err(e) = ports.alloc_any() {
+            if let Err(e) = ports.alloc() {
                 anyhow::bail!("failed to allocate an ephemeral port (error={:?})", &e);
             }
         }
 
         // All ports should be allocated.
-        if ports.alloc_any().is_ok() {
+        if ports.alloc().is_ok() {
             anyhow::bail!("all ports should be allocated");
         }
 
@@ -166,18 +194,17 @@ mod test {
     /// Attempts to allocate all ephemeral ports using [`EphemeralPorts::alloc_port`] and then release them.
     #[test]
     fn test_alloc_port_all() -> Result<()> {
-        let mut rng: SmallRng = SmallRng::seed_from_u64(0);
-        let mut ports: EphemeralPorts = EphemeralPorts::new(&mut rng);
+        let mut ports: EphemeralPorts = EphemeralPorts::default();
 
         // Allocate all ports.
         for port in FIRST_PRIVATE_PORT..LAST_PRIVATE_PORT {
-            if let Err(e) = ports.alloc_port(port) {
+            if let Err(e) = ports.reserve(port) {
                 anyhow::bail!("failed to allocate an ephemeral port (port={:?}, error={:?})", port, &e);
             }
         }
 
         // All ports should be allocated.
-        if ports.alloc_any().is_ok() {
+        if ports.alloc().is_ok() {
             anyhow::bail!("all ports should be allocated");
         }
 
@@ -194,8 +221,7 @@ mod test {
     /// Attempts to release a port that is not managed by the ephemeral port allocator.
     #[test]
     fn test_free_unmanaged_port() -> Result<()> {
-        let mut rng: SmallRng = SmallRng::seed_from_u64(0);
-        let mut ports: EphemeralPorts = EphemeralPorts::new(&mut rng);
+        let mut ports: EphemeralPorts = EphemeralPorts::default();
 
         // Attempt to free a port that is not in the pool.
         if ports.free(FIRST_PRIVATE_PORT).is_ok() {
@@ -208,8 +234,7 @@ mod test {
     /// Attempts to release a port that is not allocated.
     #[test]
     fn test_free_unallocated_port() -> Result<()> {
-        let mut rng: SmallRng = SmallRng::seed_from_u64(0);
-        let mut ports: EphemeralPorts = EphemeralPorts::new(&mut rng);
+        let mut ports: EphemeralPorts = EphemeralPorts::default();
 
         // Attempt to free a port that is not in the pool.
         if ports.free(FIRST_PRIVATE_PORT).is_ok() {

--- a/src/rust/runtime/network/mod.rs
+++ b/src/rust/runtime/network/mod.rs
@@ -21,6 +21,7 @@ use ::std::net::{
 
 pub mod config;
 pub mod consts;
+pub mod ephemeral;
 pub mod ring;
 pub mod socket;
 pub mod types;


### PR DESCRIPTION
This PR moves the ephemeral port allocator into the SharedDemiRuntime to avoid collisions when running more than one libOS. It also removes a lot of extraneous code and extra dependencies because the ephemeral port allocator is not in the inetstack any longer.