### PR TITLE
[inetstack] Move TCP stack to use shared state machine

### DIFF
--- a/src/rust/catnip/mod.rs
+++ b/src/rust/catnip/mod.rs
@@ -118,9 +118,7 @@ impl CatnipLibOS {
                     return Err(Fail::new(libc::EINVAL, "zero-length buffer"));
                 }
 
-                let handle: TaskHandle = self.do_push(qd, buf)?;
-                let qt: QToken = handle.get_task_id().into();
-                Ok(qt)
+                self.do_push(qd, buf)
             },
             Err(e) => Err(e),
         }

--- a/src/rust/catpowder/mod.rs
+++ b/src/rust/catpowder/mod.rs
@@ -98,9 +98,7 @@ impl CatpowderLibOS {
                 if buf.len() == 0 {
                     return Err(Fail::new(libc::EINVAL, "zero-length buffer"));
                 }
-                let handle: TaskHandle = self.do_push(qd, buf)?;
-                let qt: QToken = handle.get_task_id().into();
-                Ok(qt)
+                self.do_push(qd, buf)
             },
             Err(e) => Err(e),
         }

--- a/src/rust/inetstack/protocols/tcp/passive_open.rs
+++ b/src/rust/inetstack/protocols/tcp/passive_open.rs
@@ -164,7 +164,7 @@ impl<const N: usize> SharedPassiveSocket<N> {
         self.local
     }
 
-    pub async fn accept(&mut self, yielder: Yielder) -> Result<EstablishedSocket<N>, Fail> {
+    pub async fn do_accept(&mut self, yielder: Yielder) -> Result<EstablishedSocket<N>, Fail> {
         self.ready.pop(yielder).await
     }
 

--- a/src/rust/inetstack/test_helpers/engine.rs
+++ b/src/rust/inetstack/test_helpers/engine.rs
@@ -26,6 +26,7 @@ use crate::{
         scheduler::Yielder,
         Operation,
         QDesc,
+        QToken,
         SharedBox,
         SharedObject,
     },
@@ -136,11 +137,7 @@ impl<const N: usize> SharedEngine<N> {
         self.ipv4.tcp.socket()
     }
 
-    pub fn tcp_connect(
-        &mut self,
-        socket_fd: QDesc,
-        remote_endpoint: SocketAddrV4,
-    ) -> Result<Pin<Box<Operation>>, Fail> {
+    pub fn tcp_connect(&mut self, socket_fd: QDesc, remote_endpoint: SocketAddrV4) -> Result<QToken, Fail> {
         self.ipv4.tcp.connect(socket_fd, remote_endpoint)
     }
 
@@ -148,15 +145,15 @@ impl<const N: usize> SharedEngine<N> {
         self.ipv4.tcp.bind(socket_fd, endpoint)
     }
 
-    pub fn tcp_accept(&self, fd: QDesc) -> Result<Pin<Box<Operation>>, Fail> {
+    pub fn tcp_accept(&mut self, fd: QDesc) -> Result<QToken, Fail> {
         self.ipv4.tcp.accept(fd)
     }
 
-    pub fn tcp_push(&mut self, socket_fd: QDesc, buf: DemiBuffer) -> Result<Pin<Box<Operation>>, Fail> {
+    pub fn tcp_push(&mut self, socket_fd: QDesc, buf: DemiBuffer) -> Result<QToken, Fail> {
         self.ipv4.tcp.push(socket_fd, buf)
     }
 
-    pub fn tcp_pop(&mut self, socket_fd: QDesc) -> Result<Pin<Box<Operation>>, Fail> {
+    pub fn tcp_pop(&mut self, socket_fd: QDesc) -> Result<QToken, Fail> {
         self.ipv4.tcp.pop(socket_fd, None)
     }
 

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -177,6 +177,11 @@ impl SharedDemiRuntime {
         OperationTask::from(boxed_task.as_any())
     }
 
+    /// Removes a coroutine from the underlying scheduler given its associated [QToken] `qt`.
+    pub fn remove_coroutine_with_qtoken(&mut self, qt: QToken) -> OperationTask {
+        self.remove_coroutine(&self.scheduler.from_task_id(qt.into()).expect("coroutine should exist"))
+    }
+
     /// Removes a coroutine from the underlying scheduler given its associated [TaskHandle] `handle`
     /// and gets the result immediately.
     pub fn remove_coroutine_and_get_result(&mut self, handle: &TaskHandle, qt: u64) -> demi_qresult_t {

--- a/tests/rust/tcp.rs
+++ b/tests/rust/tcp.rs
@@ -562,11 +562,11 @@ fn tcp_bad_listen() -> Result<()> {
     safe_bind(&mut libos, sockqd, local2)?;
     safe_listen(&mut libos, sockqd)?;
     match libos.listen(sockqd, 16) {
-        Err(e) if e.errno == libc::EINVAL => (),
+        Err(e) if e.errno == libc::EADDRINUSE => (),
         _ => {
             // Close socket if not error because this test cannot continue.
             // FIXME: https://github.com/demikernel/demikernel/issues/633
-            anyhow::bail!("listen() called on an already listening socket should fail with EINVAL")
+            anyhow::bail!("listen() called on an already listening socket should fail with EADDRINUSE")
         },
     };
     safe_close_passive(&mut libos, sockqd)?;


### PR DESCRIPTION
This PR moves the TCP portion of the inetstack to using the shared state machine that is in the runtime. A few important things to note:
1. The TCP queue is now maintaining 2 state machines. We should deduplicate this and I have filed an issue to track it #1007.
2. This PR moves the inetstack closer to the same architecture as Catnap with functions passed in that move the state machine forward/rollback when there are errors (e.g., we were not able to insert the coroutine into the scheduler).  
3. This PR has added a list of pending ops to the TCP queue. However, because the packing for each returned result is in the libOS, I cannot remove the operation from the pending list. I think this will be resolved with #888 however.
4.  To align with Catnap, we now return queue tokens on synchronous paths for the task that was inserted to run the coroutine. This required adding another call to the runtime so we can remove coroutines using queue tokens because it is needed for the test engine. This should all be deduplicated once we merge the return path and the testing infrastructure.
5. There was one place where the existing inetstack state machine and the shared runtime state machine diverged on the return value when listening on an already listening socket. The former returns EINVAL and the latter returns EADDRINUSE. I chose to go with the runtime but we should make sure that is the expected behavior because I had to change a test case.
6. I've placed profiler and trace messages in the TCP peer because I suspect the other file will go away. I had started adding some of them anyway when debugging the other test cases and it seemed like we should just have them at a finer granularity.