### PR TITLE
[runtime] Remove file descriptor from socket id data structure

### DIFF
--- a/src/rust/runtime/network/socket/mod.rs
+++ b/src/rust/runtime/network/socket/mod.rs
@@ -12,10 +12,7 @@ pub mod state;
 // Imports
 //======================================================================================================================
 
-use ::std::{
-    net::SocketAddrV4,
-    os::fd::RawFd,
-};
+use ::std::net::SocketAddrV4;
 
 //======================================================================================================================
 // Structures
@@ -25,5 +22,4 @@ use ::std::{
 pub enum SocketId {
     Active(SocketAddrV4, SocketAddrV4),
     Passive(SocketAddrV4),
-    FileDescriptor(RawFd),
 }


### PR DESCRIPTION
I added a file descriptor to the socket id data structure for demuxing from incoming I/O but it is not platform-agnostic.