### PR TITLE
[inetstack] Move TCP stack to objects

### DIFF
--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -253,7 +253,7 @@ impl<const N: usize> InetStack<N> {
         // Search for target queue descriptor.
         match self.runtime.get_queue_type(&qd)? {
             QType::TcpSocket => {
-                let coroutine: Pin<Box<Operation>> = self.ipv4.tcp.accept(qd);
+                let coroutine: Pin<Box<Operation>> = self.ipv4.tcp.accept(qd)?;
                 let task_id: String = format!("Inetstack::TCP::accept for qd={:?}", qd);
                 let handle: TaskHandle = self.runtime.insert_coroutine(task_id.as_str(), coroutine)?;
                 Ok(handle.get_task_id().into())
@@ -285,7 +285,7 @@ impl<const N: usize> InetStack<N> {
 
         match self.runtime.get_queue_type(&qd)? {
             QType::TcpSocket => {
-                let coroutine: Pin<Box<Operation>> = self.ipv4.tcp.connect(qd, remote);
+                let coroutine: Pin<Box<Operation>> = self.ipv4.tcp.connect(qd, remote)?;
                 let task_id: String = format!("Inetstack::TCP::connect for qd={:?}", qd);
                 let handle: TaskHandle = self.runtime.insert_coroutine(task_id.as_str(), coroutine)?;
                 Ok(handle.get_task_id().into())
@@ -334,7 +334,7 @@ impl<const N: usize> InetStack<N> {
         let (task_id, coroutine): (String, Pin<Box<Operation>>) = match self.runtime.get_queue_type(&qd)? {
             QType::TcpSocket => {
                 let task_id: String = format!("Inetstack::TCP::close for qd={:?}", qd);
-                let coroutine: Pin<Box<Operation>> = self.ipv4.tcp.async_close(qd);
+                let coroutine: Pin<Box<Operation>> = self.ipv4.tcp.async_close(qd)?;
                 (task_id, coroutine)
             },
             QType::UdpSocket => {
@@ -365,7 +365,7 @@ impl<const N: usize> InetStack<N> {
     pub fn do_push(&mut self, qd: QDesc, buf: DemiBuffer) -> Result<TaskHandle, Fail> {
         match self.runtime.get_queue_type(&qd)? {
             QType::TcpSocket => {
-                let coroutine: Pin<Box<Operation>> = self.ipv4.tcp.push(qd, buf);
+                let coroutine: Pin<Box<Operation>> = self.ipv4.tcp.push(qd, buf)?;
                 let task_id: String = format!("Inetstack::TCP::push for qd={:?}", qd);
                 self.runtime.insert_coroutine(task_id.as_str(), coroutine)
             },
@@ -443,7 +443,7 @@ impl<const N: usize> InetStack<N> {
         let (task_id, coroutine): (String, Pin<Box<Operation>>) = match self.runtime.get_queue_type(&qd)? {
             QType::TcpSocket => {
                 let task_id: String = format!("Inetstack::TCP::pop for qd={:?}", qd);
-                let coroutine: Pin<Box<Operation>> = self.ipv4.tcp.pop(qd, size);
+                let coroutine: Pin<Box<Operation>> = self.ipv4.tcp.pop(qd, size)?;
                 (task_id, coroutine)
             },
             QType::UdpSocket => {

--- a/src/rust/inetstack/protocols/tcp/established/sender.rs
+++ b/src/rust/inetstack/protocols/tcp/established/sender.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use super::SharedControlBlock;
 use crate::{
     inetstack::protocols::tcp::{
+        established::SharedControlBlock,
         segment::TcpHeader,
         SeqNumber,
     },

--- a/src/rust/inetstack/protocols/tcp/peer.rs
+++ b/src/rust/inetstack/protocols/tcp/peer.rs
@@ -5,28 +5,14 @@
 // Imports
 //======================================================================================================================
 
-use super::{
-    active_open::SharedActiveOpenSocket,
-    established::EstablishedSocket,
-    isn_generator::IsnGenerator,
-    passive_open::SharedPassiveSocket,
-    queue::SharedTcpQueue,
-};
 use crate::{
     inetstack::protocols::{
         arp::SharedArpPeer,
-        ethernet2::{
-            EtherType2,
-            Ethernet2Header,
-        },
-        ip::IpProtocol,
         ipv4::Ipv4Header,
         tcp::{
-            established::SharedControlBlock,
-            segment::{
-                TcpHeader,
-                TcpSegment,
-            },
+            isn_generator::IsnGenerator,
+            queue::SharedTcpQueue,
+            segment::TcpHeader,
             SeqNumber,
         },
     },
@@ -39,6 +25,7 @@ use crate::{
             types::MacAddress,
             NetworkRuntime,
         },
+        queue::NetworkQueue,
         Operation,
         OperationResult,
         QDesc,
@@ -70,18 +57,6 @@ use ::std::{
 
 #[cfg(feature = "profiler")]
 use crate::timer;
-
-//======================================================================================================================
-// Enumerations
-//======================================================================================================================
-
-pub enum Socket<const N: usize> {
-    Inactive(Option<SocketAddrV4>),
-    Listening(SharedPassiveSocket<N>),
-    Connecting(SharedActiveOpenSocket<N>),
-    Established(EstablishedSocket<N>),
-    Closing(EstablishedSocket<N>),
-}
 
 //======================================================================================================================
 // Structures
@@ -132,16 +107,23 @@ impl<const N: usize> SharedTcpPeer<N> {
         })))
     }
 
-    /// Opens a TCP socket.
+    /// Creates a TCP socket.
     pub fn socket(&mut self) -> Result<QDesc, Fail> {
         #[cfg(feature = "profiler")]
         timer!("tcp::socket");
-        let new_qd: QDesc = self
-            .runtime
-            .alloc_queue::<SharedTcpQueue<N>>(SharedTcpQueue::<N>::new());
+        let new_queue: SharedTcpQueue<N> = SharedTcpQueue::<N>::new(
+            self.runtime.clone(),
+            self.transport.clone(),
+            self.local_link_addr,
+            self.tcp_config.clone(),
+            self.arp.clone(),
+            self.dead_socket_tx.clone(),
+        );
+        let new_qd: QDesc = self.runtime.alloc_queue::<SharedTcpQueue<N>>(new_queue);
         Ok(new_qd)
     }
 
+    /// Binds a socket to a local address supplied by [local].
     pub fn bind(&mut self, qd: QDesc, local: SocketAddrV4) -> Result<(), Fail> {
         // Check if we are binding to the wildcard address.
         // FIXME: https://github.com/demikernel/demikernel/issues/189
@@ -175,20 +157,7 @@ impl<const N: usize> SharedTcpPeer<N> {
         }
 
         // Issue operation.
-        let ret: Result<(), Fail> = {
-            let mut queue: SharedTcpQueue<N> = self.get_shared_queue(&qd)?;
-            match queue.get_socket() {
-                Socket::Inactive(None) => {
-                    queue.set_socket(Socket::Inactive(Some(local)));
-                    Ok(())
-                },
-                Socket::Inactive(_) => Err(Fail::new(libc::EINVAL, "socket is already bound to an address")),
-                Socket::Listening(_) => return Err(Fail::new(libc::EINVAL, "socket is already listening")),
-                Socket::Connecting(_) => return Err(Fail::new(libc::EINVAL, "socket is connecting")),
-                Socket::Established(_) => return Err(Fail::new(libc::EINVAL, "socket is connected")),
-                Socket::Closing(_) => return Err(Fail::new(libc::EINVAL, "socket is closed")),
-            }
-        };
+        let ret: Result<(), Fail> = self.get_shared_queue(&qd)?.bind(local);
 
         // Handle return value.
         match ret {
@@ -210,351 +179,193 @@ impl<const N: usize> SharedTcpPeer<N> {
 
     // Marks the target socket as passive.
     pub fn listen(&mut self, qd: QDesc, backlog: usize) -> Result<(), Fail> {
-        // This code borrows a reference to inner, instead of the entire self structure,
-        // so we can still borrow self later.
         // Get bound address while checking for several issues.
+        // Check if there isn't a socket listening on this address/port pair.
         let mut queue: SharedTcpQueue<N> = self.get_shared_queue(&qd)?;
-        match queue.get_mut_socket() {
-            Socket::Inactive(Some(local)) => {
-                // Check if there isn't a socket listening on this address/port pair.
-                if let Some(existing_qd) = self.runtime.get_qd_from_socket_id(&SocketId::Passive(*local)) {
-                    if existing_qd != qd {
-                        return Err(Fail::new(
-                            libc::EADDRINUSE,
-                            "another socket is already listening on the same address/port pair",
-                        ));
-                    }
+        if let Some(local) = queue.local() {
+            if let Some(existing_qd) = self.runtime.get_qd_from_socket_id(&SocketId::Passive(local)) {
+                if existing_qd != qd {
+                    return Err(Fail::new(
+                        libc::EADDRINUSE,
+                        "another socket is already listening on the same address/port pair",
+                    ));
                 }
-
-                let nonce: u32 = self.rng.gen();
-                let socket = SharedPassiveSocket::new(
-                    *local,
-                    backlog,
-                    self.runtime.clone(),
-                    self.transport.clone(),
-                    self.tcp_config.clone(),
-                    self.local_link_addr,
-                    self.arp.clone(),
-                    nonce,
-                );
-                queue.set_socket(Socket::Listening(socket));
-                Ok(())
-            },
-            Socket::Inactive(None) => {
-                return Err(Fail::new(libc::EDESTADDRREQ, "socket is not bound to a local address"))
-            },
-            Socket::Listening(_) => return Err(Fail::new(libc::EINVAL, "socket is already listening")),
-            Socket::Connecting(_) => return Err(Fail::new(libc::EINVAL, "socket is connecting")),
-            Socket::Established(_) => return Err(Fail::new(libc::EINVAL, "socket is connected")),
-            Socket::Closing(_) => return Err(Fail::new(libc::EINVAL, "socket is closed")),
+            }
+            let nonce: u32 = self.rng.gen();
+            queue.listen(backlog, nonce)
+        } else {
+            Err(Fail::new(libc::EDESTADDRREQ, "socket is not bound to a local address"))
         }
     }
 
     /// Sets up the coroutine for accepting a new connection.
-    pub fn accept(&self, qd: QDesc) -> Pin<Box<Operation>> {
+    pub fn accept(&self, qd: QDesc) -> Result<Pin<Box<Operation>>, Fail> {
         let yielder: Yielder = Yielder::new();
-        let peer: Self = self.clone();
-        Box::pin(async move {
-            // Wait for accept to complete.
-            // Handle result: If unsuccessful, free the new queue descriptor.
-            match peer.accept_coroutine(qd, yielder).await {
-                Ok((new_qd, addr)) => (qd, OperationResult::Accept((new_qd, addr))),
-                Err(e) => (qd, OperationResult::Failed(e)),
-            }
-        })
-    }
-
-    /// Coroutine to asynchronously accept an incoming connection.
-    pub async fn accept_coroutine(mut self, qd: QDesc, yielder: Yielder) -> Result<(QDesc, SocketAddrV4), Fail> {
-        // Create queue structure.
-        let mut new_queue: SharedTcpQueue<N> = SharedTcpQueue::<N>::new();
-        // Wait for a new connection on the listening socket.
-        let cb: SharedControlBlock<N> = match self.get_shared_queue(&qd)?.get_mut_socket() {
-            Socket::Listening(socket) => socket.accept(yielder).await?,
-            _ => return Err(Fail::new(libc::EOPNOTSUPP, "socket not listening")),
-        };
-        // Insert queue into queue table and get new queue descriptor.
-        let new_qd: QDesc = self.runtime.alloc_queue::<SharedTcpQueue<N>>(new_queue.clone());
-        // Set up established socket data structure.
-        let established: EstablishedSocket<N> =
-            EstablishedSocket::new(cb, self.dead_socket_tx.clone(), self.runtime.clone())?;
-        let local: SocketAddrV4 = established.cb.get_local();
-        let remote: SocketAddrV4 = established.cb.get_remote();
-        // Set the socket in the new queue to established
-        new_queue.set_socket(Socket::Established(established));
-        // Insert new connection into the backmap of addresses to queues.
-        if self
-            .runtime
-            .insert_socket_id_to_qd(SocketId::Active(local, remote), new_qd)
-            .is_some()
-        {
-            panic!("duplicate queue descriptor in established sockets table");
-        }
-        // TODO: Reset the connection if the following following check fails, instead of panicking.
-        Ok((new_qd, remote))
-    }
-
-    pub fn connect(&mut self, qd: QDesc, remote: SocketAddrV4) -> Pin<Box<Operation>> {
-        let yielder: Yielder = Yielder::new();
-        let peer: Self = self.clone();
-        Box::pin(async move {
-            // Wait for accept to complete.
-            // Handle result: If unsuccessful, free the new queue descriptor.
-            match peer.connect_coroutine(qd, remote, yielder).await {
-                Ok(()) => (qd, OperationResult::Connect),
-                Err(e) => (qd, OperationResult::Failed(e)),
-            }
-        })
-    }
-
-    pub async fn connect_coroutine(mut self, qd: QDesc, remote: SocketAddrV4, yielder: Yielder) -> Result<(), Fail> {
-        // Get local address bound to socket.
         let mut queue: SharedTcpQueue<N> = self.get_shared_queue(&qd)?;
-
-        let (socket, local): (SharedActiveOpenSocket<N>, SocketAddrV4) = match queue.get_socket() {
-            Socket::Inactive(local_socket) => {
-                let local: SocketAddrV4 = match local_socket {
-                    Some(local) => local.clone(),
-                    None => {
-                        // TODO: we should free this when closing.
-                        let local_port: u16 = self.runtime.alloc_ephemeral_port()?;
-                        SocketAddrV4::new(self.local_ipv4_addr, local_port)
-                    },
-                };
-                // Create active socket.
-                let local_isn: SeqNumber = self.isn_generator.generate(&local, &remote);
-                (
-                    SharedActiveOpenSocket::new(
-                        local_isn,
-                        local,
-                        remote,
-                        self.runtime.clone(),
-                        self.transport.clone(),
-                        self.tcp_config.clone(),
-                        self.local_link_addr,
-                        self.arp.clone(),
-                    )?,
-                    local,
-                )
-            },
-            Socket::Listening(_) => return Err(Fail::new(libc::EOPNOTSUPP, "socket is listening")),
-            Socket::Connecting(_) => return Err(Fail::new(libc::EALREADY, "socket is connecting")),
-            Socket::Established(_) => return Err(Fail::new(libc::EISCONN, "socket is connected")),
-            Socket::Closing(_) => return Err(Fail::new(libc::EINVAL, "socket is closed")),
-        };
-        // Update socket state.
-        queue.set_socket(Socket::Connecting(socket.clone()));
-        if let Some(existing_qd) = self
-            .runtime
-            .insert_socket_id_to_qd(SocketId::Active(local, remote.clone()), qd)
-        {
-            // We should panic here because the ephemeral port allocator should not allocate the same port more than
-            // once.
-            panic!(
-                "There is already a queue listening on this queue descriptor {:?}",
-                existing_qd
-            );
-        }
-        let cb: SharedControlBlock<N> = socket.get_result(yielder).await?;
-        let new_socket = Socket::Established(EstablishedSocket::new(
-            cb,
-            self.dead_socket_tx.clone(),
-            self.runtime.clone(),
-        )?);
-        queue.set_socket(new_socket);
-        Ok(())
+        let mut runtime: SharedDemiRuntime = self.runtime.clone();
+        Ok(Box::pin(async move {
+            // Wait for accept to complete.
+            // Handle result: If successful, allocate a new queue.
+            match queue.accept(yielder).await {
+                Ok(new_queue) => {
+                    let endpoints: (SocketAddrV4, SocketAddrV4) = match new_queue.endpoints() {
+                        Ok(endpoints) => endpoints,
+                        Err(e) => return (qd, OperationResult::Failed(e)),
+                    };
+                    let new_qd: QDesc = runtime.alloc_queue::<SharedTcpQueue<N>>(new_queue.clone());
+                    if let Some(existing_qd) =
+                        runtime.insert_socket_id_to_qd(SocketId::Active(endpoints.0, endpoints.1), new_qd)
+                    {
+                        // We should panic here because the ephemeral port allocator should not allocate the same port more than
+                        // once.
+                        unreachable!(
+                            "There is already a queue listening on this queue descriptor {:?}",
+                            existing_qd
+                        );
+                    }
+                    (qd, OperationResult::Accept((new_qd, endpoints.1)))
+                },
+                Err(e) => (qd, OperationResult::Failed(e)),
+            }
+        }))
     }
 
-    /// TODO: Should probably check for valid queue descriptor before we schedule the future
-    pub fn push(&self, qd: QDesc, buf: DemiBuffer) -> Pin<Box<Operation>> {
-        let result: Result<(), Fail> = match self.get_shared_queue(&qd) {
-            Ok(mut queue) => match queue.get_mut_socket() {
-                Socket::Established(socket) => socket.send(buf),
-                _ => Err(Fail::new(libc::ENOTCONN, "connection not established")),
-            },
-            Err(e) => Err(e),
+    /// Sets up the coroutine for connecting the socket to [remote].
+    pub fn connect(&mut self, qd: QDesc, remote: SocketAddrV4) -> Result<Pin<Box<Operation>>, Fail> {
+        let yielder: Yielder = Yielder::new();
+        let mut queue: SharedTcpQueue<N> = self.get_shared_queue(&qd)?;
+        let local: SocketAddrV4 = {
+            // TODO: we should free this when closing.
+            let local_port: u16 = self.runtime.alloc_ephemeral_port()?;
+            SocketAddrV4::new(self.local_ipv4_addr, local_port)
         };
-        Box::pin(async move {
-            // Wait for accept to complete.
-            // Handle result: If unsuccessful, free the new queue descriptor.
+        let local_isn: SeqNumber = self.isn_generator.generate(&local, &remote);
+        let mut peer: SharedTcpPeer<N> = self.clone();
+        Ok(Box::pin(async move {
+            // Wait for connect to complete.
+            if let Some(existing_qd) = peer
+                .runtime
+                .insert_socket_id_to_qd(SocketId::Active(local, remote.clone()), qd)
+            {
+                // We should panic here because the ephemeral port allocator should not allocate the same port more than
+                // once.
+                unreachable!(
+                    "There is already a queue listening on this queue descriptor {:?}",
+                    existing_qd
+                );
+            }
+            match queue.connect(local, remote, local_isn, yielder).await {
+                Ok(()) => (qd, OperationResult::Connect),
+                Err(e) => {
+                    peer.runtime
+                        .remove_socket_id_to_qd(&SocketId::Active(local, remote.clone()));
+                    (qd, OperationResult::Failed(e))
+                },
+            }
+        }))
+    }
+
+    /// Pushes immediately to the socket and returns the result asynchronously.
+    pub fn push(&self, qd: QDesc, buf: DemiBuffer) -> Result<Pin<Box<Operation>>, Fail> {
+        let mut queue: SharedTcpQueue<N> = self.get_shared_queue(&qd)?;
+        let result: Result<(), Fail> = queue.push(buf);
+        Ok(Box::pin(async move {
+            // Wait for push to complete.
             match result {
                 Ok(()) => (qd, OperationResult::Push),
                 Err(e) => (qd, OperationResult::Failed(e)),
             }
-        })
+        }))
     }
 
-    /// TODO: Should probably check for valid queue descriptor before we schedule the future
-    pub fn pop(&self, qd: QDesc, size: Option<usize>) -> Pin<Box<Operation>> {
+    /// Sets up a coroutine for popping data from the socket.
+    pub fn pop(&self, qd: QDesc, size: Option<usize>) -> Result<Pin<Box<Operation>>, Fail> {
         let yielder: Yielder = Yielder::new();
-        let peer: Self = self.clone();
-        Box::pin(async move {
-            // Wait for accept to complete.
-            // Handle result: If unsuccessful, free the new queue descriptor.
-            match peer.pop_coroutine(qd, size, yielder).await {
-                Ok(buf) => (qd, OperationResult::Pop(None, buf)),
-                Err(e) => (qd, OperationResult::Failed(e)),
-            }
-        })
-    }
-
-    pub async fn pop_coroutine(self, qd: QDesc, size: Option<usize>, yielder: Yielder) -> Result<DemiBuffer, Fail> {
         // Get local address bound to socket.
         let mut queue: SharedTcpQueue<N> = self.get_shared_queue(&qd)?;
 
-        match queue.get_mut_socket() {
-            Socket::Established(socket) => socket.pop(size, yielder).await,
-            Socket::Closing(_) => Err(Fail::new(libc::EBADF, "socket closing")),
-            Socket::Connecting(_) => Err(Fail::new(libc::EINPROGRESS, "socket connecting")),
-            Socket::Inactive(_) => Err(Fail::new(libc::EBADF, "socket inactive")),
-            Socket::Listening(_) => Err(Fail::new(libc::ENOTCONN, "socket listening")),
-        }
+        Ok(Box::pin(async move {
+            // Wait for pop to complete.
+            match queue.pop(size, yielder).await {
+                Ok(buf) => (qd, OperationResult::Pop(None, buf)),
+                Err(e) => (qd, OperationResult::Failed(e)),
+            }
+        }))
     }
 
     /// Closes a TCP socket.
     pub fn close(&mut self, qd: QDesc) -> Result<(), Fail> {
+        trace!("Closing socket: qd={:?}", qd);
         // TODO: Currently we do not handle close correctly because we continue to receive packets at this point to finish the TCP close protocol.
         // 1. We do not remove the endpoint from the addresses table
         // 2. We do not remove the queue from the queue table.
         // As a result, we have stale closed queues that are labelled as closing. We should clean these up.
         // look up socket
         let mut queue: SharedTcpQueue<N> = self.get_shared_queue(&qd)?;
-
-        let (addr, result): (SocketAddrV4, Result<(), Fail>) = match queue.get_mut_socket() {
-            // Closing an active socket.
-            Socket::Established(socket) => {
-                socket.close()?;
-                // Only using a clone here because we need to read and write the socket.
-                self.get_shared_queue(&qd)?.set_socket(Socket::Closing(socket.clone()));
-                return Ok(());
-            },
-            // Closing an unbound socket.
-            Socket::Inactive(None) => {
-                return Ok(());
-            },
-            // Closing a bound socket.
-            Socket::Inactive(Some(addr)) => (addr.clone(), Ok(())),
-            // Closing a listening socket.
-            Socket::Listening(socket) => {
-                let cause: String = format!("cannot close a listening socket (qd={:?})", qd);
-                error!("do_close(): {}", &cause);
-                (socket.endpoint(), Err(Fail::new(libc::ENOTSUP, &cause)))
-            },
-            // Closing a connecting socket.
-            Socket::Connecting(_) => {
-                let cause: String = format!("cannot close a connecting socket (qd={:?})", qd);
-                error!("do_close(): {}", &cause);
-                return Err(Fail::new(libc::ENOTSUP, &cause));
-            },
-            // Closing a closing socket.
-            Socket::Closing(_) => {
-                let cause: String = format!("cannot close a socket that is closing (qd={:?})", qd);
-                error!("do_close(): {}", &cause);
-                return Err(Fail::new(libc::ENOTSUP, &cause));
-            },
-        };
-
-        // TODO: remove active sockets from the addresses table.
-        match self.runtime.remove_socket_id_to_qd(&SocketId::Passive(addr)) {
-            Some(existing_qd) if existing_qd == qd => {},
-            _ => return Err(Fail::new(libc::EINVAL, "socket id did not map to this qd!")),
-        };
-        result
-    }
-
-    /// Closes a TCP socket.
-    pub fn async_close(&self, qd: QDesc) -> Pin<Box<Operation>> {
-        let yielder: Yielder = Yielder::new();
-        let peer: Self = self.clone();
-        Box::pin(async move {
-            // Wait for accept to complete.
-            // Handle result: If unsuccessful, free the new queue descriptor.
-            match peer.close_coroutine(qd, yielder).await {
-                Ok(()) => (qd, OperationResult::Close),
-                Err(e) => (qd, OperationResult::Failed(e)),
-            }
-        })
-    }
-
-    pub async fn close_coroutine(mut self, qd: QDesc, _: Yielder) -> Result<(), Fail> {
-        let mut queue: SharedTcpQueue<N> = self.get_shared_queue(&qd)?;
-        match queue.get_mut_socket() {
-            // Closing an active socket.
-            Socket::Established(socket) => {
-                // Send FIN
-                socket.close()?;
-                // Move socket to closing state
-                // Only using a clone here because we need to read and write the socket.
-                self.get_shared_queue(&qd)?.set_socket(Socket::Closing(socket.clone()));
-                // TODO: Wait for the close protocol to finish here.
-                // Remove address from backmap.
-                match self
-                    .runtime
-                    .remove_socket_id_to_qd(&SocketId::Active(socket.endpoints().0, socket.endpoints().1))
-                {
-                    Some(existing_qd) if existing_qd == qd => {},
-                    _ => return Err(Fail::new(libc::EINVAL, "socket id did not map to this qd!")),
-                };
-            },
-            // Closing an unbound socket.
-            Socket::Inactive(None) => {},
-            Socket::Inactive(Some(addr)) => {
-                // Remove address from backmap.
-                match self.runtime.remove_socket_id_to_qd(&SocketId::Passive(addr.clone())) {
-                    Some(existing_qd) if existing_qd == qd => {},
-                    _ => return Err(Fail::new(libc::EINVAL, "socket id did not map to this qd!")),
-                };
-            },
-            // Closing a listening socket.
-            Socket::Listening(_) => {
-                // TODO: Remove this address from the addresses table
-                let cause: String = format!("cannot close a listening socket (qd={:?})", qd);
-                error!("do_close(): {}", &cause);
-                return Err(Fail::new(libc::ENOTSUP, &cause));
-            },
-            // Closing a connecting socket.
-            Socket::Connecting(_) => {
-                let cause: String = format!("cannot close a connecting socket (qd={:?})", qd);
-                error!("do_close(): {}", &cause);
-                return Err(Fail::new(libc::ENOTSUP, &cause));
-            },
-            // Closing a closing socket.
-            Socket::Closing(_) => {
-                let cause: String = format!("cannot close a socket that is closing (qd={:?})", qd);
-                error!("do_close(): {}", &cause);
-                return Err(Fail::new(libc::ENOTSUP, &cause));
-            },
-        };
-        // Free the queue.
-        self.runtime
-            .free_queue::<SharedTcpQueue<N>>(&qd)
-            .expect("queue should exist");
+        queue.close()?;
+        // TODO: Uncomment this when we have moved totally to async close.
+        // FIXME: https://github.com/microsoft/demikernel/issues/224
+        // if let Some(socket_id) = queue.close()? {
+        //     match self.runtime.remove_socket_id_to_qd(&socket_id) {
+        //         Some(existing_qd) if existing_qd == qd => {},
+        //         _ => return Err(Fail::new(libc::EINVAL, "socket id did not map to this qd!")),
+        //     };
+        // }
+        // // Free the queue.
+        // self.runtime
+        //     .free_queue::<SharedTcpQueue<N>>(&qd)
+        //     .expect("queue should exist");
 
         Ok(())
     }
 
+    /// Closes a TCP socket.
+    pub fn async_close(&self, qd: QDesc) -> Result<Pin<Box<Operation>>, Fail> {
+        trace!("Closing socket: qd={:?}", qd);
+        let yielder: Yielder = Yielder::new();
+        let mut queue: SharedTcpQueue<N> = self.get_shared_queue(&qd)?;
+        let mut peer: SharedTcpPeer<N> = self.clone();
+        Ok(Box::pin(async move {
+            // Wait for accept to complete.
+            // Handle result: If unsuccessful, free the new queue descriptor.
+            match queue.async_close(yielder).await {
+                Ok(socket_id) => {
+                    if let Some(socket_id) = socket_id {
+                        match peer.runtime.remove_socket_id_to_qd(&socket_id) {
+                            Some(existing_qd) if existing_qd == qd => {},
+                            _ => {
+                                return (
+                                    qd,
+                                    OperationResult::Failed(Fail::new(
+                                        libc::EINVAL,
+                                        "socket id did not map to this qd!",
+                                    )),
+                                )
+                            },
+                        }
+                    }
+                    // Free the queue.
+                    peer.runtime
+                        .free_queue::<SharedTcpQueue<N>>(&qd)
+                        .expect("queue should exist");
+
+                    (qd, OperationResult::Close)
+                },
+                Err(e) => (qd, OperationResult::Failed(e)),
+            }
+        }))
+    }
+
     pub fn remote_mss(&self, qd: QDesc) -> Result<usize, Fail> {
-        let queue: SharedTcpQueue<N> = self.get_shared_queue(&qd)?;
-        match queue.get_socket() {
-            Socket::Established(socket) => Ok(socket.remote_mss()),
-            _ => Err(Fail::new(libc::ENOTCONN, "connection not established")),
-        }
+        self.get_shared_queue(&qd)?.remote_mss()
     }
 
     pub fn current_rto(&self, qd: QDesc) -> Result<Duration, Fail> {
-        let queue: SharedTcpQueue<N> = self.get_shared_queue(&qd)?;
-        match queue.get_socket() {
-            Socket::Established(socket) => Ok(socket.current_rto()),
-            _ => return Err(Fail::new(libc::ENOTCONN, "connection not established")),
-        }
+        self.get_shared_queue(&qd)?.current_rto()
     }
 
     pub fn endpoints(&self, qd: QDesc) -> Result<(SocketAddrV4, SocketAddrV4), Fail> {
-        let queue: SharedTcpQueue<N> = self.get_shared_queue(&qd)?;
-        match queue.get_socket() {
-            Socket::Established(socket) => Ok(socket.endpoints()),
-            _ => Err(Fail::new(libc::ENOTCONN, "connection not established")),
-        }
+        self.get_shared_queue(&qd)?.endpoints()
     }
 
     fn get_shared_queue(&self, qd: &QDesc) -> Result<SharedTcpQueue<N>, Fail> {
@@ -589,105 +400,8 @@ impl<const N: usize> SharedTcpPeer<N> {
         };
 
         // Dispatch to further processing depending on the socket state.
-        // It is safe to call expect() here because qd must be on the queue table.
-        let mut queue: SharedTcpQueue<N> = self.get_shared_queue(&qd)?;
-        match queue.get_mut_socket() {
-            Socket::Established(socket) => {
-                debug!("Routing to established connection: {:?}", socket.endpoints());
-                socket.receive(&mut tcp_hdr, data);
-                return Ok(());
-            },
-            Socket::Connecting(socket) => {
-                debug!("Routing to connecting connection: {:?}", socket.endpoints());
-                socket.receive(&tcp_hdr);
-                return Ok(());
-            },
-            Socket::Listening(socket) => {
-                debug!("Routing to passive connection: {:?}", local);
-                match socket.receive(ip_hdr, &tcp_hdr) {
-                    Ok(()) => return Ok(()),
-                    // Connection was refused.
-                    Err(e) if e.errno == libc::ECONNREFUSED => {
-                        // Fall through and send a RST segment back.
-                    },
-                    Err(e) => return Err(e),
-                }
-            },
-            // The segment is for an inactive connection.
-            Socket::Inactive(_) => {
-                debug!("Routing to inactive connection: {:?}", local);
-                // Fall through and send a RST segment back.
-            },
-            Socket::Closing(socket) => {
-                debug!("Routing to closing connection: {:?}", socket.endpoints());
-                socket.receive(&mut tcp_hdr, data);
-                return Ok(());
-            },
-        }
-
-        // Generate the RST segment accordingly to the ACK field.
-        // If the incoming segment has an ACK field, the reset takes its
-        // sequence number from the ACK field of the segment, otherwise the
-        // reset has sequence number zero and the ACK field is set to the sum
-        // of the sequence number and segment length of the incoming segment.
-        // Reference: https://datatracker.ietf.org/doc/html/rfc793#section-3.4
-        let (seq_num, ack_num): (SeqNumber, Option<SeqNumber>) = if tcp_hdr.ack {
-            (tcp_hdr.ack_num, None)
-        } else {
-            (
-                SeqNumber::from(0),
-                Some(tcp_hdr.seq_num + SeqNumber::from(tcp_hdr.compute_size() as u32)),
-            )
-        };
-
-        debug!("receive(): sending RST (local={:?}, remote={:?})", local, remote);
-        self.send_rst(&local, &remote, seq_num, ack_num)?;
-        Ok(())
-    }
-
-    /// Sends a RST segment from `local` to `remote`.
-    pub fn send_rst(
-        &mut self,
-        local: &SocketAddrV4,
-        remote: &SocketAddrV4,
-        seq_num: SeqNumber,
-        ack_num: Option<SeqNumber>,
-    ) -> Result<(), Fail> {
-        // Query link address for destination.
-        let dst_link_addr: MacAddress = match self.arp.try_query(remote.ip().clone()) {
-            Some(link_addr) => link_addr,
-            None => {
-                // ARP query is unlikely to fail, but if it does, don't send the RST segment,
-                // and return an error to server side.
-                let cause: String = format!("missing ARP entry (remote={})", remote.ip());
-                error!("send_rst(): {}", &cause);
-                return Err(Fail::new(libc::EHOSTUNREACH, &cause));
-            },
-        };
-
-        // Create a RST segment.
-        let segment: TcpSegment = {
-            let mut tcp_hdr: TcpHeader = TcpHeader::new(local.port(), remote.port());
-            tcp_hdr.rst = true;
-            tcp_hdr.seq_num = seq_num;
-            if let Some(ack_num) = ack_num {
-                tcp_hdr.ack = true;
-                tcp_hdr.ack_num = ack_num;
-            }
-            TcpSegment {
-                ethernet2_hdr: Ethernet2Header::new(dst_link_addr, self.local_link_addr, EtherType2::Ipv4),
-                ipv4_hdr: Ipv4Header::new(local.ip().clone(), remote.ip().clone(), IpProtocol::TCP),
-                tcp_hdr,
-                data: None,
-                tx_checksum_offload: self.tcp_config.get_rx_checksum_offload(),
-            }
-        };
-
-        // Send it.
-        let pkt: Box<TcpSegment> = Box::new(segment);
-        self.transport.transmit(pkt);
-
-        Ok(())
+        self.get_shared_queue(&qd)?
+            .receive(&ip_hdr, &mut tcp_hdr, &local, &remote, data)
     }
 }
 

--- a/src/rust/inetstack/protocols/tcp/queue.rs
+++ b/src/rust/inetstack/protocols/tcp/queue.rs
@@ -5,19 +5,71 @@
 // Imports
 //======================================================================================================================
 
-use super::peer::Socket;
-use crate::runtime::{
-    queue::IoQueue,
-    QType,
-    SharedObject,
+use crate::{
+    inetstack::{
+        protocols::{
+            ethernet2::{
+                EtherType2,
+                Ethernet2Header,
+            },
+            ip::IpProtocol,
+            ipv4::Ipv4Header,
+            tcp::{
+                active_open::SharedActiveOpenSocket,
+                established::EstablishedSocket,
+                passive_open::SharedPassiveSocket,
+                segment::{
+                    TcpHeader,
+                    TcpSegment,
+                },
+                SeqNumber,
+            },
+        },
+        MacAddress,
+        SharedArpPeer,
+        TcpConfig,
+    },
+    runtime::{
+        fail::Fail,
+        memory::DemiBuffer,
+        network::{
+            socket::SocketId,
+            NetworkRuntime,
+        },
+        queue::{
+            IoQueue,
+            NetworkQueue,
+        },
+        QDesc,
+        QType,
+        SharedBox,
+        SharedDemiRuntime,
+        SharedObject,
+    },
+    scheduler::Yielder,
 };
+use ::futures::channel::mpsc;
 use ::std::{
     any::Any,
+    net::SocketAddrV4,
     ops::{
         Deref,
         DerefMut,
     },
+    time::Duration,
 };
+
+//======================================================================================================================
+// Enumerations
+//======================================================================================================================
+
+pub enum Socket<const N: usize> {
+    Inactive(Option<SocketAddrV4>),
+    Listening(SharedPassiveSocket<N>),
+    Connecting(SharedActiveOpenSocket<N>),
+    Established(EstablishedSocket<N>),
+    Closing(EstablishedSocket<N>),
+}
 
 //======================================================================================================================
 // Structures
@@ -26,6 +78,12 @@ use ::std::{
 /// Per-queue metadata for the TCP socket.
 pub struct TcpQueue<const N: usize> {
     socket: Socket<N>,
+    runtime: SharedDemiRuntime,
+    transport: SharedBox<dyn NetworkRuntime<N>>,
+    local_link_addr: MacAddress,
+    tcp_config: TcpConfig,
+    arp: SharedArpPeer<N>,
+    dead_socket_tx: mpsc::UnboundedSender<QDesc>,
 }
 
 #[derive(Clone)]
@@ -37,25 +95,341 @@ pub struct SharedTcpQueue<const N: usize>(SharedObject<TcpQueue<N>>);
 
 impl<const N: usize> SharedTcpQueue<N> {
     /// Create a new shared queue.
-    pub fn new() -> Self {
+    pub fn new(
+        runtime: SharedDemiRuntime,
+        transport: SharedBox<dyn NetworkRuntime<N>>,
+        local_link_addr: MacAddress,
+        tcp_config: TcpConfig,
+        arp: SharedArpPeer<N>,
+        dead_socket_tx: mpsc::UnboundedSender<QDesc>,
+    ) -> Self {
         Self(SharedObject::<TcpQueue<N>>::new(TcpQueue {
             socket: Socket::Inactive(None),
+            runtime,
+            transport,
+            local_link_addr,
+            tcp_config,
+            arp,
+            dead_socket_tx,
         }))
     }
 
-    /// Get/borrow reference to underlying TCP socket data structure.
-    pub fn get_socket(&self) -> &Socket<N> {
-        &self.socket
+    pub fn new_established(
+        socket: EstablishedSocket<N>,
+        runtime: SharedDemiRuntime,
+        transport: SharedBox<dyn NetworkRuntime<N>>,
+        local_link_addr: MacAddress,
+        tcp_config: TcpConfig,
+        arp: SharedArpPeer<N>,
+        dead_socket_tx: mpsc::UnboundedSender<QDesc>,
+    ) -> Self {
+        Self(SharedObject::<TcpQueue<N>>::new(TcpQueue {
+            socket: Socket::Established(socket),
+            runtime,
+            transport,
+            local_link_addr,
+            tcp_config,
+            arp,
+            dead_socket_tx,
+        }))
     }
 
-    /// Get/borrow mutable reference to underlying TCP socket data structure.
-    pub fn get_mut_socket(&mut self) -> &mut Socket<N> {
-        &mut self.socket
+    /// Binds the target queue to `local` address.
+    pub fn bind(&mut self, local: SocketAddrV4) -> Result<(), Fail> {
+        match self.socket {
+            Socket::Inactive(None) => {
+                self.socket = Socket::Inactive(Some(local));
+                Ok(())
+            },
+            Socket::Inactive(_) => Err(Fail::new(libc::EINVAL, "socket is already bound to an address")),
+            Socket::Listening(_) => Err(Fail::new(libc::EINVAL, "socket is already listening")),
+            Socket::Connecting(_) => Err(Fail::new(libc::EINVAL, "socket is connecting")),
+            Socket::Established(_) => Err(Fail::new(libc::EINVAL, "socket is connected")),
+            Socket::Closing(_) => Err(Fail::new(libc::EINVAL, "socket is closed")),
+        }
     }
 
-    /// Set underlying TCP socket data structure.
-    pub fn set_socket(&mut self, s: Socket<N>) {
-        self.socket = s;
+    /// Sets the target queue to listen for incoming connections.
+    pub fn listen(&mut self, backlog: usize, nonce: u32) -> Result<(), Fail> {
+        match self.socket {
+            Socket::Inactive(Some(local)) => {
+                self.socket = Socket::Listening(SharedPassiveSocket::new(
+                    local,
+                    backlog,
+                    self.runtime.clone(),
+                    self.transport.clone(),
+                    self.tcp_config.clone(),
+                    self.local_link_addr,
+                    self.arp.clone(),
+                    self.dead_socket_tx.clone(),
+                    nonce,
+                ));
+                Ok(())
+            },
+            Socket::Inactive(None) => Err(Fail::new(libc::EDESTADDRREQ, "socket is not bound to a local address")),
+            Socket::Listening(_) => Err(Fail::new(libc::EINVAL, "socket is already listening")),
+            Socket::Connecting(_) => Err(Fail::new(libc::EINVAL, "socket is connecting")),
+            Socket::Established(_) => Err(Fail::new(libc::EINVAL, "socket is connected")),
+            Socket::Closing(_) => Err(Fail::new(libc::EINVAL, "socket is closed")),
+        }
+    }
+
+    pub async fn accept(&mut self, yielder: Yielder) -> Result<SharedTcpQueue<N>, Fail> {
+        // Wait for a new connection on the listening socket.
+        let mut listening_socket: SharedPassiveSocket<N> = match self.socket {
+            Socket::Listening(ref listening_socket) => listening_socket.clone(),
+            _ => return Err(Fail::new(libc::EOPNOTSUPP, "socket not listening")),
+        };
+        let new_socket: EstablishedSocket<N> = listening_socket.accept(yielder).await?;
+        // Insert queue into queue table and get new queue descriptor.
+        let new_queue = Self::new_established(
+            new_socket,
+            self.runtime.clone(),
+            self.transport.clone(),
+            self.local_link_addr,
+            self.tcp_config.clone(),
+            self.arp.clone(),
+            self.dead_socket_tx.clone(),
+        );
+        Ok(new_queue)
+    }
+
+    pub async fn connect(
+        &mut self,
+        local: SocketAddrV4,
+        remote: SocketAddrV4,
+        local_isn: SeqNumber,
+        yielder: Yielder,
+    ) -> Result<(), Fail> {
+        let socket: SharedActiveOpenSocket<N> = match self.socket {
+            Socket::Inactive(Some(local)) => {
+                // Create active socket.
+                SharedActiveOpenSocket::new(
+                    local_isn,
+                    local,
+                    remote,
+                    self.runtime.clone(),
+                    self.transport.clone(),
+                    self.tcp_config.clone(),
+                    self.local_link_addr,
+                    self.arp.clone(),
+                    self.dead_socket_tx.clone(),
+                )?
+            },
+            Socket::Inactive(None) => {
+                // Create active socket.
+                SharedActiveOpenSocket::new(
+                    local_isn,
+                    local,
+                    remote,
+                    self.runtime.clone(),
+                    self.transport.clone(),
+                    self.tcp_config.clone(),
+                    self.local_link_addr,
+                    self.arp.clone(),
+                    self.dead_socket_tx.clone(),
+                )?
+            },
+            Socket::Listening(_) => return Err(Fail::new(libc::EOPNOTSUPP, "socket is listening")),
+            Socket::Connecting(_) => return Err(Fail::new(libc::EALREADY, "socket is connecting")),
+            Socket::Established(_) => return Err(Fail::new(libc::EISCONN, "socket is connected")),
+            Socket::Closing(_) => return Err(Fail::new(libc::EINVAL, "socket is closed")),
+        };
+        // Update socket state to active open.
+        self.socket = Socket::Connecting(socket.clone());
+        // Wait for the established socket to come back and update again.
+        self.socket = Socket::Established(socket.connect(yielder).await?);
+        Ok(())
+    }
+
+    pub fn push(&mut self, buf: DemiBuffer) -> Result<(), Fail> {
+        match self.socket {
+            Socket::Established(ref mut socket) => socket.send(buf),
+            _ => Err(Fail::new(libc::ENOTCONN, "connection not established")),
+        }
+    }
+
+    pub async fn pop(&mut self, size: Option<usize>, yielder: Yielder) -> Result<DemiBuffer, Fail> {
+        match self.socket {
+            Socket::Established(ref mut socket) => socket.pop(size, yielder).await,
+            Socket::Closing(_) => Err(Fail::new(libc::EBADF, "socket closing")),
+            Socket::Connecting(_) => Err(Fail::new(libc::EINPROGRESS, "socket connecting")),
+            Socket::Inactive(_) => Err(Fail::new(libc::EBADF, "socket inactive")),
+            Socket::Listening(_) => Err(Fail::new(libc::ENOTCONN, "socket listening")),
+        }
+    }
+
+    pub fn close(&mut self) -> Result<Option<SocketId>, Fail> {
+        let socket: EstablishedSocket<N> = match self.socket {
+            // Closing an active socket.
+            Socket::Established(ref mut socket) => {
+                socket.close()?;
+                // Only using a clone here because we need to read and write the socket.
+                socket.clone()
+            },
+            // Closing an unbound socket.
+            Socket::Inactive(None) => {
+                return Ok(None);
+            },
+            // Closing a bound socket.
+            Socket::Inactive(Some(addr)) => return Ok(Some(SocketId::Passive(addr.clone()))),
+            // Closing a listening socket.
+            Socket::Listening(_) => {
+                let cause: String = format!("cannot close a listening socket");
+                error!("do_close(): {}", &cause);
+                return Err(Fail::new(libc::ENOTSUP, &cause));
+            },
+            // Closing a connecting socket.
+            Socket::Connecting(_) => {
+                let cause: String = format!("cannot close a connecting socket");
+                error!("do_close(): {}", &cause);
+                return Err(Fail::new(libc::ENOTSUP, &cause));
+            },
+            // Closing a closing socket.
+            Socket::Closing(_) => {
+                let cause: String = format!("cannot close a socket that is closing");
+                error!("do_close(): {}", &cause);
+                return Err(Fail::new(libc::ENOTSUP, &cause));
+            },
+        };
+        self.socket = Socket::Closing(socket.clone());
+        return Ok(Some(SocketId::Active(socket.endpoints().0, socket.endpoints().1)));
+    }
+
+    pub async fn async_close(&mut self, _: Yielder) -> Result<Option<SocketId>, Fail> {
+        self.close()
+    }
+
+    pub fn remote_mss(&self) -> Result<usize, Fail> {
+        match self.socket {
+            Socket::Established(ref socket) => Ok(socket.remote_mss()),
+            _ => Err(Fail::new(libc::ENOTCONN, "connection not established")),
+        }
+    }
+
+    pub fn current_rto(&self) -> Result<Duration, Fail> {
+        match self.socket {
+            Socket::Established(ref socket) => Ok(socket.current_rto()),
+            _ => return Err(Fail::new(libc::ENOTCONN, "connection not established")),
+        }
+    }
+
+    pub fn endpoints(&self) -> Result<(SocketAddrV4, SocketAddrV4), Fail> {
+        match self.socket {
+            Socket::Established(ref socket) => Ok(socket.endpoints()),
+            _ => Err(Fail::new(libc::ENOTCONN, "connection not established")),
+        }
+    }
+
+    pub fn receive(
+        &mut self,
+        ip_hdr: &Ipv4Header,
+        tcp_hdr: &mut TcpHeader,
+        local: &SocketAddrV4,
+        remote: &SocketAddrV4,
+        buf: DemiBuffer,
+    ) -> Result<(), Fail> {
+        match self.socket {
+            Socket::Established(ref mut socket) => {
+                debug!("Routing to established connection: {:?}", socket.endpoints());
+                socket.receive(tcp_hdr, buf);
+                return Ok(());
+            },
+            Socket::Connecting(ref mut socket) => {
+                debug!("Routing to connecting connection: {:?}", socket.endpoints());
+                socket.receive(&tcp_hdr);
+                return Ok(());
+            },
+            Socket::Listening(ref mut socket) => {
+                debug!("Routing to passive connection: {:?}", socket.endpoint());
+                match socket.receive(ip_hdr, &tcp_hdr) {
+                    Ok(()) => return Ok(()),
+                    // Connection was refused.
+                    Err(e) if e.errno == libc::ECONNREFUSED => {
+                        // Fall through and send a RST segment back.
+                    },
+                    Err(e) => return Err(e),
+                }
+            },
+            // The segment is for an inactive connection.
+            Socket::Inactive(addr) => {
+                // It is safe to expect a bound socket here because we would not have found this queue otherwise.
+                debug!(
+                    "Routing to inactive connection: {:?}",
+                    addr.expect("This queue must be bound or we could not have routed to it")
+                );
+                // Fall through and send a RST segment back.
+            },
+            Socket::Closing(ref mut socket) => {
+                debug!("Routing to closing connection: {:?}", socket.endpoints());
+                socket.receive(tcp_hdr, buf);
+                return Ok(());
+            },
+        }
+
+        // Generate the RST segment accordingly to the ACK field.
+        // If the incoming segment has an ACK field, the reset takes its
+        // sequence number from the ACK field of the segment, otherwise the
+        // reset has sequence number zero and the ACK field is set to the sum
+        // of the sequence number and segment length of the incoming segment.
+        // Reference: https://datatracker.ietf.org/doc/html/rfc793#section-3.4
+        let (seq_num, ack_num): (SeqNumber, Option<SeqNumber>) = if tcp_hdr.ack {
+            (tcp_hdr.ack_num, None)
+        } else {
+            (
+                SeqNumber::from(0),
+                Some(tcp_hdr.seq_num + SeqNumber::from(tcp_hdr.compute_size() as u32)),
+            )
+        };
+
+        debug!("receive(): sending RST (local={:?}, remote={:?})", local, remote);
+        self.send_rst(&local, &remote, seq_num, ack_num)?;
+        Ok(())
+    }
+
+    /// Sends a RST segment from `local` to `remote`.
+    pub fn send_rst(
+        &mut self,
+        local: &SocketAddrV4,
+        remote: &SocketAddrV4,
+        seq_num: SeqNumber,
+        ack_num: Option<SeqNumber>,
+    ) -> Result<(), Fail> {
+        // Query link address for destination.
+        let dst_link_addr: MacAddress = match self.arp.try_query(remote.ip().clone()) {
+            Some(link_addr) => link_addr,
+            None => {
+                // ARP query is unlikely to fail, but if it does, don't send the RST segment,
+                // and return an error to server side.
+                let cause: String = format!("missing ARP entry (remote={})", remote.ip());
+                error!("send_rst(): {}", &cause);
+                return Err(Fail::new(libc::EHOSTUNREACH, &cause));
+            },
+        };
+
+        // Create a RST segment.
+        let segment: TcpSegment = {
+            let mut tcp_hdr: TcpHeader = TcpHeader::new(local.port(), remote.port());
+            tcp_hdr.rst = true;
+            tcp_hdr.seq_num = seq_num;
+            if let Some(ack_num) = ack_num {
+                tcp_hdr.ack = true;
+                tcp_hdr.ack_num = ack_num;
+            }
+            TcpSegment {
+                ethernet2_hdr: Ethernet2Header::new(dst_link_addr, self.local_link_addr, EtherType2::Ipv4),
+                ipv4_hdr: Ipv4Header::new(local.ip().clone(), remote.ip().clone(), IpProtocol::TCP),
+                tcp_hdr,
+                data: None,
+                tx_checksum_offload: self.tcp_config.get_rx_checksum_offload(),
+            }
+        };
+
+        // Send it.
+        let pkt: Box<TcpSegment> = Box::new(segment);
+        self.transport.transmit(pkt);
+
+        Ok(())
     }
 }
 
@@ -78,6 +452,30 @@ impl<const N: usize> IoQueue for SharedTcpQueue<N> {
 
     fn as_any(self: Box<Self>) -> Box<dyn Any> {
         self
+    }
+}
+
+impl<const N: usize> NetworkQueue for SharedTcpQueue<N> {
+    /// Returns the local address to which the target queue is bound.
+    fn local(&self) -> Option<SocketAddrV4> {
+        match self.socket {
+            Socket::Inactive(addr) => addr,
+            Socket::Listening(ref socket) => Some(socket.endpoint()),
+            Socket::Connecting(ref socket) => Some(socket.endpoints().0),
+            Socket::Established(ref socket) => Some(socket.endpoints().0),
+            Socket::Closing(ref socket) => Some(socket.endpoints().0),
+        }
+    }
+
+    /// Returns the remote address to which the target queue is connected to.
+    fn remote(&self) -> Option<SocketAddrV4> {
+        match self.socket {
+            Socket::Inactive(_) => None,
+            Socket::Listening(_) => None,
+            Socket::Connecting(ref socket) => Some(socket.endpoints().1),
+            Socket::Established(ref socket) => Some(socket.endpoints().1),
+            Socket::Closing(ref socket) => Some(socket.endpoints().1),
+        }
     }
 }
 

--- a/src/rust/inetstack/protocols/tcp/tests/established.rs
+++ b/src/rust/inetstack/protocols/tcp/tests/established.rs
@@ -73,7 +73,7 @@ fn send_data<const N: usize>(
     );
 
     // Push data.
-    let push_coroutine: Pin<Box<Operation>> = sender.tcp_push(sender_qd, bytes.clone());
+    let push_coroutine: Pin<Box<Operation>> = sender.tcp_push(sender_qd, bytes.clone())?;
     let handle: TaskHandle = sender
         .get_test_rig()
         .get_runtime()
@@ -137,7 +137,7 @@ fn recv_data<const N: usize>(
     );
 
     // Pop data.
-    let pop_coroutine: Pin<Box<Operation>> = receiver.tcp_pop(receiver_qd);
+    let pop_coroutine: Pin<Box<Operation>> = receiver.tcp_pop(receiver_qd)?;
     let handle: TaskHandle = receiver
         .get_test_rig()
         .get_runtime()

--- a/src/rust/inetstack/protocols/tcp/tests/setup.rs
+++ b/src/rust/inetstack/protocols/tcp/tests/setup.rs
@@ -362,7 +362,7 @@ fn connection_setup_listen_syn_sent<const N: usize>(
         Ok(fd) => fd,
         Err(e) => anyhow::bail!("client tcp socket returned error: {:?}", e),
     };
-    let connect_coroutine: Pin<Box<Operation>> = client.tcp_connect(client_fd, listen_addr);
+    let connect_coroutine: Pin<Box<Operation>> = client.tcp_connect(client_fd, listen_addr)?;
     let connect_handle: TaskHandle = client
         .get_test_rig()
         .get_runtime()
@@ -393,7 +393,7 @@ fn connection_setup_closed_listen<const N: usize>(
     if let Err(e) = server.tcp_listen(socket_fd, 1) {
         anyhow::bail!("server listen returned an error: {:?}", e);
     }
-    let accept_coroutine: Pin<Box<Operation>> = server.tcp_accept(socket_fd);
+    let accept_coroutine: Pin<Box<Operation>> = server.tcp_accept(socket_fd)?;
     let accept_handle: TaskHandle = server.get_test_rig().get_runtime().insert_coroutine(
         "test::connection_setup_closed_listen::accept_coroutine",
         accept_coroutine,

--- a/src/rust/inetstack/test_helpers/engine.rs
+++ b/src/rust/inetstack/test_helpers/engine.rs
@@ -135,7 +135,11 @@ impl<const N: usize> SharedEngine<N> {
         self.ipv4.tcp.socket()
     }
 
-    pub fn tcp_connect(&mut self, socket_fd: QDesc, remote_endpoint: SocketAddrV4) -> Pin<Box<Operation>> {
+    pub fn tcp_connect(
+        &mut self,
+        socket_fd: QDesc,
+        remote_endpoint: SocketAddrV4,
+    ) -> Result<Pin<Box<Operation>>, Fail> {
         self.ipv4.tcp.connect(socket_fd, remote_endpoint)
     }
 
@@ -143,15 +147,15 @@ impl<const N: usize> SharedEngine<N> {
         self.ipv4.tcp.bind(socket_fd, endpoint)
     }
 
-    pub fn tcp_accept(&self, fd: QDesc) -> Pin<Box<Operation>> {
+    pub fn tcp_accept(&self, fd: QDesc) -> Result<Pin<Box<Operation>>, Fail> {
         self.ipv4.tcp.accept(fd)
     }
 
-    pub fn tcp_push(&mut self, socket_fd: QDesc, buf: DemiBuffer) -> Pin<Box<Operation>> {
+    pub fn tcp_push(&mut self, socket_fd: QDesc, buf: DemiBuffer) -> Result<Pin<Box<Operation>>, Fail> {
         self.ipv4.tcp.push(socket_fd, buf)
     }
 
-    pub fn tcp_pop(&mut self, socket_fd: QDesc) -> Pin<Box<Operation>> {
+    pub fn tcp_pop(&mut self, socket_fd: QDesc) -> Result<Pin<Box<Operation>>, Fail> {
         self.ipv4.tcp.pop(socket_fd, None)
     }
 

--- a/tests/rust/tcp.rs
+++ b/tests/rust/tcp.rs
@@ -529,7 +529,9 @@ fn tcp_bad_listen() -> Result<()> {
     };
 
     let port: u16 = PORT_BASE;
+    let port2: u16 = PORT_BASE + 1;
     let local: SocketAddr = SocketAddr::new(ALICE_IP, port);
+    let local2: SocketAddr = SocketAddr::new(ALICE_IP, port2);
 
     // Invalid queue descriptor.
     match libos.listen(QDesc::from(0), 8) {
@@ -555,8 +557,9 @@ fn tcp_bad_listen() -> Result<()> {
     safe_close_active(&mut libos, sockqd)?;
 
     // Listen on an already listening socket.
+    // TODO: use a single IP and port when we properly clean up bound addresses on close.
     let sockqd: QDesc = safe_socket(&mut libos)?;
-    safe_bind(&mut libos, sockqd, local)?;
+    safe_bind(&mut libos, sockqd, local2)?;
     safe_listen(&mut libos, sockqd)?;
     match libos.listen(sockqd, 16) {
         Err(e) if e.errno == libc::EINVAL => (),


### PR DESCRIPTION
This PR moves the TCP portion of the inetstack to a more object oriented architecture. This move will enable us to eventually shared code between the libOSes for queues and the socket state machine.