### PR TITLE
[demikernel] Improve pending_ops lifecycle management

### DIFF
--- a/src/rust/catcollar/mod.rs
+++ b/src/rust/catcollar/mod.rs
@@ -672,8 +672,7 @@ impl CatcollarLibOS {
     }
 
     pub fn pack_result(&mut self, handle: TaskHandle, qt: QToken) -> Result<demi_qresult_t, Fail> {
-        let result: demi_qresult_t = self.runtime.remove_coroutine_and_get_result(&handle, qt.into());
-        Ok(result)
+        self.runtime.remove_coroutine_and_get_result(&handle, qt.into())
     }
 
     /// Allocates a scatter-gather array.

--- a/src/rust/catloop/mod.rs
+++ b/src/rust/catloop/mod.rs
@@ -518,8 +518,7 @@ impl SharedCatloopLibOS {
     pub fn pack_result(&mut self, handle: TaskHandle, qt: QToken) -> Result<demi_qresult_t, Fail> {
         #[cfg(feature = "profiler")]
         timer!("catloop::pack_result");
-        let result: demi_qresult_t = self.runtime.remove_coroutine_and_get_result(&handle, qt.into());
-        Ok(result)
+        self.runtime.remove_coroutine_and_get_result(&handle, qt.into())
     }
 
     /// Polls scheduling queues.

--- a/src/rust/catloop/mod.rs
+++ b/src/rust/catloop/mod.rs
@@ -32,11 +32,9 @@ use crate::{
         scheduler::{
             TaskHandle,
             Yielder,
+            YielderHandle,
         },
-        types::{
-            demi_opcode_t,
-            demi_qresult_t,
-        },
+        types::demi_qresult_t,
         Operation,
         OperationResult,
         QDesc,
@@ -225,15 +223,16 @@ impl SharedCatloopLibOS {
         // Allocate ephemeral port.
         let new_port: u16 = self.runtime.alloc_ephemeral_port()?;
         let mut queue: SharedCatloopQueue = self.get_queue(&qd)?;
-        // Create coroutine to run this accept.
-        let coroutine = |yielder: Yielder| -> Result<TaskHandle, Fail> {
-            // Asynchronous accept code.
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().accept_coroutine(qd, new_port, yielder));
-            // Insert async coroutine into the scheduler.
+        let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catloop::accept for qd={:?}", qd);
-            self.runtime.insert_coroutine(&task_name, coroutine)
+            let yielder: Yielder = Yielder::new();
+            let yielder_handle: YielderHandle = yielder.get_handle();
+            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().accept_coroutine(qd, new_port, yielder));
+            self.runtime
+                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
         };
-        queue.accept(coroutine)
+
+        queue.accept(coroutine_constructor)
     }
 
     /// Asynchronous cross-queue code for accepting a connection. This function returns a coroutine that runs
@@ -286,13 +285,16 @@ impl SharedCatloopLibOS {
         let remote: SocketAddrV4 = unwrap_socketaddr(remote)?;
         let mut queue: SharedCatloopQueue = self.get_queue(&qd)?;
 
-        // Create connect coroutine.
-        let coroutine = |yielder: Yielder| -> Result<TaskHandle, Fail> {
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().connect_coroutine(qd, remote, yielder));
+        let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catloop::connect for qd={:?}", qd);
-            self.runtime.insert_coroutine(&task_name, coroutine)
+            let yielder: Yielder = Yielder::new();
+            let yielder_handle: YielderHandle = yielder.get_handle();
+            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().connect_coroutine(qd, remote, yielder));
+            self.runtime
+                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
         };
-        queue.connect(coroutine)
+
+        queue.connect(coroutine_constructor)
     }
 
     /// Asynchronous code to establish a connection to a remote endpoint. This function returns a coroutine that runs
@@ -321,6 +323,7 @@ impl SharedCatloopLibOS {
         #[cfg(feature = "profiler")]
         timer!("catloop::close");
         trace!("close() qd={:?}", qd);
+
         let mut queue: SharedCatloopQueue = self.get_queue(&qd)?;
         queue.close()?;
         if let Some(addr) = queue.local() {
@@ -350,15 +353,17 @@ impl SharedCatloopLibOS {
         trace!("async_close() qd={:?}", qd);
 
         let mut queue: SharedCatloopQueue = self.get_queue(&qd)?;
-
         // Note that this coroutine is only inserted if we do not allocate a Catmem coroutine.
-        let coroutine = |yielder: Yielder| -> Result<TaskHandle, Fail> {
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().close_coroutine(qd, yielder));
+        let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catloop::close for qd={:?}", qd);
-            self.runtime.insert_coroutine(&task_name, coroutine)
+            let yielder: Yielder = Yielder::new();
+            let yielder_handle: YielderHandle = yielder.get_handle();
+            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().close_coroutine(qd, yielder));
+            self.runtime
+                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
         };
 
-        queue.async_close(coroutine)
+        queue.async_close(coroutine_constructor)
     }
 
     /// Asynchronous code to close a queue. This function returns a coroutine that runs asynchronously to close a queue
@@ -402,6 +407,7 @@ impl SharedCatloopLibOS {
         #[cfg(feature = "profiler")]
         timer!("catloop::push");
         trace!("push() qd={:?}", qd);
+
         let buf: DemiBuffer = self.runtime.clone_sgarray(sga)?;
 
         if buf.len() == 0 {
@@ -409,13 +415,18 @@ impl SharedCatloopLibOS {
             error!("push(): {}", cause);
             return Err(Fail::new(libc::EINVAL, &cause));
         }
+
         let mut queue: SharedCatloopQueue = self.get_queue(&qd)?;
-        let coroutine = |yielder: Yielder| -> Result<TaskHandle, Fail> {
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().push_coroutine(qd, buf, yielder));
+        let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catloop::push for qd={:?}", qd);
-            self.runtime.insert_coroutine(&task_name, coroutine)
+            let yielder: Yielder = Yielder::new();
+            let yielder_handle: YielderHandle = yielder.get_handle();
+            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().push_coroutine(qd, buf, yielder));
+            self.runtime
+                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
         };
-        queue.push(coroutine)
+
+        queue.push(coroutine_constructor)
     }
 
     /// Asynchronous code to push to a Catloop queue.
@@ -450,14 +461,16 @@ impl SharedCatloopLibOS {
         debug_assert!(size.is_none() || ((size.unwrap() > 0) && (size.unwrap() <= limits::POP_SIZE_MAX)));
 
         let mut queue: SharedCatloopQueue = self.get_queue(&qd)?;
-        let coroutine = |yielder: Yielder| -> Result<TaskHandle, Fail> {
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().pop_coroutine(qd, size, yielder));
+        let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catloop::pop for qd={:?}", qd);
-            self.runtime.insert_coroutine(&task_name, coroutine)
+            let yielder: Yielder = Yielder::new();
+            let yielder_handle: YielderHandle = yielder.get_handle();
+            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().pop_coroutine(qd, size, yielder));
+            self.runtime
+                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
         };
-        let qt: QToken = queue.pop(coroutine)?;
 
-        Ok(qt)
+        queue.pop(coroutine_constructor)
     }
 
     /// Coroutine to pop from a Catloop queue.
@@ -506,7 +519,6 @@ impl SharedCatloopLibOS {
         #[cfg(feature = "profiler")]
         timer!("catloop::pack_result");
         let result: demi_qresult_t = self.runtime.remove_coroutine_and_get_result(&handle, qt.into());
-        self.remove_pending_op_if_needed(&result, handle);
         Ok(result)
     }
 
@@ -515,19 +527,6 @@ impl SharedCatloopLibOS {
         #[cfg(feature = "profiler")]
         timer!("catloop::poll");
         self.runtime.poll()
-    }
-
-    fn remove_pending_op_if_needed(&mut self, result: &demi_qresult_t, handle: TaskHandle) {
-        match result.qr_opcode {
-            // The queue would already have been freed for Close, so nothing left to do here.
-            demi_opcode_t::DEMI_OPC_CLOSE => {},
-            _ => {
-                match self.get_queue(&QDesc::from(result.qr_qd)) {
-                    Ok(mut queue) => queue.remove_pending_op(&handle),
-                    Err(_) => warn!("catloop: qd={:?}, lingering pending op found", result.qr_qd),
-                };
-            },
-        }
     }
 
     fn get_queue(&self, qd: &QDesc) -> Result<SharedCatloopQueue, Fail> {

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -196,7 +196,7 @@ impl SharedCatnapLibOS {
         timer!("catnap::accept");
         trace!("accept(): qd={:?}", qd);
 
-        let self_clone = self.clone();
+        let mut queue = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::accept for qd={:?}", qd);
             let yielder: Yielder = Yielder::new();
@@ -206,7 +206,7 @@ impl SharedCatnapLibOS {
                 .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
         };
 
-        Ok(self_clone.get_shared_queue(&qd)?.accept(coroutine_constructor)?)
+        queue.accept(coroutine_constructor)
     }
 
     /// Asynchronous cross-queue code for accepting a connection. This function returns a coroutine that runs
@@ -249,7 +249,7 @@ impl SharedCatnapLibOS {
 
         // FIXME: add IPv6 support; https://github.com/microsoft/demikernel/issues/935
         let remote: SocketAddrV4 = unwrap_socketaddr(remote)?;
-        let self_clone = self.clone();
+        let mut queue = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::connect for qd={:?}", qd);
             let yielder: Yielder = Yielder::new();
@@ -259,7 +259,7 @@ impl SharedCatnapLibOS {
                 .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
         };
 
-        Ok(self_clone.get_shared_queue(&qd)?.connect(coroutine_constructor)?)
+        queue.connect(coroutine_constructor)
     }
 
     /// Asynchronous code to establish a connection to a remote endpoint. This function returns a coroutine that runs
@@ -313,7 +313,7 @@ impl SharedCatnapLibOS {
         timer!("catnap::async_close");
         trace!("async_close() qd={:?}", qd);
 
-        let self_clone = self.clone();
+        let mut queue = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::close for qd={:?}", qd);
             let yielder: Yielder = Yielder::new();
@@ -321,7 +321,7 @@ impl SharedCatnapLibOS {
             self.runtime.insert_coroutine(&task_name, coroutine)
         };
 
-        Ok(self_clone.get_shared_queue(&qd)?.async_close(coroutine_constructor)?)
+        queue.async_close(coroutine_constructor)
     }
 
     /// Asynchronous code to close a queue. This function returns a coroutine that runs asynchronously to close a queue
@@ -370,7 +370,7 @@ impl SharedCatnapLibOS {
             return Err(Fail::new(libc::EINVAL, "zero-length buffer"));
         };
 
-        let self_clone = self.clone();
+        let mut queue = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::push for qd={:?}", qd);
             let yielder: Yielder = Yielder::new();
@@ -380,7 +380,7 @@ impl SharedCatnapLibOS {
                 .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
         };
 
-        Ok(self_clone.get_shared_queue(&qd)?.push(coroutine_constructor)?)
+        queue.push(coroutine_constructor)
     }
 
     /// Asynchronous code to push [buf] to a SharedCatnapQueue and its underlying POSIX socket. This function returns a
@@ -420,7 +420,7 @@ impl SharedCatnapLibOS {
             return Err(Fail::new(libc::EINVAL, "zero-length buffer"));
         }
 
-        let self_clone = self.clone();
+        let mut queue = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::pushto for qd={:?}", qd);
             let yielder: Yielder = Yielder::new();
@@ -430,7 +430,7 @@ impl SharedCatnapLibOS {
                 .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
         };
 
-        Ok(self_clone.get_shared_queue(&qd)?.push(coroutine_constructor)?)
+        queue.push(coroutine_constructor)
     }
 
     /// Asynchronous code to pushto [buf] to [remote] on a SharedCatnapQueue and its underlying POSIX socket. This function
@@ -471,7 +471,7 @@ impl SharedCatnapLibOS {
         // We just assert 'size' here, because it was previously checked at PDPIX layer.
         debug_assert!(size.is_none() || ((size.unwrap() > 0) && (size.unwrap() <= limits::POP_SIZE_MAX)));
 
-        let self_clone = self.clone();
+        let mut queue = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::pop for qd={:?}", qd);
             let yielder: Yielder = Yielder::new();
@@ -481,7 +481,7 @@ impl SharedCatnapLibOS {
                 .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
         };
 
-        Ok(self_clone.get_shared_queue(&qd)?.pop(coroutine_constructor)?)
+        queue.pop(coroutine_constructor)
     }
 
     /// Asynchronous code to pop data from a SharedCatnapQueue and its underlying POSIX socket of optional [size]. This

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -196,7 +196,7 @@ impl SharedCatnapLibOS {
         timer!("catnap::accept");
         trace!("accept(): qd={:?}", qd);
 
-        let mut queue = self.get_shared_queue(&qd)?;
+        let mut queue: SharedCatnapQueue = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::accept for qd={:?}", qd);
             let yielder: Yielder = Yielder::new();
@@ -249,7 +249,7 @@ impl SharedCatnapLibOS {
 
         // FIXME: add IPv6 support; https://github.com/microsoft/demikernel/issues/935
         let remote: SocketAddrV4 = unwrap_socketaddr(remote)?;
-        let mut queue = self.get_shared_queue(&qd)?;
+        let mut queue: SharedCatnapQueue = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::connect for qd={:?}", qd);
             let yielder: Yielder = Yielder::new();
@@ -313,7 +313,7 @@ impl SharedCatnapLibOS {
         timer!("catnap::async_close");
         trace!("async_close() qd={:?}", qd);
 
-        let mut queue = self.get_shared_queue(&qd)?;
+        let mut queue: SharedCatnapQueue = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::close for qd={:?}", qd);
             let yielder: Yielder = Yielder::new();
@@ -370,7 +370,7 @@ impl SharedCatnapLibOS {
             return Err(Fail::new(libc::EINVAL, "zero-length buffer"));
         };
 
-        let mut queue = self.get_shared_queue(&qd)?;
+        let mut queue: SharedCatnapQueue = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::push for qd={:?}", qd);
             let yielder: Yielder = Yielder::new();
@@ -420,7 +420,7 @@ impl SharedCatnapLibOS {
             return Err(Fail::new(libc::EINVAL, "zero-length buffer"));
         }
 
-        let mut queue = self.get_shared_queue(&qd)?;
+        let mut queue: SharedCatnapQueue = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::pushto for qd={:?}", qd);
             let yielder: Yielder = Yielder::new();
@@ -471,7 +471,7 @@ impl SharedCatnapLibOS {
         // We just assert 'size' here, because it was previously checked at PDPIX layer.
         debug_assert!(size.is_none() || ((size.unwrap() > 0) && (size.unwrap() <= limits::POP_SIZE_MAX)));
 
-        let mut queue = self.get_shared_queue(&qd)?;
+        let mut queue: SharedCatnapQueue = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::pop for qd={:?}", qd);
             let yielder: Yielder = Yielder::new();

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -521,8 +521,7 @@ impl SharedCatnapLibOS {
     pub fn pack_result(&mut self, handle: TaskHandle, qt: QToken) -> Result<demi_qresult_t, Fail> {
         #[cfg(feature = "profiler")]
         timer!("catnap::pack_result");
-        let result: demi_qresult_t = self.runtime.remove_coroutine_and_get_result(&handle, qt.into());
-        Ok(result)
+        self.runtime.remove_coroutine_and_get_result(&handle, qt.into())
     }
 
     /// Allocates a scatter-gather array.

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -35,9 +35,9 @@ use crate::{
         scheduler::{
             TaskHandle,
             Yielder,
+            YielderHandle,
         },
         types::{
-            demi_opcode_t,
             demi_qresult_t,
             demi_sgarray_t,
         },
@@ -195,16 +195,18 @@ impl SharedCatnapLibOS {
         #[cfg(feature = "profiler")]
         timer!("catnap::accept");
         trace!("accept(): qd={:?}", qd);
-        let self_: Self = self.clone();
-        let coroutine_constructor = |yielder: Yielder| -> Result<TaskHandle, Fail> {
-            // Asynchronous accept code. Clone the self reference and move into the coroutine.
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().accept_coroutine(qd, yielder));
-            // Insert async coroutine into the scheduler.
+
+        let self_clone = self.clone();
+        let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::accept for qd={:?}", qd);
-            self.runtime.insert_coroutine(&task_name, coroutine)
+            let yielder: Yielder = Yielder::new();
+            let yielder_handle: YielderHandle = yielder.get_handle();
+            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().accept_coroutine(qd, yielder));
+            self.runtime
+                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
         };
 
-        Ok(self_.get_shared_queue(&qd)?.accept(coroutine_constructor)?)
+        Ok(self_clone.get_shared_queue(&qd)?.accept(coroutine_constructor)?)
     }
 
     /// Asynchronous cross-queue code for accepting a connection. This function returns a coroutine that runs
@@ -232,7 +234,6 @@ impl SharedCatnapLibOS {
             },
             Err(e) => {
                 warn!("accept() listening_qd={:?}: {:?}", qd, &e);
-                // assert definitely no pending ops on new_qd
                 (qd, OperationResult::Failed(e))
             },
         }
@@ -248,15 +249,17 @@ impl SharedCatnapLibOS {
 
         // FIXME: add IPv6 support; https://github.com/microsoft/demikernel/issues/935
         let remote: SocketAddrV4 = unwrap_socketaddr(remote)?;
-        let me: Self = self.clone();
-        let coroutine_constructor = |yielder: Yielder| -> Result<TaskHandle, Fail> {
-            // Clone the self reference and move into the coroutine.
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().connect_coroutine(qd, remote, yielder));
+        let self_clone = self.clone();
+        let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::connect for qd={:?}", qd);
-            self.runtime.insert_coroutine(&task_name, coroutine)
+            let yielder: Yielder = Yielder::new();
+            let yielder_handle: YielderHandle = yielder.get_handle();
+            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().connect_coroutine(qd, remote, yielder));
+            self.runtime
+                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
         };
 
-        Ok(me.get_shared_queue(&qd)?.connect(coroutine_constructor)?)
+        Ok(self_clone.get_shared_queue(&qd)?.connect(coroutine_constructor)?)
     }
 
     /// Asynchronous code to establish a connection to a remote endpoint. This function returns a coroutine that runs
@@ -310,15 +313,15 @@ impl SharedCatnapLibOS {
         timer!("catnap::async_close");
         trace!("async_close() qd={:?}", qd);
 
-        let self_: Self = self.clone();
-        let coroutine_constructor = |yielder: Yielder| -> Result<TaskHandle, Fail> {
-            // Async code to close this queue.
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().close_coroutine(qd, yielder));
+        let self_clone = self.clone();
+        let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::close for qd={:?}", qd);
+            let yielder: Yielder = Yielder::new();
+            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().close_coroutine(qd, yielder));
             self.runtime.insert_coroutine(&task_name, coroutine)
         };
 
-        Ok(self_.get_shared_queue(&qd)?.async_close(coroutine_constructor)?)
+        Ok(self_clone.get_shared_queue(&qd)?.async_close(coroutine_constructor)?)
     }
 
     /// Asynchronous code to close a queue. This function returns a coroutine that runs asynchronously to close a queue
@@ -366,13 +369,18 @@ impl SharedCatnapLibOS {
         if buf.len() == 0 {
             return Err(Fail::new(libc::EINVAL, "zero-length buffer"));
         };
-        let self_: Self = self.clone();
-        let coroutine_constructor = |yielder: Yielder| -> Result<TaskHandle, Fail> {
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().push_coroutine(qd, buf, yielder));
+
+        let self_clone = self.clone();
+        let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::push for qd={:?}", qd);
-            self.runtime.insert_coroutine(&task_name, coroutine)
+            let yielder: Yielder = Yielder::new();
+            let yielder_handle: YielderHandle = yielder.get_handle();
+            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().push_coroutine(qd, buf, yielder));
+            self.runtime
+                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
         };
-        Ok(self_.get_shared_queue(&qd)?.push(coroutine_constructor)?)
+
+        Ok(self_clone.get_shared_queue(&qd)?.push(coroutine_constructor)?)
     }
 
     /// Asynchronous code to push [buf] to a SharedCatnapQueue and its underlying POSIX socket. This function returns a
@@ -411,13 +419,18 @@ impl SharedCatnapLibOS {
         if buf.len() == 0 {
             return Err(Fail::new(libc::EINVAL, "zero-length buffer"));
         }
-        let self_: Self = self.clone();
-        let coroutine_constructor = |yielder: Yielder| -> Result<TaskHandle, Fail> {
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().pushto_coroutine(qd, buf, remote, yielder));
+
+        let self_clone = self.clone();
+        let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::pushto for qd={:?}", qd);
-            self.runtime.insert_coroutine(&task_name, coroutine)
+            let yielder: Yielder = Yielder::new();
+            let yielder_handle: YielderHandle = yielder.get_handle();
+            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().pushto_coroutine(qd, buf, remote, yielder));
+            self.runtime
+                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
         };
-        Ok(self_.get_shared_queue(&qd)?.push(coroutine_constructor)?)
+
+        Ok(self_clone.get_shared_queue(&qd)?.push(coroutine_constructor)?)
     }
 
     /// Asynchronous code to pushto [buf] to [remote] on a SharedCatnapQueue and its underlying POSIX socket. This function
@@ -457,13 +470,18 @@ impl SharedCatnapLibOS {
 
         // We just assert 'size' here, because it was previously checked at PDPIX layer.
         debug_assert!(size.is_none() || ((size.unwrap() > 0) && (size.unwrap() <= limits::POP_SIZE_MAX)));
-        let self_: Self = self.clone();
-        let coroutine_constructor = |yielder: Yielder| -> Result<TaskHandle, Fail> {
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().pop_coroutine(qd, size, yielder));
+
+        let self_clone = self.clone();
+        let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::pop for qd={:?}", qd);
-            self.runtime.insert_coroutine(&task_name, coroutine)
+            let yielder: Yielder = Yielder::new();
+            let yielder_handle: YielderHandle = yielder.get_handle();
+            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().pop_coroutine(qd, size, yielder));
+            self.runtime
+                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
         };
-        Ok(self_.get_shared_queue(&qd)?.pop(coroutine_constructor)?)
+
+        Ok(self_clone.get_shared_queue(&qd)?.pop(coroutine_constructor)?)
     }
 
     /// Asynchronous code to pop data from a SharedCatnapQueue and its underlying POSIX socket of optional [size]. This
@@ -504,21 +522,7 @@ impl SharedCatnapLibOS {
         #[cfg(feature = "profiler")]
         timer!("catnap::pack_result");
         let result: demi_qresult_t = self.runtime.remove_coroutine_and_get_result(&handle, qt.into());
-        self.remove_pending_op_if_needed(&result, handle);
         Ok(result)
-    }
-
-    fn remove_pending_op_if_needed(&mut self, result: &demi_qresult_t, handle: TaskHandle) {
-        match result.qr_opcode {
-            // The queue would already have been freed for Close, so nothing left to do here.
-            demi_opcode_t::DEMI_OPC_CLOSE => {},
-            _ => {
-                match self.get_shared_queue(&QDesc::from(result.qr_qd)) {
-                    Ok(mut queue) => queue.remove_pending_op(&handle),
-                    Err(_) => warn!("catnap: qd={:?}, lingering pending op found", result.qr_qd),
-                };
-            },
-        }
     }
 
     /// Allocates a scatter-gather array.
@@ -537,7 +541,8 @@ impl SharedCatnapLibOS {
         self.runtime.free_sgarray(sga)
     }
 
-    /// This function gets a shared queue reference out of the I/O queue table. The type if a ref counted pointer to the queue itself.
+    /// This function gets a shared queue reference out of the I/O queue table. The type if a ref counted pointer to the
+    /// queue itself.
     fn get_shared_queue(&self, qd: &QDesc) -> Result<SharedCatnapQueue, Fail> {
         self.runtime.get_shared_queue::<SharedCatnapQueue>(qd)
     }

--- a/src/rust/catnap/queue.rs
+++ b/src/rust/catnap/queue.rs
@@ -23,7 +23,6 @@ use crate::{
         scheduler::{
             TaskHandle,
             Yielder,
-            YielderHandle,
         },
         DemiRuntime,
         QToken,
@@ -37,7 +36,6 @@ use ::socket2::{
 };
 use ::std::{
     any::Any,
-    collections::HashMap,
     net::SocketAddrV4,
     ops::{
         Deref,
@@ -63,8 +61,6 @@ pub struct CatnapQueue {
     remote: Option<SocketAddrV4>,
     /// Underlying network transport.
     transport: SharedCatnapTransport,
-    /// Currently running coroutines.
-    pending_ops: HashMap<TaskHandle, YielderHandle>,
 }
 
 #[derive(Clone)]
@@ -94,7 +90,6 @@ impl CatnapQueue {
             local: None,
             remote: None,
             transport,
-            pending_ops: HashMap::<TaskHandle, YielderHandle>::new(),
         })
     }
 }
@@ -141,10 +136,10 @@ impl SharedCatnapQueue {
 
     /// Starts a coroutine to begin accepting on this queue. This function contains all of the single-queue,
     /// synchronous functionality necessary to start an accept.
-    pub fn accept<F>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail>
-    where
-        F: FnOnce(Yielder) -> Result<TaskHandle, Fail>,
-    {
+    pub fn accept<F: FnOnce() -> Result<TaskHandle, Fail>>(
+        &mut self,
+        coroutine_constructor: F,
+    ) -> Result<QToken, Fail> {
         self.state_machine.prepare(SocketOp::Accept)?;
         let task_handle: TaskHandle = self.do_generic_sync_control_path_call(coroutine_constructor)?;
         Ok(task_handle.get_task_id().into())
@@ -169,7 +164,6 @@ impl SharedCatnapQueue {
                         local: None,
                         remote: Some(saddr),
                         transport: self.transport.clone(),
-                        pending_ops: HashMap::<TaskHandle, YielderHandle>::new(),
                     })));
                 },
                 Err(Fail { errno, cause: _ }) if DemiRuntime::should_retry(errno) => {
@@ -196,10 +190,10 @@ impl SharedCatnapQueue {
     /// Start an asynchronous coroutine to start connecting this queue. This function contains all of the single-queue,
     /// asynchronous code necessary to connect to a remote endpoint and any single-queue functionality after the
     /// connect completes.
-    pub fn connect<F>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail>
-    where
-        F: FnOnce(Yielder) -> Result<TaskHandle, Fail>,
-    {
+    pub fn connect<F: FnOnce() -> Result<TaskHandle, Fail>>(
+        &mut self,
+        coroutine_constructor: F,
+    ) -> Result<QToken, Fail> {
         self.state_machine.prepare(SocketOp::Connect)?;
         let task_handle: TaskHandle = self.do_generic_sync_control_path_call(coroutine_constructor)?;
         Ok(task_handle.get_task_id().into())
@@ -240,10 +234,10 @@ impl SharedCatnapQueue {
     }
 
     /// Start an asynchronous coroutine to close this queue.
-    pub fn async_close<F>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail>
-    where
-        F: FnOnce(Yielder) -> Result<TaskHandle, Fail>,
-    {
+    pub fn async_close<F: FnOnce() -> Result<TaskHandle, Fail>>(
+        &mut self,
+        coroutine_constructor: F,
+    ) -> Result<QToken, Fail> {
         self.state_machine.prepare(SocketOp::Close)?;
         let task_handle: TaskHandle = self.do_generic_sync_control_path_call(coroutine_constructor)?;
         Ok(task_handle.get_task_id().into())
@@ -252,13 +246,7 @@ impl SharedCatnapQueue {
     /// Close this queue. This function contains all the single-queue functionality to synchronously close a queue.
     pub fn close(&mut self) -> Result<(), Fail> {
         let transport: SharedCatnapTransport = self.transport.clone();
-        match transport.close(&mut self.socket) {
-            Ok(()) => {
-                self.cancel_pending_ops(Fail::new(libc::ECANCELED, "This queue was closed"));
-                Ok(())
-            },
-            Err(e) => Err(e),
-        }
+        transport.close(&mut self.socket)
     }
 
     /// Asynchronously closes this queue. This function contains all of the single-queue, asynchronous code necessary
@@ -269,7 +257,6 @@ impl SharedCatnapQueue {
         loop {
             match transport.close(&mut self.socket) {
                 Ok(()) => {
-                    self.cancel_pending_ops(Fail::new(libc::ECANCELED, "This queue was closed"));
                     return Ok(());
                 },
                 Err(Fail { errno, cause: _ }) if DemiRuntime::should_retry(errno) => {
@@ -289,10 +276,7 @@ impl SharedCatnapQueue {
 
     /// Schedule a coroutine to push to this queue. This function contains all of the single-queue,
     /// asynchronous code necessary to run push a buffer and any single-queue functionality after the push completes.
-    pub fn push<F: FnOnce(Yielder) -> Result<TaskHandle, Fail>>(
-        &mut self,
-        coroutine_constructor: F,
-    ) -> Result<QToken, Fail> {
+    pub fn push<F: FnOnce() -> Result<TaskHandle, Fail>>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail> {
         self.do_generic_sync_data_path_call(coroutine_constructor)
     }
 
@@ -326,10 +310,7 @@ impl SharedCatnapQueue {
     /// Schedules a coroutine to pop from this queue. This function contains all of the single-queue,
     /// asynchronous code necessary to pop a buffer from this queue and any single-queue functionality after the pop
     /// completes.
-    pub fn pop<F: FnOnce(Yielder) -> Result<TaskHandle, Fail>>(
-        &mut self,
-        coroutine_constructor: F,
-    ) -> Result<QToken, Fail> {
+    pub fn pop<F: FnOnce() -> Result<TaskHandle, Fail>>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail> {
         self.do_generic_sync_data_path_call(coroutine_constructor)
     }
 
@@ -359,25 +340,17 @@ impl SharedCatnapQueue {
     }
 
     /// Generic function for spawning a control-path coroutine on [self].
-    /// This variant adds the operation to the list of pending operations.
-    fn do_generic_sync_control_path_call<F>(&mut self, coroutine_constructor: F) -> Result<TaskHandle, Fail>
-    where
-        F: FnOnce(Yielder) -> Result<TaskHandle, Fail>,
-    {
-        let yielder: Yielder = Yielder::new();
-        let yielder_handle: YielderHandle = yielder.get_handle();
-
+    fn do_generic_sync_control_path_call<F: FnOnce() -> Result<TaskHandle, Fail>>(
+        &mut self,
+        coroutine_constructor: F,
+    ) -> Result<TaskHandle, Fail> {
         // Spawn coroutine.
-        match coroutine_constructor(yielder) {
+        match coroutine_constructor() {
             // We successfully spawned the coroutine.
-            Ok(handle) => {
+            Ok(task_handle) => {
                 // Commit the operation on the socket.
                 self.state_machine.commit();
-
-                // Add to the list of pending operations only if the socket is not closing.
-                self.add_pending_op(&handle, &yielder_handle);
-
-                Ok(handle)
+                Ok(task_handle)
             },
             // We failed to spawn the coroutine.
             Err(e) => {
@@ -389,39 +362,12 @@ impl SharedCatnapQueue {
     }
 
     /// Generic function for spawning a data-path coroutine on [self].
-    fn do_generic_sync_data_path_call<F>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail>
-    where
-        F: FnOnce(Yielder) -> Result<TaskHandle, Fail>,
-    {
-        let yielder: Yielder = Yielder::new();
-        let yielder_handle: YielderHandle = yielder.get_handle();
-        let task_handle: TaskHandle = coroutine_constructor(yielder)?;
-        self.add_pending_op(&task_handle, &yielder_handle);
+    fn do_generic_sync_data_path_call<F: FnOnce() -> Result<TaskHandle, Fail>>(
+        &mut self,
+        coroutine_constructor: F,
+    ) -> Result<QToken, Fail> {
+        let task_handle: TaskHandle = coroutine_constructor()?;
         Ok(task_handle.get_task_id().into())
-    }
-
-    /// Adds a new operation to the list of pending operations on this queue.
-    fn add_pending_op(&mut self, handle: &TaskHandle, yielder_handle: &YielderHandle) {
-        self.pending_ops.insert(handle.clone(), yielder_handle.clone());
-    }
-
-    /// Removes an operation from the list of pending operations on this queue. This function should only be called if
-    /// add_pending_op() was previously called.
-    /// TODO: Remove this when we clean up take_result().
-    /// This function is deprecated, do not use.
-    /// FIXME: https://github.com/microsoft/demikernel/issues/888
-    pub fn remove_pending_op(&mut self, handle: &TaskHandle) {
-        self.pending_ops.remove(handle);
-    }
-
-    /// Cancel all currently pending operations on this queue. If the operation is not complete and the coroutine has
-    /// yielded, wake the coroutine with an error.
-    fn cancel_pending_ops(&mut self, cause: Fail) {
-        for (handle, mut yielder_handle) in self.pending_ops.drain() {
-            if !handle.has_completed() {
-                yielder_handle.wake_with(Err(cause.clone()));
-            }
-        }
     }
 }
 

--- a/src/rust/catnip/mod.rs
+++ b/src/rust/catnip/mod.rs
@@ -146,8 +146,7 @@ impl CatnipLibOS {
     }
 
     pub fn pack_result(&mut self, handle: TaskHandle, qt: QToken) -> Result<demi_qresult_t, Fail> {
-        let result: demi_qresult_t = self.runtime.remove_coroutine_and_get_result(&handle, qt.into());
-        Ok(result)
+        self.runtime.remove_coroutine_and_get_result(&handle, qt.into())
     }
 
     /// Allocates a scatter-gather array.

--- a/src/rust/catpowder/mod.rs
+++ b/src/rust/catpowder/mod.rs
@@ -126,8 +126,7 @@ impl CatpowderLibOS {
     }
 
     pub fn pack_result(&mut self, handle: TaskHandle, qt: QToken) -> Result<demi_qresult_t, Fail> {
-        let result: demi_qresult_t = self.runtime.remove_coroutine_and_get_result(&handle, qt.into());
-        Ok(result)
+        self.runtime.remove_coroutine_and_get_result(&handle, qt.into())
     }
 
     /// Allocates a scatter-gather array.

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -185,14 +185,7 @@ impl SharedDemiRuntime {
     /// Removes a coroutine from the underlying scheduler given its associated [TaskHandle] `handle`
     /// and gets the result immediately.
     pub fn remove_coroutine_and_get_result(&mut self, handle: &TaskHandle, qt: u64) -> demi_qresult_t {
-        // 1. Remove Task from scheduler.
-        let boxed_task: Box<dyn Task> = self
-            .scheduler
-            .remove(handle)
-            .expect("Removing task that does not exist (either was previously removed or never inserted");
-        // 2. Cast to void and then downcast to operation task.
-        trace!("Removing coroutine: {:?}", boxed_task.get_name());
-        let operation_task: OperationTask = OperationTask::from(boxed_task.as_any());
+        let operation_task: OperationTask = self.remove_coroutine(handle);
         let (qd, result) = operation_task.get_result().expect("Coroutine not finished");
         self.pack_result(result, qd, qt)
     }

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -60,6 +60,7 @@ use crate::{
 };
 use ::std::{
     boxed::Box,
+    collections::HashMap,
     future::Future,
     mem,
     net::SocketAddrV4,
@@ -71,7 +72,6 @@ use ::std::{
     rc::Rc,
     time::Instant,
 };
-use std::collections::HashMap;
 
 #[cfg(target_os = "windows")]
 use windows::Win32::Networking::WinSock::{
@@ -213,11 +213,11 @@ impl SharedDemiRuntime {
 
     /// Removes a coroutine from the underlying scheduler given its associated [TaskHandle] `handle`
     /// and gets the result immediately.
-    pub fn remove_coroutine_and_get_result(&mut self, handle: &TaskHandle, qt: u64) -> demi_qresult_t {
+    pub fn remove_coroutine_and_get_result(&mut self, handle: &TaskHandle, qt: u64) -> Result<demi_qresult_t, Fail> {
         let operation_task: OperationTask = self.remove_coroutine(handle);
         let (qd, result) = operation_task.get_result().expect("coroutine not finished");
         self.cancel_or_remove_pending_ops_as_needed(&result, &qd, handle);
-        self.pack_result(result, qd, qt)
+        Ok(self.pack_result(result, qd, qt))
     }
 
     /// When the queue is closed, we need to cancel all pending ops. When the coroutine is removed, we only need to

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -186,7 +186,7 @@ impl SharedDemiRuntime {
     /// and gets the result immediately.
     pub fn remove_coroutine_and_get_result(&mut self, handle: &TaskHandle, qt: u64) -> demi_qresult_t {
         let operation_task: OperationTask = self.remove_coroutine(handle);
-        let (qd, result) = operation_task.get_result().expect("Coroutine not finished");
+        let (qd, result) = operation_task.get_result().expect("coroutine not finished");
         self.pack_result(result, qd, qt)
     }
 

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -172,8 +172,8 @@ impl SharedDemiRuntime {
         }
     }
 
-    /// Inserts the `coroutine` named `task_name` into the scheduler.
-    /// This function also tracks the coroutine and it's yielder_handle.
+    /// Inserts the `coroutine` named `task_name` into the scheduler. This function also tracks the qd, coroutine and
+    /// it's yielder_handle.
     pub fn insert_coroutine_with_tracking(
         &mut self,
         task_name: &str,


### PR DESCRIPTION
Currently, pending ops management is done at the LibOS level. This has caused duplication of the hashmap datastructure and the associated management code in the `queue`, which decides when pending ops are added/removed/canceled.

After this change, the {qd -> {task_handle -> yielder_handle}} mappings will reside in the `runtime`, instead of the LibOS. This allows better tracking of yielder_handles and pending_op management in a cleaner manner. Another advantage of doing this is that the LibOS does not need to keep track of pending ops and cancellations. Additionaly, the coroutine constructors are simpler now because they don't need a `yielder` to be passed in any longer, so the `queue` does not need to create yielders.

This PR covers the following changes
- [runtime]
    - Simplifies remove_coroutine_and_get_result()
    - Add mappings to track qds/task_handles/yielder_handles at a central place
- [catnap]
    - Moved pending_ops management to runtime
    - Deleted remove_pending_op_if_needed() as it's no longer needed at the LibOS level
- [catloop]
    - Moved pending_ops management to runtime
    - Deleted remove_pending_op_if_needed() as it's no longer needed at the LibOS level