### PR TITLE
[examples] Remove should_async_close flag from tcp-close

### DIFF
--- a/examples/tcp-close/args.rs
+++ b/examples/tcp-close/args.rs
@@ -30,8 +30,6 @@ pub struct ProgramArguments {
     peer_type: Option<String>,
     /// Who closes sockets?
     who_closes: Option<String>,
-    /// Should async close?
-    should_async_close: bool,
 }
 
 impl ProgramArguments {
@@ -63,14 +61,6 @@ impl ProgramArguments {
                     .required(false)
                     .value_name("server|client")
                     .help("Sets who_closes the sockets"),
-            )
-            .arg(
-                Arg::new("should_async_close")
-                    .long("should_async_close")
-                    .value_parser(clap::value_parser!(bool))
-                    .required(false)
-                    .value_name("true|false")
-                    .help("Sets should_async_close"),
             )
             .arg(
                 Arg::new("nclients")
@@ -108,7 +98,6 @@ impl ProgramArguments {
             nclients: None,
             peer_type: None,
             who_closes: None,
-            should_async_close: false,
         };
 
         // Number of clients.
@@ -135,14 +124,6 @@ impl ProgramArguments {
             args.who_closes = Some(who_closes.to_string());
         }
 
-        // Should close sockets using async_close()/close()?
-        if let Some(should_async_close) = matches.get_one::<bool>("should_async_close") {
-            match Some(should_async_close) {
-                Some(_) => args.should_async_close = *should_async_close,
-                None => anyhow::bail!("invalid should_async_close type"),
-            }
-        }
-
         Ok(args)
     }
 
@@ -164,11 +145,6 @@ impl ProgramArguments {
     /// Returns the `peer_type` command line argument.
     pub fn who_closes(&self) -> Option<String> {
         self.who_closes.clone()
-    }
-
-    /// Returns the `should_async_close` command line argument.
-    pub fn should_async_close(&self) -> bool {
-        self.should_async_close
     }
 
     /// Returns the `run_mode` command line argument.

--- a/examples/tcp-close/client.rs
+++ b/examples/tcp-close/client.rs
@@ -56,8 +56,6 @@ pub struct TcpClient {
     clients_connected: usize,
     /// Number of clients that closed their connection.
     clients_closed: usize,
-    /// Governs if the sockets are closed using async_close() or close().
-    should_async_close: bool,
 }
 
 //======================================================================================================================
@@ -66,7 +64,7 @@ pub struct TcpClient {
 
 impl TcpClient {
     /// Creates a new TCP client.
-    pub fn new(libos: LibOS, remote: SocketAddr, should_async_close: bool) -> Result<Self> {
+    pub fn new(libos: LibOS, remote: SocketAddr) -> Result<Self> {
         println!("Connecting to: {:?}", remote);
         Ok(Self {
             libos,
@@ -74,7 +72,6 @@ impl TcpClient {
             qds: HashSet::<QDesc>::default(),
             clients_connected: 0,
             clients_closed: 0,
-            should_async_close,
         })
     }
 
@@ -297,21 +294,13 @@ impl TcpClient {
 
     /// Issues a close() operation and deregisters the queue descriptor.
     fn issue_close(&mut self, qd: QDesc) -> Result<()> {
-        if self.should_async_close {
-            let qt: QToken = self.libos.async_close(qd)?;
+        let qt: QToken = self.libos.async_close(qd)?;
 
-            match self.libos.wait(qt, None) {
-                Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CLOSE && qr.qr_ret == 0 => (),
-                Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && is_closed(qr.qr_ret) => (),
-                Ok(_) => anyhow::bail!("wait() should succeed with async_close()"),
-                Err(_) => anyhow::bail!("wait() should succeed with async_close()"),
-            }
-        } else {
-            match self.libos.close(qd) {
-                Ok(_) => (),
-                Err(e) if e.errno == libc::ECONNRESET => (),
-                Err(_) => anyhow::bail!("wait() should succeed with close()"),
-            }
+        match self.libos.wait(qt, None) {
+            Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CLOSE && qr.qr_ret == 0 => (),
+            Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && is_closed(qr.qr_ret) => (),
+            Ok(_) => anyhow::bail!("wait() should succeed with async_close()"),
+            Err(_) => anyhow::bail!("wait() should succeed with async_close()"),
         }
         self.qds.remove(&qd);
         Ok(())

--- a/examples/tcp-close/client.rs
+++ b/examples/tcp-close/client.rs
@@ -5,6 +5,7 @@
 // Imports
 //======================================================================================================================
 
+use crate::helper_functions;
 use anyhow::Result;
 use demikernel::{
     demi_sgarray_t,
@@ -101,7 +102,7 @@ impl TcpClient {
                 },
             }
 
-            self.issue_close(qd)?;
+            self.issue_close_and_deregister_qd(qd)?;
         }
 
         Ok(())
@@ -148,7 +149,7 @@ impl TcpClient {
                     println!("{} clients connected", self.clients_connected);
 
                     self.clients_closed += 1;
-                    self.issue_close(qd)?;
+                    self.issue_close_and_deregister_qd(qd)?;
                 },
                 demi_opcode_t::DEMI_OPC_FAILED => {
                     anyhow::bail!("operation failed (qr_ret={:?})", qr.qr_ret)
@@ -193,7 +194,7 @@ impl TcpClient {
                             println!("server disconnected (pop returned 0 len buffer)");
                         },
                         demi_opcode_t::DEMI_OPC_FAILED => {
-                            if !is_closed(qr.qr_ret) {
+                            if !helper_functions::is_closed(qr.qr_ret) {
                                 anyhow::bail!("server should have had terminated the connection, but it has not")
                             }
                             println!("server disconnected (ECONNRESET)");
@@ -211,7 +212,7 @@ impl TcpClient {
                 },
             }
 
-            self.issue_close(qd)?;
+            self.issue_close_and_deregister_qd(qd)?;
         }
 
         Ok(())
@@ -263,7 +264,7 @@ impl TcpClient {
 
                     println!("server disconnected (pop returned 0 len buffer)");
                     self.clients_closed += 1;
-                    self.issue_close(qr.qr_qd.into())?;
+                    self.issue_close_and_deregister_qd(qr.qr_qd.into())?;
                 },
                 demi_opcode_t::DEMI_OPC_FAILED => {
                     let errno: i64 = qr.qr_ret;
@@ -274,7 +275,7 @@ impl TcpClient {
                     );
                     println!("server disconnected (ECONNRESET)");
                     self.clients_closed += 1;
-                    self.issue_close(qr.qr_qd.into())?;
+                    self.issue_close_and_deregister_qd(qr.qr_qd.into())?;
                 },
                 qr_opcode => {
                     anyhow::bail!("unexpected result (qr_opcode={:?})", qr_opcode)
@@ -292,29 +293,11 @@ impl TcpClient {
         Ok(qd)
     }
 
-    /// Issues a close() operation and deregisters the queue descriptor.
-    fn issue_close(&mut self, qd: QDesc) -> Result<()> {
-        let qt: QToken = self.libos.async_close(qd)?;
-
-        match self.libos.wait(qt, None) {
-            Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CLOSE && qr.qr_ret == 0 => (),
-            Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && is_closed(qr.qr_ret) => (),
-            Ok(_) => anyhow::bail!("wait() should succeed with async_close()"),
-            Err(_) => anyhow::bail!("wait() should succeed with async_close()"),
-        }
+    /// Issues the close() and wait() operations, and deregisters the queue descriptor.
+    fn issue_close_and_deregister_qd(&mut self, qd: QDesc) -> Result<()> {
+        helper_functions::close_and_wait(&mut self.libos, qd)?;
         self.qds.remove(&qd);
         Ok(())
-    }
-}
-
-//======================================================================================================================
-// Standalone functions
-//======================================================================================================================
-
-fn is_closed(ret: i64) -> bool {
-    match ret as i32 {
-        libc::ECONNRESET | libc::ENOTCONN | libc::ECANCELED | libc::EBADF => true,
-        _ => false,
     }
 }
 
@@ -326,7 +309,7 @@ impl Drop for TcpClient {
     // Releases all resources allocated to a pipe client.
     fn drop(&mut self) {
         for qd in self.qds.clone().drain() {
-            if let Err(e) = self.issue_close(qd) {
+            if let Err(e) = self.issue_close_and_deregister_qd(qd) {
                 println!("ERROR: close() failed (error={:?}", e);
                 println!("WARN: leaking qd={:?}", qd);
             }

--- a/examples/tcp-close/helper_functions.rs
+++ b/examples/tcp-close/helper_functions.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use anyhow::Result;
+use demikernel::{
+    runtime::types::demi_opcode_t,
+    LibOS,
+    QDesc,
+    QToken,
+};
+
+/// Returns true if the error code indicates that the socket is closed.
+pub fn is_closed(ret: i64) -> bool {
+    match ret as i32 {
+        libc::ECONNRESET | libc::ENOTCONN | libc::ECANCELED | libc::EBADF => true,
+        _ => false,
+    }
+}
+
+/// Issues a close() operation and waits for it to complete.
+pub fn close_and_wait(libos: &mut LibOS, qd: QDesc) -> Result<()> {
+    let qt: QToken = match libos.async_close(qd) {
+        Ok(qt) => qt,
+        Err(e) => anyhow::bail!("async_close() failed for qd: {:?}: {:?}", qd, e),
+    };
+
+    match libos.wait(qt, None) {
+        Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CLOSE && qr.qr_ret == 0 => {},
+        Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && is_closed(qr.qr_ret) => {},
+        _ => anyhow::bail!("wait() should succeed with async_close()"),
+    }
+
+    Ok(())
+}

--- a/examples/tcp-close/main.rs
+++ b/examples/tcp-close/main.rs
@@ -12,6 +12,7 @@
 
 mod args;
 mod client;
+mod helper_functions;
 mod server;
 
 use crate::{

--- a/examples/tcp-close/main.rs
+++ b/examples/tcp-close/main.rs
@@ -44,7 +44,7 @@ fn main() -> Result<()> {
     match args.who_closes().expect("missing whocloses the socket").as_str() {
         "client" => match args.peer_type().expect("missing peer_type").as_str() {
             "client" => {
-                let mut client: TcpClient = TcpClient::new(libos, args.addr(), args.should_async_close())?;
+                let mut client: TcpClient = TcpClient::new(libos, args.addr())?;
                 let nclients: usize = args.nclients().expect("missing number of clients");
                 match args.run_mode().as_str() {
                     "sequential" => client.run_sequential(nclients),
@@ -53,14 +53,14 @@ fn main() -> Result<()> {
                 }
             },
             "server" => {
-                let mut server: TcpServer = TcpServer::new(libos, args.addr(), args.should_async_close())?;
+                let mut server: TcpServer = TcpServer::new(libos, args.addr())?;
                 server.run(args.nclients())
             },
             _ => anyhow::bail!("invalid peer type"),
         },
         "server" => match args.peer_type().expect("missing peer_type").as_str() {
             "client" => {
-                let mut client: TcpClient = TcpClient::new(libos, args.addr(), args.should_async_close())?;
+                let mut client: TcpClient = TcpClient::new(libos, args.addr())?;
                 let nclients: usize = args.nclients().expect("missing number of clients");
                 match args.run_mode().as_str() {
                     "sequential" => client.run_sequential_expecting_server_to_close_sockets(nclients),
@@ -69,7 +69,7 @@ fn main() -> Result<()> {
                 }
             },
             "server" => {
-                let mut server: TcpServer = TcpServer::new(libos, args.addr(), args.should_async_close())?;
+                let mut server: TcpServer = TcpServer::new(libos, args.addr())?;
                 server.run_close_sockets_on_accept(args.nclients())
             },
             _ => anyhow::bail!("invalid peer type"),


### PR DESCRIPTION
This PR:
- Removes synchronous close from the `tcp-close` example.
- Moves common code to a helper functions module.

This is a part of the series of PRs aimed towards removing synchronous `close()` from Demikernel.

