### PR TITLE
[test] Use TCP Async Close in Test Engine

### DIFF
--- a/src/rust/inetstack/test_helpers/engine.rs
+++ b/src/rust/inetstack/test_helpers/engine.rs
@@ -161,6 +161,10 @@ impl<const N: usize> SharedEngine<N> {
         self.ipv4.tcp.close(socket_fd)
     }
 
+    pub fn tcp_async_close(&mut self, socket_fd: QDesc) -> Result<QToken, Fail> {
+        self.ipv4.tcp.async_close(socket_fd)
+    }
+
     pub fn tcp_listen(&mut self, socket_fd: QDesc, backlog: usize) -> Result<(), Fail> {
         self.ipv4.tcp.listen(socket_fd, backlog)
     }

--- a/src/rust/inetstack/test_helpers/engine.rs
+++ b/src/rust/inetstack/test_helpers/engine.rs
@@ -157,10 +157,6 @@ impl<const N: usize> SharedEngine<N> {
         self.ipv4.tcp.pop(socket_fd, None)
     }
 
-    pub fn tcp_close(&mut self, socket_fd: QDesc) -> Result<(), Fail> {
-        self.ipv4.tcp.close(socket_fd)
-    }
-
     pub fn tcp_async_close(&mut self, socket_fd: QDesc) -> Result<QToken, Fail> {
         self.ipv4.tcp.async_close(socket_fd)
     }


### PR DESCRIPTION
## Description

This PR changes the tcp test engine to use `async_close()` rather than `close()`.