### PR TITLE
[inetstack] Move tcp pending ops mgmt to runtime

### DIFF
--- a/src/rust/catloop/queue.rs
+++ b/src/rust/catloop/queue.rs
@@ -105,10 +105,10 @@ impl SharedCatloopQueue {
 
     /// Starts a coroutine to begin accepting on this queue. This function contains all of the single-queue,
     /// synchronous functionality necessary to start an accept.
-    pub fn accept<F: FnOnce() -> Result<TaskHandle, Fail>>(
-        &mut self,
-        coroutine_constructor: F,
-    ) -> Result<QToken, Fail> {
+    pub fn accept<F>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail>
+    where
+        F: FnOnce() -> Result<TaskHandle, Fail>,
+    {
         let task_handle: TaskHandle = self.socket.accept(coroutine_constructor)?;
         Ok(task_handle.get_task_id().into())
     }
@@ -131,10 +131,10 @@ impl SharedCatloopQueue {
     /// Start an asynchronous coroutine to start connecting this queue. This function contains all of the single-queue,
     /// asynchronous code necessary to connect to a remote endpoint and any single-queue functionality after the
     /// connect completes.
-    pub fn connect<F: FnOnce() -> Result<TaskHandle, Fail>>(
-        &mut self,
-        coroutine_constructor: F,
-    ) -> Result<QToken, Fail> {
+    pub fn connect<F>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail>
+    where
+        F: FnOnce() -> Result<TaskHandle, Fail>,
+    {
         let task_handle: TaskHandle = self.socket.connect(coroutine_constructor)?;
         Ok(task_handle.get_task_id().into())
     }
@@ -152,10 +152,10 @@ impl SharedCatloopQueue {
     }
 
     /// Start an asynchronous coroutine to close this queue.
-    pub fn async_close<F: FnOnce() -> Result<TaskHandle, Fail>>(
-        &mut self,
-        coroutine_constructor: F,
-    ) -> Result<QToken, Fail> {
+    pub fn async_close<F>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail>
+    where
+        F: FnOnce() -> Result<TaskHandle, Fail>,
+    {
         let task_handle: TaskHandle = self.socket.async_close(coroutine_constructor)?;
         Ok(task_handle.get_task_id().into())
     }
@@ -168,7 +168,10 @@ impl SharedCatloopQueue {
 
     /// Schedule a coroutine to push to this queue. This function contains all of the single-queue,
     /// asynchronous code necessary to run push a buffer and any single-queue functionality after the push completes.
-    pub fn push<F: FnOnce() -> Result<TaskHandle, Fail>>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail> {
+    pub fn push<F>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail>
+    where
+        F: FnOnce() -> Result<TaskHandle, Fail>,
+    {
         let task_handle: TaskHandle = self.socket.push(coroutine_constructor)?;
         Ok(task_handle.get_task_id().into())
     }
@@ -179,8 +182,11 @@ impl SharedCatloopQueue {
 
     /// Schedule a coroutine to pop from this queue. This function contains all of the single-queue,
     /// asynchronous code necessary to run push a buffer and any single-queue functionality after the pop completes.
-    pub fn pop<F: FnOnce() -> Result<TaskHandle, Fail>>(&mut self, insert_coroutine: F) -> Result<QToken, Fail> {
-        let task_handle: TaskHandle = self.socket.pop(insert_coroutine)?;
+    pub fn pop<F>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail>
+    where
+        F: FnOnce() -> Result<TaskHandle, Fail>,
+    {
+        let task_handle: TaskHandle = self.socket.pop(coroutine_constructor)?;
         Ok(task_handle.get_task_id().into())
     }
 

--- a/src/rust/catloop/socket.rs
+++ b/src/rust/catloop/socket.rs
@@ -161,10 +161,10 @@ impl Socket {
         Ok(())
     }
 
-    pub fn accept<F: FnOnce() -> Result<TaskHandle, Fail>>(
-        &mut self,
-        coroutine_constructor: F,
-    ) -> Result<TaskHandle, Fail> {
+    pub fn accept<F>(&mut self, coroutine_constructor: F) -> Result<TaskHandle, Fail>
+    where
+        F: FnOnce() -> Result<TaskHandle, Fail>,
+    {
         self.state.may_accept()?;
         self.do_generic_sync_control_path_call(coroutine_constructor)
     }
@@ -234,10 +234,10 @@ impl Socket {
         }
     }
 
-    pub fn connect<F: FnOnce() -> Result<TaskHandle, Fail>>(
-        &mut self,
-        coroutine_constructor: F,
-    ) -> Result<TaskHandle, Fail> {
+    pub fn connect<F>(&mut self, coroutine_constructor: F) -> Result<TaskHandle, Fail>
+    where
+        F: FnOnce() -> Result<TaskHandle, Fail>,
+    {
         self.state.prepare(SocketOp::Connect)?;
         self.do_generic_sync_control_path_call(coroutine_constructor)
     }
@@ -317,10 +317,10 @@ impl Socket {
     }
 
     /// Asynchronously closes this socket by allocating a coroutine.
-    pub fn async_close<F: FnOnce() -> Result<TaskHandle, Fail>>(
-        &mut self,
-        coroutine_constructor: F,
-    ) -> Result<TaskHandle, Fail> {
+    pub fn async_close<F>(&mut self, coroutine_constructor: F) -> Result<TaskHandle, Fail>
+    where
+        F: FnOnce() -> Result<TaskHandle, Fail>,
+    {
         self.state.prepare(SocketOp::Close)?;
         Ok(self.do_generic_sync_control_path_call(coroutine_constructor)?)
     }
@@ -350,7 +350,10 @@ impl Socket {
 
     /// Schedule a coroutine to push to this queue. This function contains all of the single-queue,
     /// asynchronous code necessary to run push a buffer and any single-queue functionality after the push completes.
-    pub fn push<F: FnOnce() -> Result<TaskHandle, Fail>>(&self, coroutine_constructor: F) -> Result<TaskHandle, Fail> {
+    pub fn push<F>(&self, coroutine_constructor: F) -> Result<TaskHandle, Fail>
+    where
+        F: FnOnce() -> Result<TaskHandle, Fail>,
+    {
         self.state.may_push()?;
         coroutine_constructor()
     }
@@ -367,7 +370,10 @@ impl Socket {
 
     /// Schedule a coroutine to pop from the underlying Catmem queue. This function contains all of the single-queue,
     /// asynchronous code necessary to run push a buffer and any single-queue functionality after the pop completes.
-    pub fn pop<F: FnOnce() -> Result<TaskHandle, Fail>>(&self, coroutine_constructor: F) -> Result<TaskHandle, Fail> {
+    pub fn pop<F>(&self, coroutine_constructor: F) -> Result<TaskHandle, Fail>
+    where
+        F: FnOnce() -> Result<TaskHandle, Fail>,
+    {
         self.state.may_pop()?;
         coroutine_constructor()
     }
@@ -396,10 +402,10 @@ impl Socket {
     }
 
     /// Generic function for spawning a control-path coroutine on [self].
-    fn do_generic_sync_control_path_call<F: FnOnce() -> Result<TaskHandle, Fail>>(
-        &mut self,
-        coroutine_constructor: F,
-    ) -> Result<TaskHandle, Fail> {
+    fn do_generic_sync_control_path_call<F>(&mut self, coroutine_constructor: F) -> Result<TaskHandle, Fail>
+    where
+        F: FnOnce() -> Result<TaskHandle, Fail>,
+    {
         // Spawn coroutine.
         match coroutine_constructor() {
             // We successfully spawned the coroutine.

--- a/src/rust/catmem/queue.rs
+++ b/src/rust/catmem/queue.rs
@@ -116,12 +116,12 @@ impl SharedCatmemQueue {
 
     /// Start an asynchronous coroutine to close this queue. This function contains all of the single-queue,
     /// asynchronous code necessary to run a close and any single-queue functionality after the close completes.
-    pub fn async_close<F>(&mut self, insert_coroutine: F) -> Result<QToken, Fail>
+    pub fn async_close<F>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail>
     where
         F: FnOnce(Yielder) -> Result<TaskHandle, Fail>,
     {
         self.ring.prepare_close()?;
-        self.do_generic_sync_control_path_call(insert_coroutine, false)
+        self.do_generic_sync_control_path_call(coroutine_constructor, false)
     }
 
     /// This function perms an async close on the target queue.
@@ -155,8 +155,11 @@ impl SharedCatmemQueue {
 
     /// Schedule a coroutine to pop from this queue. This function contains all of the single-queue,
     /// asynchronous code necessary to pop a buffer and any single-queue functionality after the pop completes.
-    pub fn pop<F: FnOnce(Yielder) -> Result<TaskHandle, Fail>>(&mut self, insert_coroutine: F) -> Result<QToken, Fail> {
-        self.do_generic_sync_data_path_call(insert_coroutine)
+    pub fn pop<F>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail>
+    where
+        F: FnOnce(Yielder) -> Result<TaskHandle, Fail>,
+    {
+        self.do_generic_sync_data_path_call(coroutine_constructor)
     }
 
     /// This function pops a buffer of optional [size] from the queue. If the queue is connected to the push end of a
@@ -194,11 +197,11 @@ impl SharedCatmemQueue {
 
     /// Schedule a coroutine to push to this queue. This function contains all of the single-queue,
     /// asynchronous code necessary to run push a buffer and any single-queue functionality after the push completes.
-    pub fn push<F: FnOnce(Yielder) -> Result<TaskHandle, Fail>>(
-        &mut self,
-        insert_coroutine: F,
-    ) -> Result<QToken, Fail> {
-        self.do_generic_sync_data_path_call(insert_coroutine)
+    pub fn push<F>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail>
+    where
+        F: FnOnce(Yielder) -> Result<TaskHandle, Fail>,
+    {
+        self.do_generic_sync_data_path_call(coroutine_constructor)
     }
 
     /// This function tries to push [buf] to the shared memory ring. If the queue is connected to the pop end, then

--- a/src/rust/catnap/queue.rs
+++ b/src/rust/catnap/queue.rs
@@ -136,10 +136,10 @@ impl SharedCatnapQueue {
 
     /// Starts a coroutine to begin accepting on this queue. This function contains all of the single-queue,
     /// synchronous functionality necessary to start an accept.
-    pub fn accept<F: FnOnce() -> Result<TaskHandle, Fail>>(
-        &mut self,
-        coroutine_constructor: F,
-    ) -> Result<QToken, Fail> {
+    pub fn accept<F>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail>
+    where
+        F: FnOnce() -> Result<TaskHandle, Fail>,
+    {
         self.state_machine.may_accept()?;
         let task_handle: TaskHandle = self.do_generic_sync_control_path_call(coroutine_constructor)?;
         Ok(task_handle.get_task_id().into())
@@ -173,10 +173,10 @@ impl SharedCatnapQueue {
     /// Start an asynchronous coroutine to start connecting this queue. This function contains all of the single-queue,
     /// asynchronous code necessary to connect to a remote endpoint and any single-queue functionality after the
     /// connect completes.
-    pub fn connect<F: FnOnce() -> Result<TaskHandle, Fail>>(
-        &mut self,
-        coroutine_constructor: F,
-    ) -> Result<QToken, Fail> {
+    pub fn connect<F>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail>
+    where
+        F: FnOnce() -> Result<TaskHandle, Fail>,
+    {
         self.state_machine.prepare(SocketOp::Connect)?;
         let task_handle: TaskHandle = self.do_generic_sync_control_path_call(coroutine_constructor)?;
         Ok(task_handle.get_task_id().into())
@@ -205,10 +205,10 @@ impl SharedCatnapQueue {
     }
 
     /// Start an asynchronous coroutine to close this queue.
-    pub fn async_close<F: FnOnce() -> Result<TaskHandle, Fail>>(
-        &mut self,
-        coroutine_constructor: F,
-    ) -> Result<QToken, Fail> {
+    pub fn async_close<F>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail>
+    where
+        F: FnOnce() -> Result<TaskHandle, Fail>,
+    {
         self.state_machine.prepare(SocketOp::Close)?;
         let task_handle: TaskHandle = self.do_generic_sync_control_path_call(coroutine_constructor)?;
         Ok(task_handle.get_task_id().into())
@@ -243,7 +243,10 @@ impl SharedCatnapQueue {
 
     /// Schedule a coroutine to push to this queue. This function contains all of the single-queue,
     /// asynchronous code necessary to run push a buffer and any single-queue functionality after the push completes.
-    pub fn push<F: FnOnce() -> Result<TaskHandle, Fail>>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail> {
+    pub fn push<F>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail>
+    where
+        F: FnOnce() -> Result<TaskHandle, Fail>,
+    {
         self.state_machine.may_push()?;
         self.do_generic_sync_data_path_call(coroutine_constructor)
     }
@@ -269,7 +272,10 @@ impl SharedCatnapQueue {
     /// Schedules a coroutine to pop from this queue. This function contains all of the single-queue,
     /// asynchronous code necessary to pop a buffer from this queue and any single-queue functionality after the pop
     /// completes.
-    pub fn pop<F: FnOnce() -> Result<TaskHandle, Fail>>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail> {
+    pub fn pop<F>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail>
+    where
+        F: FnOnce() -> Result<TaskHandle, Fail>,
+    {
         self.state_machine.may_pop()?;
         self.do_generic_sync_data_path_call(coroutine_constructor)
     }
@@ -299,10 +305,10 @@ impl SharedCatnapQueue {
     }
 
     /// Generic function for spawning a control-path coroutine on [self].
-    fn do_generic_sync_control_path_call<F: FnOnce() -> Result<TaskHandle, Fail>>(
-        &mut self,
-        coroutine_constructor: F,
-    ) -> Result<TaskHandle, Fail> {
+    fn do_generic_sync_control_path_call<F>(&mut self, coroutine_constructor: F) -> Result<TaskHandle, Fail>
+    where
+        F: FnOnce() -> Result<TaskHandle, Fail>,
+    {
         // Spawn coroutine.
         match coroutine_constructor() {
             // We successfully spawned the coroutine.
@@ -321,10 +327,10 @@ impl SharedCatnapQueue {
     }
 
     /// Generic function for spawning a data-path coroutine on [self].
-    fn do_generic_sync_data_path_call<F: FnOnce() -> Result<TaskHandle, Fail>>(
-        &mut self,
-        coroutine_constructor: F,
-    ) -> Result<QToken, Fail> {
+    fn do_generic_sync_data_path_call<F>(&mut self, coroutine_constructor: F) -> Result<QToken, Fail>
+    where
+        F: FnOnce() -> Result<TaskHandle, Fail>,
+    {
         let task_handle: TaskHandle = coroutine_constructor()?;
         Ok(task_handle.get_task_id().into())
     }

--- a/src/rust/inetstack/protocols/tcp/peer.rs
+++ b/src/rust/inetstack/protocols/tcp/peer.rs
@@ -29,6 +29,7 @@ use crate::{
         scheduler::{
             TaskHandle,
             Yielder,
+            YielderHandle,
         },
         Operation,
         OperationResult,
@@ -212,7 +213,7 @@ impl<const N: usize> SharedTcpPeer<N> {
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("inetstack::tcp::accept for qd={:?}", qd);
             let yielder: Yielder = Yielder::new();
-            let yielder_handle = yielder.get_handle();
+            let yielder_handle: YielderHandle = yielder.get_handle();
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().accept_coroutine(qd, yielder));
             self.runtime
                 .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
@@ -287,7 +288,7 @@ impl<const N: usize> SharedTcpPeer<N> {
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("inetstack::tcp::connect for qd={:?}", qd);
             let yielder: Yielder = Yielder::new();
-            let yielder_handle = yielder.get_handle();
+            let yielder_handle: YielderHandle = yielder.get_handle();
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().connect_coroutine(qd, yielder));
             self.runtime
                 .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
@@ -324,7 +325,7 @@ impl<const N: usize> SharedTcpPeer<N> {
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("inetstack::tcp::push for qd={:?}", qd);
             let yielder: Yielder = Yielder::new();
-            let yielder_handle = yielder.get_handle();
+            let yielder_handle: YielderHandle = yielder.get_handle();
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().push_coroutine(qd, yielder));
             self.runtime
                 .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
@@ -358,7 +359,7 @@ impl<const N: usize> SharedTcpPeer<N> {
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("inetstack::tcp::pop for qd={:?}", qd);
             let yielder: Yielder = Yielder::new();
-            let yielder_handle = yielder.get_handle();
+            let yielder_handle: YielderHandle = yielder.get_handle();
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().pop_coroutine(qd, size, yielder));
             self.runtime
                 .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
@@ -408,7 +409,7 @@ impl<const N: usize> SharedTcpPeer<N> {
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("inetstack::tcp::close for qd={:?}", qd);
             let yielder: Yielder = Yielder::new();
-            let yielder_handle = yielder.get_handle();
+            let yielder_handle: YielderHandle = yielder.get_handle();
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().close_coroutine(qd, yielder));
             self.runtime
                 .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)

--- a/src/rust/inetstack/protocols/tcp/peer.rs
+++ b/src/rust/inetstack/protocols/tcp/peer.rs
@@ -207,13 +207,15 @@ impl<const N: usize> SharedTcpPeer<N> {
     /// Sets up the coroutine for accepting a new connection.
     pub fn accept(&mut self, qd: QDesc) -> Result<QToken, Fail> {
         trace!("accept(): qd={:?}", qd);
+
         let mut queue: SharedTcpQueue<N> = self.get_shared_queue(&qd)?;
-        let coroutine_constructor = |yielder: Yielder| -> Result<TaskHandle, Fail> {
-            // Asynchronous accept code. Clone the self reference and move into the coroutine.
+        let coroutine_constructor = || -> Result<TaskHandle, Fail> {
+            let task_name: String = format!("inetstack::tcp::accept for qd={:?}", qd);
+            let yielder: Yielder = Yielder::new();
+            let yielder_handle = yielder.get_handle();
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().accept_coroutine(qd, yielder));
-            // Insert async coroutine into the scheduler.
-            let task_name: String = format!("Catnap::accept for qd={:?}", qd);
-            self.runtime.insert_coroutine(&task_name, coroutine)
+            self.runtime
+                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
         };
 
         queue.accept(coroutine_constructor)
@@ -282,11 +284,13 @@ impl<const N: usize> SharedTcpPeer<N> {
             );
         }
         let local_isn: SeqNumber = self.isn_generator.generate(&local, &remote);
-        let coroutine_constructor = |yielder: Yielder| -> Result<TaskHandle, Fail> {
-            // Clone the self reference and move into the coroutine.
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().connect_coroutine(qd, yielder));
+        let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("inetstack::tcp::connect for qd={:?}", qd);
-            self.runtime.insert_coroutine(&task_name, coroutine)
+            let yielder: Yielder = Yielder::new();
+            let yielder_handle = yielder.get_handle();
+            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().connect_coroutine(qd, yielder));
+            self.runtime
+                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
         };
 
         queue.connect(local, remote, local_isn, coroutine_constructor)
@@ -317,12 +321,15 @@ impl<const N: usize> SharedTcpPeer<N> {
     /// Pushes immediately to the socket and returns the result asynchronously.
     pub fn push(&mut self, qd: QDesc, buf: DemiBuffer) -> Result<QToken, Fail> {
         let mut queue: SharedTcpQueue<N> = self.get_shared_queue(&qd)?;
-        let coroutine_constructor = |yielder: Yielder| -> Result<TaskHandle, Fail> {
-            // Clone the self reference and move into the coroutine.
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().push_coroutine(qd, yielder));
+        let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("inetstack::tcp::push for qd={:?}", qd);
-            self.runtime.insert_coroutine(&task_name, coroutine)
+            let yielder: Yielder = Yielder::new();
+            let yielder_handle = yielder.get_handle();
+            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().push_coroutine(qd, yielder));
+            self.runtime
+                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
         };
+
         queue.push(buf, coroutine_constructor)
     }
 
@@ -348,12 +355,15 @@ impl<const N: usize> SharedTcpPeer<N> {
     pub fn pop(&mut self, qd: QDesc, size: Option<usize>) -> Result<QToken, Fail> {
         // Get local address bound to socket.
         let mut queue: SharedTcpQueue<N> = self.get_shared_queue(&qd)?;
-        let coroutine_constructor = |yielder: Yielder| -> Result<TaskHandle, Fail> {
-            // Clone the self reference and move into the coroutine.
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().pop_coroutine(qd, size, yielder));
+        let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("inetstack::tcp::pop for qd={:?}", qd);
-            self.runtime.insert_coroutine(&task_name, coroutine)
+            let yielder: Yielder = Yielder::new();
+            let yielder_handle = yielder.get_handle();
+            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().pop_coroutine(qd, size, yielder));
+            self.runtime
+                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
         };
+
         queue.pop(coroutine_constructor)
     }
 
@@ -387,22 +397,21 @@ impl<const N: usize> SharedTcpPeer<N> {
                 _ => return Err(Fail::new(libc::EINVAL, "socket id did not map to this qd!")),
             };
         }
-        // // Free the queue.
-        // self.runtime
-        //     .free_queue::<SharedTcpQueue<N>>(&qd)
-        //     .expect("queue should exist");
         Ok(())
     }
 
     /// Closes a TCP socket.
     pub fn async_close(&mut self, qd: QDesc) -> Result<QToken, Fail> {
         trace!("Closing socket: qd={:?}", qd);
+
         let mut queue: SharedTcpQueue<N> = self.get_shared_queue(&qd)?;
-        let coroutine_constructor = |yielder: Yielder| -> Result<TaskHandle, Fail> {
-            // Clone the self reference and move into the coroutine.
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().close_coroutine(qd, yielder));
+        let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("inetstack::tcp::close for qd={:?}", qd);
-            self.runtime.insert_coroutine(&task_name, coroutine)
+            let yielder: Yielder = Yielder::new();
+            let yielder_handle = yielder.get_handle();
+            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().close_coroutine(qd, yielder));
+            self.runtime
+                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
         };
 
         queue.async_close(coroutine_constructor)


### PR DESCRIPTION
This PR moves the tcp pending ops mgmt to the runtime.

Please keep in mind that the synchronous `close()` path will soon be removed from the codebase.