### PR TITLE
[examples] Use `async_close()` in tcp-echo

### DIFF
--- a/examples/tcp-echo/helper_functions.rs
+++ b/examples/tcp-echo/helper_functions.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use anyhow::Result;
+use demikernel::{
+    runtime::types::demi_opcode_t,
+    LibOS,
+    QDesc,
+    QToken,
+};
+
+/// Returns true if the error code indicates that the socket is closed.
+pub fn is_closed(ret: i64) -> bool {
+    match ret as i32 {
+        libc::ECONNRESET | libc::ENOTCONN | libc::ECANCELED | libc::EBADF => true,
+        _ => false,
+    }
+}
+
+/// Issues a close() operation and waits for it to complete.
+pub fn close_and_wait(libos: &mut LibOS, qd: QDesc) -> Result<()> {
+    let qt: QToken = match libos.async_close(qd) {
+        Ok(qt) => qt,
+        Err(e) => anyhow::bail!("async_close() failed for qd: {:?}: {:?}", qd, e),
+    };
+
+    match libos.wait(qt, None) {
+        Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CLOSE && qr.qr_ret == 0 => {},
+        Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && is_closed(qr.qr_ret) => {},
+        _ => anyhow::bail!("wait() should succeed with async_close()"),
+    }
+
+    Ok(())
+}

--- a/examples/tcp-echo/main.rs
+++ b/examples/tcp-echo/main.rs
@@ -40,6 +40,7 @@ pub const AF_INET: i32 = libc::AF_INET;
 pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
 
 mod client;
+mod helper_functions;
 mod server;
 
 //======================================================================================================================


### PR DESCRIPTION
This PR:
- Removes synchronous close from the tcp-echo example.
- Moves common code to a helper functions module.

This is a part of the series of PRs aimed towards removing synchronous close() from Demikernel.