### PR TITLE
[inetstack] Check for non-local address

### DIFF
--- a/src/rust/inetstack/protocols/tcp/peer.rs
+++ b/src/rust/inetstack/protocols/tcp/peer.rs
@@ -144,7 +144,11 @@ impl<const N: usize> SharedTcpPeer<N> {
         }
 
         // TODO: Check if we are binding to a non-local address.
-
+        if *local.ip() != self.local_ipv4_addr {
+            let cause: String = format!("cannot bind to non-local address (qd={:?})", qd);
+            error!("bind(): {}", cause);
+            return Err(Fail::new(libc::EADDRNOTAVAIL, &cause));
+        }
         // Check whether the address is in use.
         if self.runtime.addr_in_use(local) {
             let cause: String = format!("address is already bound to a socket (qd={:?}", qd);


### PR DESCRIPTION
This PR fixes the single non-passing test in the integration tests for bind. This closes #1010 