### PR TITLE
[runtime] Ephemeral Allocator Misses to Allocate Last Port on Private Range

### DIFF
--- a/src/rust/runtime/network/ephemeral.rs
+++ b/src/rust/runtime/network/ephemeral.rs
@@ -31,16 +31,6 @@ pub struct EphemeralPorts {
 //======================================================================================================================
 
 impl EphemeralPorts {
-    /// Creates a new ephemeral port allocator.
-    pub fn new(rng: &mut SmallRng) -> Self {
-        let mut ports: Vec<u16> = Vec::<u16>::new();
-        for port in FIRST_PRIVATE_PORT..LAST_PRIVATE_PORT {
-            ports.push(port);
-        }
-        ports.shuffle(rng);
-        Self { ports }
-    }
-
     /// Asserts wether a port is in the ephemeral port range.
     pub fn is_private(port: u16) -> bool {
         port >= FIRST_PRIVATE_PORT

--- a/src/rust/runtime/network/ephemeral.rs
+++ b/src/rust/runtime/network/ephemeral.rs
@@ -107,7 +107,7 @@ impl Default for EphemeralPorts {
             }
         };
         let mut ports: Vec<u16> = Vec::<u16>::new();
-        for port in FIRST_PRIVATE_PORT..LAST_PRIVATE_PORT {
+        for port in FIRST_PRIVATE_PORT..=LAST_PRIVATE_PORT {
             ports.push(port);
         }
         ports.shuffle(&mut rng);
@@ -171,7 +171,7 @@ mod test {
         let mut ports: EphemeralPorts = EphemeralPorts::default();
 
         // Allocate all ports.
-        for _ in FIRST_PRIVATE_PORT..LAST_PRIVATE_PORT {
+        for _ in FIRST_PRIVATE_PORT..=LAST_PRIVATE_PORT {
             if let Err(e) = ports.alloc() {
                 anyhow::bail!("failed to allocate an ephemeral port (error={:?})", &e);
             }
@@ -183,7 +183,7 @@ mod test {
         }
 
         // Free all ports.
-        for port in FIRST_PRIVATE_PORT..LAST_PRIVATE_PORT {
+        for port in FIRST_PRIVATE_PORT..=LAST_PRIVATE_PORT {
             if let Err(e) = ports.free(port) {
                 anyhow::bail!("failed to free ephemeral port (error={:?})", &e);
             }
@@ -198,7 +198,7 @@ mod test {
         let mut ports: EphemeralPorts = EphemeralPorts::default();
 
         // Allocate all ports.
-        for port in FIRST_PRIVATE_PORT..LAST_PRIVATE_PORT {
+        for port in FIRST_PRIVATE_PORT..=LAST_PRIVATE_PORT {
             if let Err(e) = ports.reserve(port) {
                 anyhow::bail!("failed to allocate an ephemeral port (port={:?}, error={:?})", port, &e);
             }
@@ -210,7 +210,7 @@ mod test {
         }
 
         // Free all ports.
-        for port in FIRST_PRIVATE_PORT..LAST_PRIVATE_PORT {
+        for port in FIRST_PRIVATE_PORT..=LAST_PRIVATE_PORT {
             if let Err(e) = ports.free(port) {
                 anyhow::bail!("failed to free ephemeral port (port={:?}, error={:?})", port, &e);
             }


### PR DESCRIPTION
## Description

This PR closes https://github.com/microsoft/demikernel/issues/1039

## Summary of Changes

- Included last port in the allocator
- Changed shuffling to occur only on release mode
- Cleaned up dead code