### PR TITLE
[inetstack] Move UDP stack to objects

### DIFF
--- a/src/rust/inetstack/protocols/arp/peer.rs
+++ b/src/rust/inetstack/protocols/arp/peer.rs
@@ -276,13 +276,12 @@ impl<const N: usize> SharedArpPeer<N> {
         // > The frequency of the ARP request is very close to one per
         // > second, the maximum suggested by [RFC1122].
         let result = {
-            let yielder: Yielder = Yielder::new();
             for i in 0..self.arp_config.get_retry_count() + 1 {
                 self.transport.transmit(Box::new(msg.clone()));
                 let timer = self
                     .runtime
                     .get_timer()
-                    .wait(self.arp_config.get_request_timeout(), &yielder);
+                    .wait(self.arp_config.get_request_timeout(), yielder);
 
                 match arp_response.with_timeout(timer).await {
                     Ok(link_addr) => {

--- a/src/rust/inetstack/protocols/arp/peer.rs
+++ b/src/rust/inetstack/protocols/arp/peer.rs
@@ -255,7 +255,7 @@ impl<const N: usize> SharedArpPeer<N> {
         self.cache.get(ipv4_addr).cloned()
     }
 
-    pub async fn query(&mut self, ipv4_addr: Ipv4Addr) -> Result<MacAddress, Fail> {
+    pub async fn query(&mut self, ipv4_addr: Ipv4Addr, yielder: &Yielder) -> Result<MacAddress, Fail> {
         if let Some(&link_addr) = self.cache.get(ipv4_addr) {
             return Ok(link_addr);
         }

--- a/src/rust/inetstack/protocols/icmpv4/peer.rs
+++ b/src/rust/inetstack/protocols/icmpv4/peer.rs
@@ -179,7 +179,7 @@ impl<const N: usize> SharedIcmpv4Peer<N> {
         // Reply requests.
         while let Some((dst_ipv4_addr, id, seq_num, data)) = rx.next().await {
             debug!("initiating ARP query");
-            let dst_link_addr: MacAddress = match arp.query(dst_ipv4_addr).await {
+            let dst_link_addr: MacAddress = match arp.query(dst_ipv4_addr, &Yielder::new()).await {
                 Ok(dst_link_addr) => dst_link_addr,
                 Err(e) => {
                     warn!("reply_to_ping({}, {}, {}) failed: {:?}", dst_ipv4_addr, id, seq_num, e);
@@ -257,7 +257,7 @@ impl<const N: usize> SharedIcmpv4Peer<N> {
 
         let t0: Instant = self.runtime.get_now();
         debug!("initiating ARP query");
-        let dst_link_addr: MacAddress = self.arp.query(dst_ipv4_addr).await?;
+        let dst_link_addr: MacAddress = self.arp.query(dst_ipv4_addr, &Yielder::new()).await?;
         debug!("ARP query complete ({} -> {})", dst_ipv4_addr, dst_link_addr);
 
         let data: DemiBuffer = DemiBuffer::new(datagram::ICMPV4_ECHO_REQUEST_MESSAGE_SIZE);

--- a/src/rust/inetstack/protocols/tcp/active_open.rs
+++ b/src/rust/inetstack/protocols/tcp/active_open.rs
@@ -248,7 +248,7 @@ impl<const N: usize> SharedActiveOpenSocket<N> {
         let handshake_retries: usize = self.tcp_config.get_handshake_retries();
         let handshake_timeout = self.tcp_config.get_handshake_timeout();
         for _ in 0..handshake_retries {
-            let remote_link_addr = match self.clone().arp.query(self.remote.ip().clone()).await {
+            let remote_link_addr = match self.clone().arp.query(self.remote.ip().clone(), &yielder).await {
                 Ok(r) => r,
                 Err(e) => {
                     warn!("ARP query failed: {:?}", e);

--- a/src/rust/inetstack/protocols/tcp/established/background/sender.rs
+++ b/src/rust/inetstack/protocols/tcp/established/background/sender.rs
@@ -61,7 +61,8 @@ pub async fn sender<const N: usize>(mut cb: SharedControlBlock<N>, yielder: Yiel
         // repeatedly send window probes until window opens up.
         if win_sz == 0 {
             // Send a window probe (this is a one-byte packet designed to elicit a window update from our peer).
-            let remote_link_addr = cb.arp().query(cb.get_remote().ip().clone()).await?;
+            let arp_yielder: Yielder = Yielder::new();
+            let remote_link_addr = cb.arp().query(cb.get_remote().ip().clone(), &arp_yielder).await?;
             let buf: DemiBuffer = cb
                 .pop_one_unsent_byte()
                 .unwrap_or_else(|| panic!("No unsent data? {}, {}", send_next, unsent_seq));
@@ -146,7 +147,8 @@ pub async fn sender<const N: usize>(mut cb: SharedControlBlock<N>, yielder: Yiel
         // TODO: Silly window syndrome - See RFC 1122's discussion of the SWS avoidance algorithm.
 
         // TODO: Link-level concerns don't belong here, we should call an IP-level send routine below.
-        let remote_link_addr = cb.arp().query(cb.get_remote().ip().clone()).await?;
+        let arp_yielder: Yielder = Yielder::new();
+        let remote_link_addr = cb.arp().query(cb.get_remote().ip().clone(), &arp_yielder).await?;
 
         // Form an outgoing packet.
         let max_size: usize = cmp::min(

--- a/src/rust/inetstack/protocols/tcp/established/ctrlblk.rs
+++ b/src/rust/inetstack/protocols/tcp/established/ctrlblk.rs
@@ -123,7 +123,7 @@ impl Receiver {
 
     pub async fn pop(&mut self, size: Option<usize>, yielder: Yielder) -> Result<DemiBuffer, Fail> {
         let buf: DemiBuffer = if let Some(size) = size {
-            let mut buf: DemiBuffer = self.recv_queue.pop(yielder).await?;
+            let mut buf: DemiBuffer = self.recv_queue.pop(&yielder).await?;
             // Split the buffer if it's too big.
             if buf.len() > size {
                 buf.split_front(size)?
@@ -131,7 +131,7 @@ impl Receiver {
                 buf
             }
         } else {
-            self.recv_queue.pop(yielder).await?
+            self.recv_queue.pop(&yielder).await?
         };
 
         self.reader_next = self.reader_next + SeqNumber::from(buf.len() as u32);

--- a/src/rust/inetstack/protocols/tcp/passive_open.rs
+++ b/src/rust/inetstack/protocols/tcp/passive_open.rs
@@ -101,7 +101,7 @@ impl<const N: usize> ReadySockets<N> {
     }
 
     async fn pop(&mut self, yielder: Yielder) -> Result<EstablishedSocket<N>, Fail> {
-        let new_socket: EstablishedSocket<N> = self.ready.pop(yielder).await??;
+        let new_socket: EstablishedSocket<N> = self.ready.pop(&yielder).await??;
         assert!(self.endpoints.remove(&new_socket.endpoints().1));
         Ok(new_socket.clone())
     }

--- a/src/rust/inetstack/protocols/tcp/passive_open.rs
+++ b/src/rust/inetstack/protocols/tcp/passive_open.rs
@@ -305,7 +305,7 @@ impl<const N: usize> SharedPassiveSocket<N> {
         let handshake_timeout: Duration = self.tcp_config.get_handshake_timeout();
 
         for _ in 0..handshake_retries {
-            let remote_link_addr = match self.arp.query(remote.ip().clone()).await {
+            let remote_link_addr = match self.arp.query(remote.ip().clone(), &Yielder::new()).await {
                 Ok(r) => r,
                 Err(e) => {
                     warn!("ARP query failed: {:?}", e);

--- a/src/rust/inetstack/protocols/udp/queue.rs
+++ b/src/rust/inetstack/protocols/udp/queue.rs
@@ -6,7 +6,9 @@
 //======================================================================================================================
 
 use crate::{
+    collections::async_queue::AsyncQueue,
     inetstack::protocols::{
+        arp::SharedArpPeer,
         ethernet2::{
             EtherType2,
             Ethernet2Header,
@@ -31,18 +33,10 @@ use crate::{
         },
         scheduler::Yielder,
         SharedBox,
+        SharedDemiRuntime,
         SharedObject,
     },
 };
-use ::futures::{
-    channel::mpsc::{
-        self,
-        Receiver,
-        Sender,
-    },
-    StreamExt,
-};
-use ::libc::EIO;
 use ::std::{
     any::Any,
     net::{
@@ -56,44 +50,38 @@ use ::std::{
 };
 
 //======================================================================================================================
+// Constants
+//======================================================================================================================
+
+// Maximum size for receive queues (in messages).
+// TODO: Support max size on async queues.
+#[allow(dead_code)]
+const RECV_QUEUE_MAX_SIZE: usize = 1024;
+
+// Maximum size for send queues (in messages).
+// TODO: Support max size on async queues.
+#[allow(dead_code)]
+const SEND_QUEUE_MAX_SIZE: usize = 1024;
+
+//======================================================================================================================
 // Structures
 //======================================================================================================================
 
-/// Shared Queue Slot
-#[derive(Clone)]
-pub struct QueueSlot<const N: usize> {
-    /// Local endpoint.
-    queue: SharedUdpQueue<N>,
-    /// Remote endpoint.
-    remote: SocketAddrV4,
-    /// Associated data.
-    data: DemiBuffer,
-}
-
-/// Shared Queue
-///
-/// TODO: Reuse this structure in TCP stack, for send/receive queues.
-/// TODO: This should be byte-oriented, not buffer-oriented.
-pub struct Queue<const N: usize> {
-    /// Send-side endpoint.
-    tx: Sender<QueueSlot<N>>,
-    /// Receive-side endpoint.
-    rx: Receiver<QueueSlot<N>>,
-    /// Length of shared queue.
-    length: usize,
-    /// Capacity of shared queue.
-    capacity: usize,
-}
-
-pub struct SharedQueue<const N: usize>(SharedObject<Queue<N>>);
-
 /// Per-queue metadata for a UDP socket.
 pub struct UdpQueue<const N: usize> {
-    local: Option<SocketAddrV4>,
+    local_ipv4_addr: Ipv4Addr,
+    bound: Option<SocketAddrV4>,
+    local_link_addr: MacAddress,
+    runtime: SharedDemiRuntime,
     transport: SharedBox<dyn NetworkRuntime<N>>,
-    recv_queue: SharedQueue<N>,
+    // A queue of incoming packets as remote address and data buffer pairs.
+    recv_queue: AsyncQueue<(SocketAddrV4, DemiBuffer)>,
+    send_queue: AsyncQueue<(SocketAddrV4, DemiBuffer)>,
+    arp: SharedArpPeer<N>,
+    checksum_offload: bool,
+    task_handle: Option<TaskHandle>,
+    yielder_handle: YielderHandle,
 }
-
 #[derive(Clone)]
 pub struct SharedUdpQueue<const N: usize>(SharedObject<UdpQueue<N>>);
 
@@ -101,130 +89,83 @@ pub struct SharedUdpQueue<const N: usize>(SharedObject<UdpQueue<N>>);
 // Associated Functions
 //======================================================================================================================
 
-impl<const N: usize> QueueSlot<N> {
-    pub fn new(queue: SharedUdpQueue<N>, remote: SocketAddrV4, data: DemiBuffer) -> Self {
-        Self { queue, remote, data }
-    }
-
-    pub fn get_queue(&self) -> SharedUdpQueue<N> {
-        self.queue.clone()
-    }
-
-    pub fn get_remote(&self) -> SocketAddrV4 {
-        self.remote
-    }
-
-    pub fn get_data(&self) -> DemiBuffer {
-        self.data.clone()
-    }
-}
-
-/// Associated Functions Shared Queues
-impl<const N: usize> Queue<N> {
-    /// Instantiates a shared queue.
-    pub fn new(size: usize) -> Self {
-        let (tx, rx): (Sender<QueueSlot<N>>, Receiver<QueueSlot<N>>) = mpsc::channel(size);
-        Self {
-            tx,
-            rx,
-            length: 0,
-            capacity: size,
-        }
-    }
-}
-
-impl<const N: usize> SharedQueue<N> {
-    pub fn new(size: usize) -> Self {
-        Self(SharedObject::new(Queue::<N>::new(size)))
-    }
-
-    /// Pushes a message to the target shared queue.
-    #[allow(unused_must_use)]
-    pub fn push(&mut self, msg: QueueSlot<N>) -> Result<(), Fail> {
-        if self.length == self.capacity {
-            while self.length >= self.capacity / 2 {
-                self.try_pop();
-            }
-        }
-
-        match self.tx.try_send(msg) {
-            Ok(_) => {
-                self.length += 1;
-                Ok(())
-            },
-            Err(_) => Err(Fail::new(EIO, "failed to push to shared queue")),
-        }
-    }
-
-    /// Synchronously attempts to pop a message from the target shared queue.
-    pub fn try_pop(&mut self) -> Result<Option<QueueSlot<N>>, Fail> {
-        match self.rx.try_next() {
-            Ok(Some(msg)) => {
-                self.length -= 1;
-                Ok(Some(msg))
-            },
-            Ok(None) => Err(Fail::new(EIO, "failed to pop from shared queue")),
-            Err(_) => Ok(None),
-        }
-    }
-
-    /// Asynchronously pops a message from the target shared queue.
-    pub async fn pop(&mut self) -> Result<QueueSlot<N>, Fail> {
-        match self.rx.next().await {
-            Some(msg) => {
-                self.length -= 1;
-                Ok(msg)
-            },
-            None => Err(Fail::new(EIO, "failed to pop from shared queue")),
-        }
-    }
-}
-
-/// Getters and setters for per UDP queue metadata.
-impl<const N: usize> UdpQueue<N> {
-    pub fn new(transport: SharedBox<dyn NetworkRuntime<N>>, recv_queue: SharedQueue<N>) -> Self {
-        Self {
-            local: None,
-            transport,
-            recv_queue,
-        }
-    }
-}
-
 impl<const N: usize> SharedUdpQueue<N> {
-    pub fn new(transport: SharedBox<dyn NetworkRuntime<N>>, recv_queue: SharedQueue<N>) -> Self {
-        Self(SharedObject::new(UdpQueue::new(transport, recv_queue)))
+    pub fn new(
+        local_ipv4_addr: Ipv4Addr,
+        local_link_addr: MacAddress,
+        runtime: SharedDemiRuntime,
+        transport: SharedBox<dyn NetworkRuntime<N>>,
+        arp: SharedArpPeer<N>,
+        checksum_offload: bool,
+    ) -> Result<Self, Fail> {
+        let yielder: Yielder = Yielder::new();
+        let mut me = Self(SharedObject::new(UdpQueue {
+            local_ipv4_addr,
+            bound: None,
+            local_link_addr,
+            runtime,
+            transport,
+            recv_queue: AsyncQueue::<(SocketAddrV4, DemiBuffer)>::default(),
+            send_queue: AsyncQueue::<(SocketAddrV4, DemiBuffer)>::default(),
+            arp,
+            checksum_offload,
+            yielder_handle: yielder.get_handle(),
+            task_handle: None,
+        }));
+
+        let coroutine = me.clone().background_sender_coroutine(yielder);
+        let handle: TaskHandle = me
+            .runtime
+            .insert_background_coroutine("Inetstack::UDP::background", Box::pin(coroutine))?;
+        me.task_handle = Some(handle);
+        Ok(me)
     }
 
     pub fn bind(&mut self, local: SocketAddrV4) -> Result<(), Fail> {
-        self.local = Some(local);
+        self.bound = Some(local);
         Ok(())
     }
 
-    pub fn close(&self) -> Result<(), Fail> {
+    /// Close this UDP queue and release its resources
+    pub fn close(&mut self) -> Result<(), Fail> {
+        // Cancel background coroutine.
+        self.yielder_handle
+            .wake_with(Err(Fail::new(libc::ECANCELED, "this queue has been closed")));
+        let task_handle: TaskHandle = self
+            .task_handle
+            .take()
+            .expect("we should have allocated this when the queue was created");
+        self.runtime.remove_background_coroutine(&task_handle)?;
         Ok(())
     }
 
-    pub fn pushto(
-        &mut self,
-        local_ipv4_addr: Ipv4Addr,
-        remote: &SocketAddrV4,
-        local_link_addr: MacAddress,
-        remote_link_addr: MacAddress,
-        buf: DemiBuffer,
-        offload_checksum: bool,
-    ) -> Result<(), Fail> {
+    pub fn pushto(&mut self, remote: &SocketAddrV4, buf: DemiBuffer) -> Result<(), Fail> {
+        // What happens if not bound?
+        // TODO: Move to a UDP socket state machine.
+        if !self.is_bound() {
+            let cause: String = format!("queue is not bound");
+            error!("pushto(): {}", &cause);
+            return Err(Fail::new(libc::ENOTSUP, &cause));
+        }
         // Fast path: try to send the datagram immediately.
-        let udp_header: UdpHeader = UdpHeader::new(self.local.expect("socket should be bound").port(), remote.port());
-        debug!("UDP send {:?}", udp_header);
-        let datagram = UdpDatagram::new(
-            Ethernet2Header::new(remote_link_addr, local_link_addr, EtherType2::Ipv4),
-            Ipv4Header::new(local_ipv4_addr, remote.ip().clone(), IpProtocol::UDP),
-            udp_header,
-            buf,
-            offload_checksum,
-        );
-        Ok(self.transport.transmit(Box::new(datagram)))
+        if let Some(remote_link_addr) = self.arp.try_query(remote.ip().clone()) {
+            // Fast path: try to send the datagram immediately.
+            let udp_header: UdpHeader =
+                UdpHeader::new(self.bound.expect("socket should be bound").port(), remote.port());
+            debug!("UDP send {:?}", udp_header);
+            let datagram = UdpDatagram::new(
+                Ethernet2Header::new(remote_link_addr, self.local_link_addr, EtherType2::Ipv4),
+                Ipv4Header::new(self.local_ipv4_addr, remote.ip().clone(), IpProtocol::UDP),
+                udp_header,
+                buf,
+                self.checksum_offload,
+            );
+            Ok(self.transport.transmit(Box::new(datagram)))
+        } else {
+            // Slow path: Defer send operation to the async path.
+            self.send_queue.push((remote.clone(), buf));
+            Ok(())
+        }
     }
 
     pub async fn pop(&mut self, size: Option<usize>, yielder: Yielder) -> Result<(SocketAddrV4, DemiBuffer), Fail> {
@@ -232,19 +173,15 @@ impl<const N: usize> SharedUdpQueue<N> {
         let size: usize = size.unwrap_or(MAX_POP_SIZE);
 
         loop {
-            match self.recv_queue.try_pop() {
-                Ok(Some(msg)) => {
-                    let remote: SocketAddrV4 = msg.remote;
-                    let mut buf: DemiBuffer = msg.data;
+            match self.recv_queue.pop(&yielder).await {
+                Ok(msg) => {
+                    let remote: SocketAddrV4 = msg.0;
+                    let mut buf: DemiBuffer = msg.1;
                     // We got more bytes than expected, so we trim the buffer.
                     if size < buf.len() {
                         buf.trim(size - buf.len())?;
                     };
                     return Ok((remote, buf));
-                },
-                Ok(None) => match yielder.yield_once().await {
-                    Ok(()) => continue,
-                    Err(e) => return Err(e),
                 },
                 Err(e) => return Err(e),
             }
@@ -254,16 +191,32 @@ impl<const N: usize> SharedUdpQueue<N> {
     pub fn receive(&mut self, remote: SocketAddrV4, buf: DemiBuffer) -> Result<(), Fail> {
         // Push data to the receiver-side shared queue. This will cause the
         // associated pool operation to be ready.
-        let queue: SharedUdpQueue<N> = self.clone();
-        self.recv_queue.push(QueueSlot::<N>::new(queue, remote, buf))
-    }
-
-    pub fn local(&self) -> Option<SocketAddrV4> {
-        self.local
+        self.recv_queue.push((remote, buf));
+        Ok(())
     }
 
     pub fn is_bound(&self) -> bool {
-        self.local.is_some()
+        self.bound.is_some()
+    }
+
+    /// Asynchronously send unsent datagrams to remote peer.
+    async fn background_sender_coroutine(mut self, yielder: Yielder) {
+        loop {
+            // Grab next unsent datagram.
+            match self.send_queue.pop(&yielder).await {
+                // Resolve remote address.
+                Ok(slot) => {
+                    let remote: SocketAddrV4 = slot.0;
+                    let buf: DemiBuffer = slot.1;
+                    if let Err(e) = self.pushto(&remote, buf) {
+                        let cause: String = format!("failed to send: {}", e);
+                        warn!("background_sender_coroutine(): {}", cause);
+                    }
+                },
+                // Pop from shared queue failed.
+                Err(e) => warn!("Failed to send UDP datagram: {:?}", e),
+            }
+        }
     }
 }
 
@@ -271,25 +224,6 @@ impl<const N: usize> SharedUdpQueue<N> {
 // Trait Implementations
 //======================================================================================================================
 
-impl<const N: usize> Deref for SharedQueue<N> {
-    type Target = Queue<N>;
-
-    fn deref(&self) -> &Self::Target {
-        self.0.deref()
-    }
-}
-
-impl<const N: usize> DerefMut for SharedQueue<N> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.0.deref_mut()
-    }
-}
-
-impl<const N: usize> Clone for SharedQueue<N> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
 /// IoQueue Trait Implementation for UDP Queues.
 impl<const N: usize> IoQueue for SharedUdpQueue<N> {
     fn get_qtype(&self) -> crate::QType {
@@ -326,7 +260,7 @@ impl<const N: usize> DerefMut for SharedUdpQueue<N> {
 impl<const N: usize> NetworkQueue for SharedUdpQueue<N> {
     /// Returns the local address to which the target queue is bound.
     fn local(&self) -> Option<SocketAddrV4> {
-        self.local()
+        self.bound
     }
 
     /// Returns the remote address to which the target queue is connected to.


### PR DESCRIPTION
This PR moves the UDP stack towards our new architecture. We have moved functionality into each SharedUDPQueue, including a per-queue background coroutine that sends pending packets. Since most of the time we will be able to send synchronously, it's better to avoid the lookup on each send and just rely on the scheduler to wake the appropriate background coroutine. I also added a clean up for the background coroutine on socket close.

This PR has a few lingering issues: 
1. I moved the UDP queues to the AsyncQueue data structure, which is currently unbounded. We should move it back to being bounded and possibly using the mpsc abstractions from the futures crate. We should decide what kind of blocking behavior we want when the receive or send queues fill up.
2. I added a SharedAsyncQueue data structure but wound up not using it. I left it in case we need it somewhere else.

Other remaining tasks:
1. Add UDP support to the socket state machine and have the SharedUdpQueue check it on each operation.
2. Add pending ops to the SharedUdpQueue and cancel them when the queue is closed. 