### PR TITLE
[runtime] Add extra states to indicate which end is closing

### DIFF
--- a/src/rust/catloop/socket.rs
+++ b/src/rust/catloop/socket.rs
@@ -297,7 +297,7 @@ impl Socket {
 
     /// Closes this socket.
     pub fn close(&mut self) -> Result<(), Fail> {
-        self.state.prepare(SocketOp::Close)?;
+        self.state.prepare(SocketOp::LocalClose)?;
         self.state.commit();
         self.state.prepare(SocketOp::Closed)?;
         if let Some(qd) = self.catmem_qd {
@@ -321,7 +321,7 @@ impl Socket {
     where
         F: FnOnce(Yielder) -> Result<TaskHandle, Fail>,
     {
-        self.state.prepare(SocketOp::Close)?;
+        self.state.prepare(SocketOp::LocalClose)?;
         Ok(self.do_generic_sync_control_path_call(coroutine, yielder)?)
     }
 

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -465,7 +465,7 @@ impl SharedCatnapLibOS {
         // Grab the queue, make sure it hasn't been closed in the meantime.
         // This will bump the Rc refcount so the coroutine can have it's own reference to the shared queue data
         // structure and the SharedCatnapQueue will not be freed until this coroutine finishes.
-        let queue: SharedCatnapQueue = match self.get_shared_queue(&qd) {
+        let mut queue: SharedCatnapQueue = match self.get_shared_queue(&qd) {
             Ok(queue) => queue,
             Err(e) => return (qd, OperationResult::Failed(e)),
         };

--- a/src/rust/catnap/queue.rs
+++ b/src/rust/catnap/queue.rs
@@ -271,7 +271,7 @@ impl SharedCatnapQueue {
     /// Asynchronously pops data from the queue. This function contains all of the single-queue, asynchronous code
     /// necessary to pop from a queue and any single-queue functionality after the pop completes.
     pub async fn do_pop(
-        &self,
+        &mut self,
         size: Option<usize>,
         yielder: Yielder,
     ) -> Result<(Option<SocketAddrV4>, DemiBuffer), Fail> {

--- a/src/rust/runtime/network/socket/operation.rs
+++ b/src/rust/runtime/network/socket/operation.rs
@@ -13,6 +13,7 @@ pub enum SocketOp {
     Accepted,
     Connect,
     Connected,
-    Close,
+    LocalClose,
+    RemoteClose,
     Closed,
 }


### PR DESCRIPTION
This PR closes #369 and #367. We currently signal close to application by returning a zero-length buffer, per the POSIX specification and issue a cancellation of all other tokens. This PR also lets us distinguish whether we are closing from the remote end or the local end or if both have issued close. Once the application receives a zero-length buffer indicating that the remote has closed, the application should also close its end. If the application closes locally first, then the async close will return when the remote has also indicated close and all resources can be cleaned up.  If we would like another way to indicate close, then we should file another issue (and find an error code because POSIX does not offer one in libc).