### PR TITLE
[inetstack] Remove spurious wake ups

### DIFF
--- a/src/rust/inetstack/protocols/icmpv4/peer.rs
+++ b/src/rust/inetstack/protocols/icmpv4/peer.rs
@@ -276,7 +276,7 @@ impl<const N: usize> SharedIcmpv4Peer<N> {
         };
         let yielder: Yielder = Yielder::new();
         let clock_ref: SharedTimer = self.runtime.get_timer();
-        let timer = clock_ref.wait(timeout, yielder);
+        let timer = clock_ref.wait(timeout, &yielder);
         match rx.fuse().with_timeout(timer).await? {
             // Request completed successfully.
             Ok(_) => Ok(self.runtime.get_now() - t0),

--- a/src/rust/inetstack/protocols/tcp/established/background/acknowledger.rs
+++ b/src/rust/inetstack/protocols/tcp/established/background/acknowledger.rs
@@ -17,7 +17,7 @@ use ::futures::future::{
 };
 use ::std::time::Instant;
 
-pub async fn acknowledger<const N: usize>(mut cb: SharedControlBlock<N>) -> Result<!, Fail> {
+pub async fn acknowledger<const N: usize>(mut cb: SharedControlBlock<N>, yielder: Yielder) -> Result<!, Fail> {
     loop {
         // TODO: Implement TCP delayed ACKs, subject to restrictions from RFC 1122
         // - TCP should implement a delayed ACK
@@ -33,9 +33,8 @@ pub async fn acknowledger<const N: usize>(mut cb: SharedControlBlock<N>) -> Resu
         futures::pin_mut!(ack_deadline_changed);
 
         let clock_ref: SharedTimer = cb.get_timer();
-        let yielder: Yielder = Yielder::new();
         let ack_future = match deadline {
-            Some(t) => Either::Left(clock_ref.wait_until(t, yielder).fuse()),
+            Some(t) => Either::Left(clock_ref.wait_until(t, &yielder).fuse()),
             None => Either::Right(future::pending()),
         };
         futures::pin_mut!(ack_future);

--- a/src/rust/inetstack/protocols/tcp/established/background/acknowledger.rs
+++ b/src/rust/inetstack/protocols/tcp/established/background/acknowledger.rs
@@ -43,6 +43,11 @@ pub async fn acknowledger<const N: usize>(mut cb: SharedControlBlock<N>) -> Resu
         futures::select_biased! {
             _ = ack_deadline_changed => continue,
             _ = ack_future => {
+                match cb.get_ack_deadline().get() {
+                    Some(timeout) if timeout > cb.get_now() => continue,
+                    None => continue,
+                    _ => {},
+                }
                 cb.send_ack();
             },
         }

--- a/src/rust/inetstack/protocols/tcp/established/mod.rs
+++ b/src/rust/inetstack/protocols/tcp/established/mod.rs
@@ -46,14 +46,13 @@ pub struct EstablishedSocket<const N: usize> {
 impl<const N: usize> EstablishedSocket<N> {
     pub fn new(
         cb: SharedControlBlock<N>,
-        qd: QDesc,
         dead_socket_tx: mpsc::UnboundedSender<QDesc>,
         mut runtime: SharedDemiRuntime,
     ) -> Result<Self, Fail> {
         // TODO: Maybe add the queue descriptor here.
         let handle: TaskHandle = runtime.insert_background_coroutine(
             "Inetstack::TCP::established::background",
-            Box::pin(background::background(cb.clone(), qd, dead_socket_tx)),
+            Box::pin(background::background(cb.clone(), dead_socket_tx)),
         )?;
         Ok(Self {
             cb,

--- a/src/rust/inetstack/protocols/tcp/peer.rs
+++ b/src/rust/inetstack/protocols/tcp/peer.rs
@@ -277,7 +277,7 @@ impl<const N: usize> SharedTcpPeer<N> {
         let new_qd: QDesc = self.runtime.alloc_queue::<SharedTcpQueue<N>>(new_queue.clone());
         // Set up established socket data structure.
         let established: EstablishedSocket<N> =
-            EstablishedSocket::new(cb, new_qd, self.dead_socket_tx.clone(), self.runtime.clone())?;
+            EstablishedSocket::new(cb, self.dead_socket_tx.clone(), self.runtime.clone())?;
         let local: SocketAddrV4 = established.cb.get_local();
         let remote: SocketAddrV4 = established.cb.get_remote();
         // Set the socket in the new queue to established
@@ -358,7 +358,6 @@ impl<const N: usize> SharedTcpPeer<N> {
         let cb: SharedControlBlock<N> = socket.get_result(yielder).await?;
         let new_socket = Socket::Established(EstablishedSocket::new(
             cb,
-            qd,
             self.dead_socket_tx.clone(),
             self.runtime.clone(),
         )?);

--- a/src/rust/runtime/timer.rs
+++ b/src/rust/runtime/timer.rs
@@ -86,12 +86,12 @@ impl SharedTimer {
         self.now
     }
 
-    pub async fn wait(self, timeout: Duration, yielder: Yielder) -> Result<(), Fail> {
+    pub async fn wait(self, timeout: Duration, yielder: &Yielder) -> Result<(), Fail> {
         let now: Instant = self.now;
-        self.wait_until(now + timeout, yielder).await
+        self.wait_until(now + timeout, &yielder).await
     }
 
-    pub async fn wait_until(mut self, expiry: Instant, yielder: Yielder) -> Result<(), Fail> {
+    pub async fn wait_until(mut self, expiry: Instant, yielder: &Yielder) -> Result<(), Fail> {
         let entry = TimerQueueEntry {
             expiry,
             yielder: yielder.get_handle(),
@@ -206,7 +206,7 @@ mod tests {
         let timer_ref: SharedTimer = timer.clone();
         let yielder: Yielder = Yielder::new();
 
-        let wait_future1 = timer_ref.wait(Duration::from_secs(2), yielder);
+        let wait_future1 = timer_ref.wait(Duration::from_secs(2), &yielder);
         futures::pin_mut!(wait_future1);
 
         crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future1), &mut ctx).is_pending(), true);
@@ -217,7 +217,7 @@ mod tests {
         let timer_ref2: SharedTimer = timer.clone();
         let yielder2: Yielder = Yielder::new();
         crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future1), &mut ctx).is_pending(), true);
-        let wait_future2 = timer_ref2.wait(Duration::from_secs(1), yielder2);
+        let wait_future2 = timer_ref2.wait(Duration::from_secs(1), &yielder2);
         futures::pin_mut!(wait_future2);
 
         crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future1), &mut ctx).is_pending(), true);

--- a/src/rust/scheduler/handle.rs
+++ b/src/rust/scheduler/handle.rs
@@ -87,9 +87,7 @@ impl YielderHandle {
                 "wake_with(): already scheduled, overwriting result (old={:?})",
                 old_result
             );
-        }
-
-        if let Some(waker) = self.waker_handle.borrow_mut().take() {
+        } else if let Some(waker) = self.waker_handle.borrow_mut().take() {
             waker.wake();
         }
     }

--- a/src/rust/scheduler/scheduler.rs
+++ b/src/rust/scheduler/scheduler.rs
@@ -209,7 +209,10 @@ impl Scheduler {
             // Get the pinned ref.
             let pinned_ptr = {
                 let pin_slab_index: usize = Scheduler::get_pin_slab_index(waker_page_index, waker_page_offset);
-                let pinned_ref: Pin<&mut Box<dyn Task>> = self.tasks.get_pin_mut(pin_slab_index).unwrap();
+                let pinned_ref: Pin<&mut Box<dyn Task>> = self
+                    .tasks
+                    .get_pin_mut(pin_slab_index)
+                    .expect(format!("Invalid offset: {:?}", pin_slab_index).as_str());
                 let pinned_ptr = unsafe { Pin::into_inner_unchecked(pinned_ref) as *mut _ };
                 pinned_ptr
             };


### PR DESCRIPTION
Because all of the yielders in a single coroutine share a waker bit, we are prone to spurious wake ups when a coroutine becomes runnable. Specifically, we cannot distinguish between timeouts and watched values changing, causing us to send acks and retransmits far too frequently.