### PR TITLE
[runtime] Simplify state machine

### DIFF
--- a/src/rust/catloop/socket.rs
+++ b/src/rust/catloop/socket.rs
@@ -115,7 +115,7 @@ impl Socket {
         remote: Option<SocketAddrV4>,
     ) -> Self {
         Self {
-            state: SocketStateMachine::new_connected(),
+            state: SocketStateMachine::new_established(),
             catmem,
             catmem_qd: Some(catmem_qd),
             local,
@@ -142,7 +142,7 @@ impl Socket {
                 Some(qd)
             },
             Err(e) => {
-                self.state.rollback();
+                self.state.abort();
                 return Err(e);
             },
         };
@@ -165,13 +165,12 @@ impl Socket {
         &mut self,
         coroutine_constructor: F,
     ) -> Result<TaskHandle, Fail> {
-        self.state.prepare(SocketOp::Accept)?;
+        self.state.may_accept()?;
         self.do_generic_sync_control_path_call(coroutine_constructor)
     }
 
     /// Attempts to accept a new connection on this socket. On success, returns a new Socket for the accepted connection.
     pub async fn do_accept(&mut self, ipv4: Ipv4Addr, new_port: u16, yielder: &Yielder) -> Result<Self, Fail> {
-        self.state.prepare(SocketOp::Accepted)?;
         let mut catmem: SharedCatmemLibOS = self.catmem.clone();
         let catmem_qd: QDesc = self.catmem_qd.expect("Must be a catmem queue in this state.");
         loop {
@@ -201,7 +200,6 @@ impl Socket {
                         match create_pipe(&mut catmem, catmem_qd, &ipv4, new_port, &yielder).await {
                             Ok(new_qd) => new_qd,
                             Err(e) => {
-                                self.state.rollback();
                                 return Err(e);
                             },
                         }
@@ -209,7 +207,6 @@ impl Socket {
                 },
                 // Some error.
                 Err(e) => {
-                    self.state.rollback();
                     return Err(e);
                 },
             };
@@ -229,7 +226,6 @@ impl Socket {
                 },
                 // Some error.
                 Err(e) => {
-                    self.state.rollback();
                     // Clean up newly allocated duplex pipe.
                     catmem.close(new_qd)?;
                     return Err(e);
@@ -248,7 +244,6 @@ impl Socket {
 
     /// Connects this socket to [remote].
     pub async fn do_connect(&mut self, remote: SocketAddrV4, yielder: &Yielder) -> Result<(), Fail> {
-        self.state.prepare(SocketOp::Connected)?;
         let ipv4: &Ipv4Addr = remote.ip();
         let port: u16 = remote.port().into();
         let mut catmem: SharedCatmemLibOS = self.catmem.clone();
@@ -260,7 +255,8 @@ impl Socket {
             let new_port: u16 = match get_port(&mut catmem, ipv4, port, &request_id, yielder).await {
                 Ok(new_port) => new_port,
                 Err(e) => {
-                    self.state.rollback();
+                    self.state.prepare(SocketOp::Closed)?;
+                    self.state.commit();
                     return Err(e);
                 },
             };
@@ -270,13 +266,15 @@ impl Socket {
             let new_qd: QDesc = match catmem.open_pipe(&format_pipe_str(ipv4, new_port)) {
                 Ok(new_qd) => new_qd,
                 Err(e) => {
-                    self.state.rollback();
+                    self.state.prepare(SocketOp::Closed)?;
+                    self.state.commit();
                     return Err(e);
                 },
             };
             // Send an ack to the server over the new pipe.
             if let Err(e) = send_ack(&mut catmem, new_qd, &request_id, &yielder).await {
-                self.state.rollback();
+                self.state.prepare(SocketOp::Closed)?;
+                self.state.commit();
                 return Err(e);
             }
             Ok((new_qd, remote))
@@ -284,13 +282,15 @@ impl Socket {
 
         match result {
             Ok((new_qd, remote)) => {
+                self.state.prepare(SocketOp::Established)?;
                 self.state.commit();
                 self.catmem_qd = Some(new_qd);
                 self.remote = Some(remote);
                 Ok(())
             },
             Err(e) => {
-                self.state.rollback();
+                self.state.prepare(SocketOp::Closed)?;
+                self.state.commit();
                 Err(e)
             },
         }
@@ -300,15 +300,14 @@ impl Socket {
     pub fn close(&mut self) -> Result<(), Fail> {
         self.state.prepare(SocketOp::Close)?;
         self.state.commit();
-        self.state.prepare(SocketOp::Closed)?;
         if let Some(qd) = self.catmem_qd {
             match self.catmem.close(qd) {
                 Ok(()) => {
+                    self.state.prepare(SocketOp::Closed)?;
                     self.state.commit();
                     return Ok(());
                 },
                 Err(e) => {
-                    self.state.rollback();
                     return Err(e);
                 },
             }
@@ -331,15 +330,14 @@ impl Socket {
         // TODO: Should we assert that we're still in the close state?
         let catmem_qd: Option<QDesc> = self.catmem_qd;
         if let Some(qd) = catmem_qd {
-            self.state.prepare(SocketOp::Closed)?;
             match self.catmem.clone().close_coroutine(qd, yielder).await {
                 (qd, OperationResult::Close) => {
+                    self.state.prepare(SocketOp::Closed)?;
                     self.state.commit();
                     Ok((qd, OperationResult::Close))
                 },
                 (qd, OperationResult::Failed(e)) => {
                     // Where to revert to?
-                    self.state.rollback();
                     Ok((qd, OperationResult::Failed(e)))
                 },
                 _ => panic!("Should not return anything other than close or fail"),
@@ -353,6 +351,7 @@ impl Socket {
     /// Schedule a coroutine to push to this queue. This function contains all of the single-queue,
     /// asynchronous code necessary to run push a buffer and any single-queue functionality after the push completes.
     pub fn push<F: FnOnce() -> Result<TaskHandle, Fail>>(&self, coroutine_constructor: F) -> Result<TaskHandle, Fail> {
+        self.state.may_push()?;
         coroutine_constructor()
     }
 
@@ -369,6 +368,7 @@ impl Socket {
     /// Schedule a coroutine to pop from the underlying Catmem queue. This function contains all of the single-queue,
     /// asynchronous code necessary to run push a buffer and any single-queue functionality after the pop completes.
     pub fn pop<F: FnOnce() -> Result<TaskHandle, Fail>>(&self, coroutine_constructor: F) -> Result<TaskHandle, Fail> {
+        self.state.may_pop()?;
         coroutine_constructor()
     }
 

--- a/src/rust/runtime/network/socket/operation.rs
+++ b/src/rust/runtime/network/socket/operation.rs
@@ -9,10 +9,8 @@
 pub enum SocketOp {
     Bind,
     Listen,
-    Accept,
-    Accepted,
     Connect,
-    Connected,
+    Established,
     Close,
     Closed,
 }


### PR DESCRIPTION
To begin unifying the state machines between the libOSes and runtime, I have simplified the state machine to only the states that require changes between the metadata state. Further, I have removed the rollback states (as they will not be able to also hold metadata) and simplified error handling by having the libOSes move the state machine to the closed state for now. We can revisit this decision later after we have integrated the inetstack into the state machine. This PR closes #1035 