### PR TITLE
[inetstack] Remove background coroutine from active connect

### DIFF
--- a/src/rust/inetstack/protocols/tcp/active_open.rs
+++ b/src/rust/inetstack/protocols/tcp/active_open.rs
@@ -59,6 +59,7 @@ use ::std::{
         DerefMut,
     },
 };
+
 //======================================================================================================================
 // Structures
 //======================================================================================================================
@@ -116,8 +117,8 @@ impl<const N: usize> SharedActiveOpenSocket<N> {
         self.recv_queue.push(header);
     }
 
-    pub fn process_ack(&mut self, header: TcpHeader) -> Result<EstablishedSocket<N>, Fail> {
-        let expected_seq = self.local_isn + SeqNumber::from(1);
+    fn process_ack(&mut self, header: TcpHeader) -> Result<EstablishedSocket<N>, Fail> {
+        let expected_seq: SeqNumber = self.local_isn + SeqNumber::from(1);
 
         // Bail if we didn't receive a ACK packet with the right sequence number.
         if !(header.ack && header.ack_num == expected_seq) {

--- a/src/rust/inetstack/protocols/tcp/established/ctrlblk.rs
+++ b/src/rust/inetstack/protocols/tcp/established/ctrlblk.rs
@@ -391,7 +391,7 @@ impl<const N: usize> SharedControlBlock<N> {
 
     // This is the main TCP receive routine.
     //
-    pub fn receive(&mut self, header: &mut TcpHeader, mut data: DemiBuffer) {
+    pub fn receive(&mut self, mut header: TcpHeader, mut data: DemiBuffer) {
         debug!(
             "{:?} Connection Receiving {} bytes + {:?}",
             self.state,
@@ -615,7 +615,7 @@ impl<const N: usize> SharedControlBlock<N> {
                 self.sender.send_unacked.set(header.ack_num);
 
                 // Update our send window (SND.WND).
-                self.sender.update_send_window(header);
+                self.sender.update_send_window(&header);
 
                 if header.ack_num == send_next {
                     // This segment acknowledges everything we've sent so far (i.e. nothing is currently outstanding).

--- a/src/rust/inetstack/protocols/tcp/established/mod.rs
+++ b/src/rust/inetstack/protocols/tcp/established/mod.rs
@@ -102,7 +102,7 @@ impl<const N: usize> EstablishedSocket<N> {
         })
     }
 
-    pub fn receive(&mut self, header: &mut TcpHeader, data: DemiBuffer) {
+    pub fn receive(&mut self, header: TcpHeader, data: DemiBuffer) {
         self.cb.receive(header, data)
     }
 

--- a/src/rust/inetstack/protocols/tcp/passive_open.rs
+++ b/src/rust/inetstack/protocols/tcp/passive_open.rs
@@ -168,7 +168,7 @@ impl<const N: usize> SharedPassiveSocket<N> {
         self.ready.pop(yielder).await
     }
 
-    pub fn receive(&mut self, ip_header: &Ipv4Header, header: &TcpHeader) -> Result<(), Fail> {
+    pub fn receive(&mut self, ip_header: &Ipv4Header, header: TcpHeader) -> Result<(), Fail> {
         let remote = SocketAddrV4::new(ip_header.get_src_addr(), header.src_port);
         if self.ready.endpoints.contains(&remote) {
             // TODO: What should we do if a packet shows up for a connection that hasn't been `accept`ed yet?

--- a/src/rust/inetstack/protocols/tcp/peer.rs
+++ b/src/rust/inetstack/protocols/tcp/peer.rs
@@ -460,7 +460,7 @@ impl<const N: usize> SharedTcpPeer<N> {
 
     /// Processes an incoming TCP segment.
     pub fn receive(&mut self, ip_hdr: &Ipv4Header, buf: DemiBuffer) -> Result<(), Fail> {
-        let (mut tcp_hdr, data): (TcpHeader, DemiBuffer) =
+        let (tcp_hdr, data): (TcpHeader, DemiBuffer) =
             TcpHeader::parse(ip_hdr, buf, self.tcp_config.get_rx_checksum_offload())?;
         debug!("TCP received {:?}", tcp_hdr);
         let local: SocketAddrV4 = SocketAddrV4::new(ip_hdr.get_dest_addr(), tcp_hdr.dst_port);
@@ -487,7 +487,7 @@ impl<const N: usize> SharedTcpPeer<N> {
 
         // Dispatch to further processing depending on the socket state.
         self.get_shared_queue(&qd)?
-            .receive(&ip_hdr, &mut tcp_hdr, &local, &remote, data)
+            .receive(ip_hdr, tcp_hdr, local, remote, data)
     }
 }
 

--- a/src/rust/inetstack/protocols/tcp/queue.rs
+++ b/src/rust/inetstack/protocols/tcp/queue.rs
@@ -426,11 +426,22 @@ impl<const N: usize> SharedTcpQueue<N> {
     pub fn receive(
         &mut self,
         ip_hdr: &Ipv4Header,
-        tcp_hdr: &mut TcpHeader,
-        local: &SocketAddrV4,
-        remote: &SocketAddrV4,
+        tcp_hdr: TcpHeader,
+        local: SocketAddrV4,
+        remote: SocketAddrV4,
         buf: DemiBuffer,
     ) -> Result<(), Fail> {
+        // Grab the seq number for later.
+        let (seq_num, ack_num): (SeqNumber, Option<SeqNumber>) = if tcp_hdr.ack {
+            (tcp_hdr.ack_num, None)
+        } else {
+            (
+                SeqNumber::from(0),
+                Some(tcp_hdr.seq_num + SeqNumber::from(tcp_hdr.compute_size() as u32)),
+            )
+        };
+
+        // Route the TCP packet to the socket.
         match self.socket {
             Socket::Established(ref mut socket) => {
                 debug!("Routing to established connection: {:?}", socket.endpoints());
@@ -439,12 +450,12 @@ impl<const N: usize> SharedTcpQueue<N> {
             },
             Socket::Connecting(ref mut socket) => {
                 debug!("Routing to connecting connection: {:?}", socket.endpoints());
-                socket.receive(&tcp_hdr);
+                socket.receive(tcp_hdr);
                 return Ok(());
             },
             Socket::Listening(ref mut socket) => {
                 debug!("Routing to passive connection: {:?}", socket.endpoint());
-                match socket.receive(ip_hdr, &tcp_hdr) {
+                match socket.receive(ip_hdr, tcp_hdr) {
                     Ok(()) => return Ok(()),
                     // Connection was refused.
                     Err(e) if e.errno == libc::ECONNREFUSED => {
@@ -474,15 +485,6 @@ impl<const N: usize> SharedTcpQueue<N> {
         // reset has sequence number zero and the ACK field is set to the sum
         // of the sequence number and segment length of the incoming segment.
         // Reference: https://datatracker.ietf.org/doc/html/rfc793#section-3.4
-        let (seq_num, ack_num): (SeqNumber, Option<SeqNumber>) = if tcp_hdr.ack {
-            (tcp_hdr.ack_num, None)
-        } else {
-            (
-                SeqNumber::from(0),
-                Some(tcp_hdr.seq_num + SeqNumber::from(tcp_hdr.compute_size() as u32)),
-            )
-        };
-
         debug!("receive(): sending RST (local={:?}, remote={:?})", local, remote);
         self.send_rst(&local, &remote, seq_num, ack_num)?;
         Ok(())

--- a/src/rust/inetstack/protocols/tcp/tests/setup.rs
+++ b/src/rust/inetstack/protocols/tcp/tests/setup.rs
@@ -27,6 +27,7 @@ use crate::{
         },
     },
     runtime::{
+        fail::Fail,
         memory::DemiBuffer,
         network::{
             consts::RECEIVE_BATCH_SIZE,
@@ -99,7 +100,8 @@ fn test_connection_timeout() -> Result<()> {
         .get_result()
     {
         None => Ok(()),
-        _ => anyhow::bail!("connect should have timed out"),
+        Some((_, OperationResult::Failed(Fail { errno, cause: _ }))) if errno == libc::ETIMEDOUT => Ok(()),
+        Some(result) => anyhow::bail!("connect should have timed out, instead returned: {:?}", result),
     }
 }
 


### PR DESCRIPTION
This PR is a step towards having a linear flow for all of our TCP state machines by doing the following:
1. Using the connect coroutine to directly drive retries of SYN send instead of another background coroutine.
2. Directly moving the TcpHeader/packet to the module where it will be processed rather than borrowing it in the receive path. The receive path simply pushes the packet into an AsyncQueue, while the connect coroutine waits on arriving packets. The connect coroutine will then wake up and process the incoming packet.
3. The flow of connect is not changed too much because it only requires waiting on one packet. The utility of this architecture will be clear once we are performing part of the architecture with more steps. Here we are mostly getting rid of the extra coroutine.