### PR TITLE
[catloop] Do not remove pending op for Close

### DIFF
--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -536,11 +536,12 @@ impl SharedCatnapLibOS {
 
         let (qd, result): (QDesc, OperationResult) = task.get_result().expect("The coroutine has not finished");
         match result {
+            // The queue would already have been freed for Close, so nothing left to do here.
             OperationResult::Close => {},
             _ => {
                 match self.get_shared_queue(&qd) {
                     Ok(mut queue) => queue.remove_pending_op(&handle),
-                    Err(_) => debug!("Catnap::take_result() qd={:?}, This queue was closed", qd),
+                    Err(_) => warn!("Catnap::take_result() qd={:?}, lingering pending op found", qd),
                 };
             },
         }


### PR DESCRIPTION
Do nothing for Close because it's not registered. This is done because we don't want to allow canceling the Close op as that may leave dangling resources.