### PR TITLE
[runtime] Enhancement: Use runtime instead of libos

### DIFF
--- a/src/rust/catcollar/mod.rs
+++ b/src/rust/catcollar/mod.rs
@@ -47,14 +47,8 @@ use crate::{
             QToken,
             QType,
         },
-        scheduler::{
-            TaskHandle,
-            Yielder,
-        },
-        types::{
-            demi_qresult_t,
-            demi_sgarray_t,
-        },
+        scheduler::Yielder,
+        types::demi_sgarray_t,
         DemiRuntime,
         SharedDemiRuntime,
     },
@@ -661,30 +655,6 @@ impl CatcollarLibOS {
                 _ => panic!("pop failed: unknown error"),
             }
         }
-    }
-
-    pub fn poll(&mut self) {
-        self.runtime.poll()
-    }
-
-    pub fn schedule(&mut self, qt: QToken) -> Result<TaskHandle, Fail> {
-        self.runtime.from_task_id(qt.into())
-    }
-
-    pub fn pack_result(&mut self, handle: TaskHandle, qt: QToken) -> Result<demi_qresult_t, Fail> {
-        self.runtime.remove_coroutine_and_get_result(&handle, qt.into())
-    }
-
-    /// Allocates a scatter-gather array.
-    pub fn sgaalloc(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
-        trace!("sgalloc() size={:?}", size);
-        self.runtime.alloc_sgarray(size)
-    }
-
-    /// Frees a scatter-gather array.
-    pub fn sgafree(&self, sga: demi_sgarray_t) -> Result<(), Fail> {
-        trace!("sgafree()");
-        self.runtime.free_sgarray(sga)
     }
 
     fn get_shared_queue(&self, qd: &QDesc) -> Result<CatcollarQueue, Fail> {

--- a/src/rust/catloop/mod.rs
+++ b/src/rust/catloop/mod.rs
@@ -34,7 +34,6 @@ use crate::{
             Yielder,
             YielderHandle,
         },
-        types::demi_qresult_t,
         Operation,
         OperationResult,
         QDesc,
@@ -124,10 +123,11 @@ impl SharedCatloopLibOS {
         };
 
         // Create fake socket.
+        let runtime: SharedDemiRuntime = self.runtime.clone();
         let catmem: SharedCatmemLibOS = self.catmem.clone();
         let qd: QDesc = self
             .runtime
-            .alloc_queue::<SharedCatloopQueue>(SharedCatloopQueue::new(qtype, catmem)?);
+            .alloc_queue::<SharedCatloopQueue>(SharedCatloopQueue::new(qtype, runtime, catmem)?);
         Ok(qd)
     }
 
@@ -469,31 +469,6 @@ impl SharedCatloopLibOS {
                 panic!("Should not return anything other than pop or error.")
             },
         }
-    }
-
-    /// Allocates a scatter-gather array.
-    pub fn sgaalloc(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
-        self.runtime.alloc_sgarray(size)
-    }
-
-    /// Releases a scatter-gather array.
-    pub fn sgafree(&self, sga: demi_sgarray_t) -> Result<(), Fail> {
-        self.runtime.free_sgarray(sga)
-    }
-
-    /// Inserts a queue token into the scheduler.
-    pub fn schedule(&mut self, qt: QToken) -> Result<TaskHandle, Fail> {
-        self.runtime.from_task_id(qt.into())
-    }
-
-    /// Constructs an operation result from a scheduler handler and queue token pair.
-    pub fn pack_result(&mut self, handle: TaskHandle, qt: QToken) -> Result<demi_qresult_t, Fail> {
-        self.runtime.remove_coroutine_and_get_result(&handle, qt.into())
-    }
-
-    /// Polls scheduling queues.
-    pub fn poll(&mut self) {
-        self.runtime.poll()
     }
 
     fn get_queue(&self, qd: &QDesc) -> Result<SharedCatloopQueue, Fail> {

--- a/src/rust/catloop/queue.rs
+++ b/src/rust/catloop/queue.rs
@@ -24,6 +24,7 @@ use crate::{
         OperationResult,
         QDesc,
         QToken,
+        SharedDemiRuntime,
         SharedObject,
     },
 };
@@ -60,10 +61,10 @@ pub struct SharedCatloopQueue(SharedObject<CatloopQueue>);
 
 impl CatloopQueue {
     /// Allocates a new Catloop queue.
-    pub fn new(qtype: QType, catmem: SharedCatmemLibOS) -> Result<Self, Fail> {
+    pub fn new(qtype: QType, runtime: SharedDemiRuntime, catmem: SharedCatmemLibOS) -> Result<Self, Fail> {
         Ok(Self {
             qtype,
-            socket: Socket::new(catmem)?,
+            socket: Socket::new(runtime, catmem)?,
         })
     }
 
@@ -75,8 +76,8 @@ impl CatloopQueue {
 
 impl SharedCatloopQueue {
     /// Allocates a new shared Catloop queue.
-    pub fn new(qtype: QType, catmem: SharedCatmemLibOS) -> Result<Self, Fail> {
-        Ok(Self(SharedObject::new(CatloopQueue::new(qtype, catmem)?)))
+    pub fn new(qtype: QType, runtime: SharedDemiRuntime, catmem: SharedCatmemLibOS) -> Result<Self, Fail> {
+        Ok(Self(SharedObject::new(CatloopQueue::new(qtype, runtime, catmem)?)))
     }
 
     /// Returns the local address to which the target queue is bound.

--- a/src/rust/catmem/mod.rs
+++ b/src/rust/catmem/mod.rs
@@ -237,20 +237,6 @@ impl SharedCatmemLibOS {
         (qd, result)
     }
 
-    pub fn from_task_id(&self, qt: QToken) -> Result<TaskHandle, Fail> {
-        self.runtime.from_task_id(qt.into())
-    }
-
-    /// Allocates a scatter-gather array.
-    pub fn sgaalloc(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
-        self.runtime.alloc_sgarray(size)
-    }
-
-    /// Releases a scatter-gather array.
-    pub fn sgafree(&self, sga: demi_sgarray_t) -> Result<(), Fail> {
-        self.runtime.free_sgarray(sga)
-    }
-
     pub fn pack_result(&mut self, handle: TaskHandle, qt: QToken) -> Result<demi_qresult_t, Fail> {
         let (qd, result): (QDesc, OperationResult) = self.take_result(handle);
         let qr = match result {
@@ -303,10 +289,6 @@ impl SharedCatmemLibOS {
             _ => panic!("This libOS does not support these operations"),
         };
         Ok(qr)
-    }
-
-    pub fn poll(&mut self) {
-        self.runtime.poll()
     }
 
     pub fn get_queue(&self, qd: &QDesc) -> Result<SharedCatmemQueue, Fail> {

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -38,10 +38,7 @@ use crate::{
             Yielder,
             YielderHandle,
         },
-        types::{
-            demi_qresult_t,
-            demi_sgarray_t,
-        },
+        types::demi_sgarray_t,
         QDesc,
         QToken,
         SharedDemiRuntime,
@@ -492,30 +489,6 @@ impl SharedCatnapLibOS {
                 (qd, OperationResult::Failed(e))
             },
         }
-    }
-
-    pub fn poll(&mut self) {
-        self.runtime.poll()
-    }
-
-    pub fn schedule(&self, qt: QToken) -> Result<TaskHandle, Fail> {
-        self.runtime.from_task_id(qt)
-    }
-
-    pub fn pack_result(&mut self, handle: TaskHandle, qt: QToken) -> Result<demi_qresult_t, Fail> {
-        self.runtime.remove_coroutine_and_get_result(&handle, qt.into())
-    }
-
-    /// Allocates a scatter-gather array.
-    pub fn sgaalloc(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
-        trace!("sgalloc() size={:?}", size);
-        self.runtime.alloc_sgarray(size)
-    }
-
-    /// Frees a scatter-gather array.
-    pub fn sgafree(&self, sga: demi_sgarray_t) -> Result<(), Fail> {
-        trace!("sgafree()");
-        self.runtime.free_sgarray(sga)
     }
 
     /// This function gets a shared queue reference out of the I/O queue table. The type if a ref counted pointer to the

--- a/src/rust/catnip/mod.rs
+++ b/src/rust/catnip/mod.rs
@@ -147,12 +147,12 @@ impl CatnipLibOS {
 
     /// Allocates a scatter-gather array.
     pub fn sgaalloc(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
-        self.transport.alloc_sgarray(size)
+        self.transport.sgaalloc(size)
     }
 
     /// Releases a scatter-gather array.
     pub fn sgafree(&self, sga: demi_sgarray_t) -> Result<(), Fail> {
-        self.transport.free_sgarray(sga)
+        self.transport.sgafree(sga)
     }
 }
 

--- a/src/rust/catnip/runtime/memory/mod.rs
+++ b/src/rust/catnip/runtime/memory/mod.rs
@@ -38,12 +38,12 @@ impl MemoryRuntime for DPDKRuntime {
     }
 
     /// Allocates a [demi_sgarray_t].
-    fn alloc_sgarray(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
+    fn sgaalloc(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
         self.mm.alloc_sgarray(size)
     }
 
     /// Releases a [demi_sgarray_t].
-    fn free_sgarray(&self, sga: demi_sgarray_t) -> Result<(), Fail> {
+    fn sgafree(&self, sga: demi_sgarray_t) -> Result<(), Fail> {
         self.mm.free_sgarray(sga)
     }
 

--- a/src/rust/catpowder/mod.rs
+++ b/src/rust/catpowder/mod.rs
@@ -127,12 +127,12 @@ impl CatpowderLibOS {
 
     /// Allocates a scatter-gather array.
     pub fn sgaalloc(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
-        self.transport.alloc_sgarray(size)
+        self.transport.sgaalloc(size)
     }
 
     /// Releases a scatter-gather array.
     pub fn sgafree(&self, sga: demi_sgarray_t) -> Result<(), Fail> {
-        self.transport.free_sgarray(sga)
+        self.transport.sgafree(sga)
     }
 }
 

--- a/src/rust/demikernel/libos/memory.rs
+++ b/src/rust/demikernel/libos/memory.rs
@@ -17,7 +17,11 @@ use crate::runtime::{
 };
 
 #[cfg(feature = "catmem-libos")]
-use crate::catmem::SharedCatmemLibOS;
+use crate::{
+    catmem::SharedCatmemLibOS,
+    runtime::memory::MemoryRuntime,
+    runtime::SharedDemiRuntime,
+};
 
 //======================================================================================================================
 // Structures
@@ -26,7 +30,10 @@ use crate::catmem::SharedCatmemLibOS;
 /// Associated functions for Memory LibOSes.
 pub enum MemoryLibOS {
     #[cfg(feature = "catmem-libos")]
-    Catmem(SharedCatmemLibOS),
+    Catmem {
+        runtime: SharedDemiRuntime,
+        libos: SharedCatmemLibOS,
+    },
 }
 
 //======================================================================================================================
@@ -40,7 +47,7 @@ impl MemoryLibOS {
     pub fn create_pipe(&mut self, name: &str) -> Result<QDesc, Fail> {
         match self {
             #[cfg(feature = "catmem-libos")]
-            MemoryLibOS::Catmem(libos) => libos.create_pipe(name),
+            MemoryLibOS::Catmem { runtime: _, libos } => libos.create_pipe(name),
             _ => unreachable!("unknown memory libos"),
         }
     }
@@ -50,7 +57,7 @@ impl MemoryLibOS {
     pub fn open_pipe(&mut self, name: &str) -> Result<QDesc, Fail> {
         match self {
             #[cfg(feature = "catmem-libos")]
-            MemoryLibOS::Catmem(libos) => libos.open_pipe(name),
+            MemoryLibOS::Catmem { runtime: _, libos } => libos.open_pipe(name),
             _ => unreachable!("unknown memory libos"),
         }
     }
@@ -60,7 +67,7 @@ impl MemoryLibOS {
     pub fn close(&mut self, memqd: QDesc) -> Result<(), Fail> {
         match self {
             #[cfg(feature = "catmem-libos")]
-            MemoryLibOS::Catmem(libos) => libos.close(memqd),
+            MemoryLibOS::Catmem { runtime: _, libos } => libos.close(memqd),
             _ => unreachable!("unknown memory libos"),
         }
     }
@@ -70,7 +77,7 @@ impl MemoryLibOS {
     pub fn async_close(&mut self, memqd: QDesc) -> Result<QToken, Fail> {
         match self {
             #[cfg(feature = "catmem-libos")]
-            MemoryLibOS::Catmem(libos) => libos.async_close(memqd),
+            MemoryLibOS::Catmem { runtime: _, libos } => libos.async_close(memqd),
             _ => unreachable!("unknown memory libos"),
         }
     }
@@ -80,7 +87,7 @@ impl MemoryLibOS {
     pub fn push(&mut self, memqd: QDesc, sga: &demi_sgarray_t) -> Result<QToken, Fail> {
         match self {
             #[cfg(feature = "catmem-libos")]
-            MemoryLibOS::Catmem(libos) => libos.push(memqd, sga),
+            MemoryLibOS::Catmem { runtime: _, libos } => libos.push(memqd, sga),
             _ => unreachable!("unknown memory libos"),
         }
     }
@@ -90,7 +97,7 @@ impl MemoryLibOS {
     pub fn pop(&mut self, memqd: QDesc, size: Option<usize>) -> Result<QToken, Fail> {
         match self {
             #[cfg(feature = "catmem-libos")]
-            MemoryLibOS::Catmem(libos) => libos.pop(memqd, size),
+            MemoryLibOS::Catmem { runtime: _, libos } => libos.pop(memqd, size),
             _ => unreachable!("unknown memory libos"),
         }
     }
@@ -100,7 +107,7 @@ impl MemoryLibOS {
     pub fn sgaalloc(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
         match self {
             #[cfg(feature = "catmem-libos")]
-            MemoryLibOS::Catmem(libos) => libos.sgaalloc(size),
+            MemoryLibOS::Catmem { runtime, libos: _ } => runtime.sgaalloc(size),
             _ => unreachable!("unknown memory libos"),
         }
     }
@@ -110,17 +117,17 @@ impl MemoryLibOS {
     pub fn sgafree(&self, sga: demi_sgarray_t) -> Result<(), Fail> {
         match self {
             #[cfg(feature = "catmem-libos")]
-            MemoryLibOS::Catmem(libos) => libos.sgafree(sga),
+            MemoryLibOS::Catmem { runtime, libos: _ } => runtime.sgafree(sga),
             _ => unreachable!("unknown memory libos"),
         }
     }
 
     /// Waits for any operation in an I/O queue.
     #[allow(unreachable_patterns, unused_variables)]
-    pub fn schedule(&mut self, qt: QToken) -> Result<TaskHandle, Fail> {
+    pub fn from_task_id(&mut self, qt: QToken) -> Result<TaskHandle, Fail> {
         match self {
             #[cfg(feature = "catmem-libos")]
-            MemoryLibOS::Catmem(libos) => libos.from_task_id(qt),
+            MemoryLibOS::Catmem { runtime, libos: _ } => runtime.from_task_id(qt),
             _ => unreachable!("unknown memory libos"),
         }
     }
@@ -129,7 +136,7 @@ impl MemoryLibOS {
     pub fn pack_result(&mut self, handle: TaskHandle, qt: QToken) -> Result<demi_qresult_t, Fail> {
         match self {
             #[cfg(feature = "catmem-libos")]
-            MemoryLibOS::Catmem(libos) => libos.pack_result(handle, qt),
+            MemoryLibOS::Catmem { runtime: _, libos } => libos.pack_result(handle, qt),
             _ => unreachable!("unknown memory libos"),
         }
     }
@@ -139,7 +146,7 @@ impl MemoryLibOS {
     pub fn poll(&mut self) {
         match self {
             #[cfg(feature = "catmem-libos")]
-            MemoryLibOS::Catmem(libos) => libos.poll(),
+            MemoryLibOS::Catmem { runtime, libos: _ } => runtime.poll(),
             _ => unreachable!("unknown memory libos"),
         }
     }

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -97,27 +97,35 @@ impl LibOS {
         #[allow(unreachable_patterns)]
         let libos: LibOS = match libos_name {
             #[cfg(all(feature = "catnap-libos"))]
-            LibOSName::Catnap => {
-                Self::NetworkLibOS(NetworkLibOS::Catnap(SharedCatnapLibOS::new(&config, runtime.clone())))
-            },
+            LibOSName::Catnap => Self::NetworkLibOS(NetworkLibOS::Catnap {
+                runtime: runtime.clone(),
+                libos: SharedCatnapLibOS::new(&config, runtime.clone()),
+            }),
             #[cfg(feature = "catcollar-libos")]
-            LibOSName::Catcollar => {
-                Self::NetworkLibOS(NetworkLibOS::Catcollar(CatcollarLibOS::new(&config, runtime.clone())))
-            },
+            LibOSName::Catcollar => Self::NetworkLibOS(NetworkLibOS::Catcollar {
+                runtime: runtime.clone(),
+                libos: CatcollarLibOS::new(&config, runtime.clone()),
+            }),
             #[cfg(feature = "catpowder-libos")]
-            LibOSName::Catpowder => {
-                Self::NetworkLibOS(NetworkLibOS::Catpowder(CatpowderLibOS::new(&config, runtime.clone())))
-            },
+            LibOSName::Catpowder => Self::NetworkLibOS(NetworkLibOS::Catpowder {
+                runtime: runtime.clone(),
+                libos: CatpowderLibOS::new(&config, runtime.clone()),
+            }),
             #[cfg(feature = "catnip-libos")]
-            LibOSName::Catnip => Self::NetworkLibOS(NetworkLibOS::Catnip(CatnipLibOS::new(&config, runtime.clone()))),
+            LibOSName::Catnip => Self::NetworkLibOS(NetworkLibOS::Catnip {
+                runtime: runtime.clone(),
+                libos: CatnipLibOS::new(&config, runtime.clone()),
+            }),
             #[cfg(feature = "catmem-libos")]
-            LibOSName::Catmem => {
-                Self::MemoryLibOS(MemoryLibOS::Catmem(SharedCatmemLibOS::new(&config, runtime.clone())))
-            },
+            LibOSName::Catmem => Self::MemoryLibOS(MemoryLibOS::Catmem {
+                runtime: runtime.clone(),
+                libos: SharedCatmemLibOS::new(&config, runtime.clone()),
+            }),
             #[cfg(feature = "catloop-libos")]
-            LibOSName::Catloop => {
-                Self::NetworkLibOS(NetworkLibOS::Catloop(SharedCatloopLibOS::new(&config, runtime.clone())))
-            },
+            LibOSName::Catloop => Self::NetworkLibOS(NetworkLibOS::Catloop {
+                runtime: runtime.clone(),
+                libos: SharedCatloopLibOS::new(&config, runtime.clone()),
+            }),
             _ => panic!("unsupported libos"),
         };
 
@@ -441,8 +449,8 @@ impl LibOS {
     /// Waits for any operation in an I/O queue.
     fn schedule(&mut self, qt: QToken) -> Result<TaskHandle, Fail> {
         match self {
-            LibOS::NetworkLibOS(libos) => libos.schedule(qt),
-            LibOS::MemoryLibOS(libos) => libos.schedule(qt),
+            LibOS::NetworkLibOS(libos) => libos.from_task_id(qt),
+            LibOS::MemoryLibOS(libos) => libos.from_task_id(qt),
         }
     }
 

--- a/src/rust/demikernel/libos/network.rs
+++ b/src/rust/demikernel/libos/network.rs
@@ -9,6 +9,7 @@ use crate::{
     pal::constants::SOMAXCONN,
     runtime::{
         fail::Fail,
+        memory::MemoryRuntime,
         scheduler::TaskHandle,
         types::{
             demi_qresult_t,
@@ -16,6 +17,7 @@ use crate::{
         },
         QDesc,
         QToken,
+        SharedDemiRuntime,
     },
 };
 use ::std::net::SocketAddr;
@@ -38,15 +40,30 @@ use crate::catpowder::CatpowderLibOS;
 /// Network LIBOS.
 pub enum NetworkLibOS {
     #[cfg(feature = "catpowder-libos")]
-    Catpowder(CatpowderLibOS),
+    Catpowder {
+        runtime: SharedDemiRuntime,
+        libos: CatpowderLibOS,
+    },
     #[cfg(all(feature = "catnap-libos"))]
-    Catnap(SharedCatnapLibOS),
+    Catnap {
+        runtime: SharedDemiRuntime,
+        libos: SharedCatnapLibOS,
+    },
     #[cfg(feature = "catcollar-libos")]
-    Catcollar(CatcollarLibOS),
+    Catcollar {
+        runtime: SharedDemiRuntime,
+        libos: CatcollarLibOS,
+    },
     #[cfg(feature = "catnip-libos")]
-    Catnip(CatnipLibOS),
+    Catnip {
+        runtime: SharedDemiRuntime,
+        libos: CatnipLibOS,
+    },
     #[cfg(feature = "catloop-libos")]
-    Catloop(SharedCatloopLibOS),
+    Catloop {
+        runtime: SharedDemiRuntime,
+        libos: SharedCatloopLibOS,
+    },
 }
 
 //======================================================================================================================
@@ -64,15 +81,17 @@ impl NetworkLibOS {
     ) -> Result<QDesc, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder(libos) => libos.socket(domain, socket_type, protocol),
+            NetworkLibOS::Catpowder { runtime: _, libos } => libos.socket(domain, socket_type, protocol),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOS::Catnap(libos) => libos.socket(domain.into(), socket_type.into(), protocol.into()),
+            NetworkLibOS::Catnap { runtime: _, libos } => {
+                libos.socket(domain.into(), socket_type.into(), protocol.into())
+            },
             #[cfg(feature = "catcollar-libos")]
-            NetworkLibOS::Catcollar(libos) => libos.socket(domain, socket_type, protocol),
+            NetworkLibOS::Catcollar { runtime: _, libos } => libos.socket(domain, socket_type, protocol),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip(libos) => libos.socket(domain, socket_type, protocol),
+            NetworkLibOS::Catnip { runtime: _, libos } => libos.socket(domain, socket_type, protocol),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOS::Catloop(libos) => libos.socket(domain, socket_type, protocol),
+            NetworkLibOS::Catloop { runtime: _, libos } => libos.socket(domain, socket_type, protocol),
         }
     }
 
@@ -80,15 +99,15 @@ impl NetworkLibOS {
     pub fn bind(&mut self, sockqd: QDesc, local: SocketAddr) -> Result<(), Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder(libos) => libos.bind(sockqd, local),
+            NetworkLibOS::Catpowder { runtime: _, libos } => libos.bind(sockqd, local),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOS::Catnap(libos) => libos.bind(sockqd, local),
+            NetworkLibOS::Catnap { runtime: _, libos } => libos.bind(sockqd, local),
             #[cfg(feature = "catcollar-libos")]
-            NetworkLibOS::Catcollar(libos) => libos.bind(sockqd, local),
+            NetworkLibOS::Catcollar { runtime: _, libos } => libos.bind(sockqd, local),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip(libos) => libos.bind(sockqd, local),
+            NetworkLibOS::Catnip { runtime: _, libos } => libos.bind(sockqd, local),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOS::Catloop(libos) => libos.bind(sockqd, local),
+            NetworkLibOS::Catloop { runtime: _, libos } => libos.bind(sockqd, local),
         }
     }
 
@@ -111,15 +130,15 @@ impl NetworkLibOS {
 
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder(libos) => libos.listen(sockqd, backlog),
+            NetworkLibOS::Catpowder { runtime: _, libos } => libos.listen(sockqd, backlog),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOS::Catnap(libos) => libos.listen(sockqd, backlog),
+            NetworkLibOS::Catnap { runtime: _, libos } => libos.listen(sockqd, backlog),
             #[cfg(feature = "catcollar-libos")]
-            NetworkLibOS::Catcollar(libos) => libos.listen(sockqd, backlog),
+            NetworkLibOS::Catcollar { runtime: _, libos } => libos.listen(sockqd, backlog),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip(libos) => libos.listen(sockqd, backlog),
+            NetworkLibOS::Catnip { runtime: _, libos } => libos.listen(sockqd, backlog),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOS::Catloop(libos) => libos.listen(sockqd, backlog),
+            NetworkLibOS::Catloop { runtime: _, libos } => libos.listen(sockqd, backlog),
         }
     }
 
@@ -127,15 +146,15 @@ impl NetworkLibOS {
     pub fn accept(&mut self, sockqd: QDesc) -> Result<QToken, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder(libos) => libos.accept(sockqd),
+            NetworkLibOS::Catpowder { runtime: _, libos } => libos.accept(sockqd),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOS::Catnap(libos) => libos.accept(sockqd),
+            NetworkLibOS::Catnap { runtime: _, libos } => libos.accept(sockqd),
             #[cfg(feature = "catcollar-libos")]
-            NetworkLibOS::Catcollar(libos) => libos.accept(sockqd),
+            NetworkLibOS::Catcollar { runtime: _, libos } => libos.accept(sockqd),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip(libos) => libos.accept(sockqd),
+            NetworkLibOS::Catnip { runtime: _, libos } => libos.accept(sockqd),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOS::Catloop(libos) => libos.accept(sockqd),
+            NetworkLibOS::Catloop { runtime: _, libos } => libos.accept(sockqd),
         }
     }
 
@@ -143,15 +162,15 @@ impl NetworkLibOS {
     pub fn connect(&mut self, sockqd: QDesc, remote: SocketAddr) -> Result<QToken, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder(libos) => libos.connect(sockqd, remote),
+            NetworkLibOS::Catpowder { runtime: _, libos } => libos.connect(sockqd, remote),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOS::Catnap(libos) => libos.connect(sockqd, remote),
+            NetworkLibOS::Catnap { runtime: _, libos } => libos.connect(sockqd, remote),
             #[cfg(feature = "catcollar-libos")]
-            NetworkLibOS::Catcollar(libos) => libos.connect(sockqd, remote),
+            NetworkLibOS::Catcollar { runtime: _, libos } => libos.connect(sockqd, remote),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip(libos) => libos.connect(sockqd, remote),
+            NetworkLibOS::Catnip { runtime: _, libos } => libos.connect(sockqd, remote),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOS::Catloop(libos) => libos.connect(sockqd, remote),
+            NetworkLibOS::Catloop { runtime: _, libos } => libos.connect(sockqd, remote),
         }
     }
 
@@ -159,30 +178,30 @@ impl NetworkLibOS {
     pub fn close(&mut self, sockqd: QDesc) -> Result<(), Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder(libos) => libos.close(sockqd),
+            NetworkLibOS::Catpowder { runtime: _, libos } => libos.close(sockqd),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOS::Catnap(libos) => libos.close(sockqd),
+            NetworkLibOS::Catnap { runtime: _, libos } => libos.close(sockqd),
             #[cfg(feature = "catcollar-libos")]
-            NetworkLibOS::Catcollar(libos) => libos.close(sockqd),
+            NetworkLibOS::Catcollar { runtime: _, libos } => libos.close(sockqd),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip(libos) => libos.close(sockqd),
+            NetworkLibOS::Catnip { runtime: _, libos } => libos.close(sockqd),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOS::Catloop(libos) => libos.close(sockqd),
+            NetworkLibOS::Catloop { runtime: _, libos } => libos.close(sockqd),
         }
     }
 
     pub fn async_close(&mut self, sockqd: QDesc) -> Result<QToken, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder(libos) => libos.async_close(sockqd),
+            NetworkLibOS::Catpowder { runtime: _, libos } => libos.async_close(sockqd),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOS::Catnap(libos) => libos.async_close(sockqd),
+            NetworkLibOS::Catnap { runtime: _, libos } => libos.async_close(sockqd),
             #[cfg(feature = "catcollar-libos")]
-            NetworkLibOS::Catcollar(libos) => libos.async_close(sockqd),
+            NetworkLibOS::Catcollar { runtime: _, libos } => libos.async_close(sockqd),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip(libos) => libos.async_close(sockqd),
+            NetworkLibOS::Catnip { runtime: _, libos } => libos.async_close(sockqd),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOS::Catloop(libos) => libos.async_close(sockqd),
+            NetworkLibOS::Catloop { runtime: _, libos } => libos.async_close(sockqd),
         }
     }
 
@@ -190,15 +209,15 @@ impl NetworkLibOS {
     pub fn push(&mut self, sockqd: QDesc, sga: &demi_sgarray_t) -> Result<QToken, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder(libos) => libos.push(sockqd, sga),
+            NetworkLibOS::Catpowder { runtime: _, libos } => libos.push(sockqd, sga),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOS::Catnap(libos) => libos.push(sockqd, sga),
+            NetworkLibOS::Catnap { runtime: _, libos } => libos.push(sockqd, sga),
             #[cfg(feature = "catcollar-libos")]
-            NetworkLibOS::Catcollar(libos) => libos.push(sockqd, sga),
+            NetworkLibOS::Catcollar { runtime: _, libos } => libos.push(sockqd, sga),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip(libos) => libos.push(sockqd, sga),
+            NetworkLibOS::Catnip { runtime: _, libos } => libos.push(sockqd, sga),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOS::Catloop(libos) => libos.push(sockqd, sga),
+            NetworkLibOS::Catloop { runtime: _, libos } => libos.push(sockqd, sga),
         }
     }
 
@@ -206,15 +225,15 @@ impl NetworkLibOS {
     pub fn pushto(&mut self, sockqd: QDesc, sga: &demi_sgarray_t, to: SocketAddr) -> Result<QToken, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder(libos) => libos.pushto(sockqd, sga, to),
+            NetworkLibOS::Catpowder { runtime: _, libos } => libos.pushto(sockqd, sga, to),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOS::Catnap(libos) => libos.pushto(sockqd, sga, to),
+            NetworkLibOS::Catnap { runtime: _, libos } => libos.pushto(sockqd, sga, to),
             #[cfg(feature = "catcollar-libos")]
-            NetworkLibOS::Catcollar(libos) => libos.pushto(sockqd, sga, to),
+            NetworkLibOS::Catcollar { runtime: _, libos } => libos.pushto(sockqd, sga, to),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip(libos) => libos.pushto(sockqd, sga, to),
+            NetworkLibOS::Catnip { runtime: _, libos } => libos.pushto(sockqd, sga, to),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOS::Catloop(_) => Err(Fail::new(libc::ENOTSUP, "operation not supported")),
+            NetworkLibOS::Catloop { runtime: _, libos: _ } => Err(Fail::new(libc::ENOTSUP, "operation not supported")),
         }
     }
 
@@ -222,15 +241,15 @@ impl NetworkLibOS {
     pub fn pop(&mut self, sockqd: QDesc, size: Option<usize>) -> Result<QToken, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder(libos) => libos.pop(sockqd, size),
+            NetworkLibOS::Catpowder { runtime: _, libos } => libos.pop(sockqd, size),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOS::Catnap(libos) => libos.pop(sockqd, size),
+            NetworkLibOS::Catnap { runtime: _, libos } => libos.pop(sockqd, size),
             #[cfg(feature = "catcollar-libos")]
-            NetworkLibOS::Catcollar(libos) => libos.pop(sockqd, size),
+            NetworkLibOS::Catcollar { runtime: _, libos } => libos.pop(sockqd, size),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip(libos) => libos.pop(sockqd, size),
+            NetworkLibOS::Catnip { runtime: _, libos } => libos.pop(sockqd, size),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOS::Catloop(libos) => libos.pop(sockqd, size),
+            NetworkLibOS::Catloop { runtime: _, libos } => libos.pop(sockqd, size),
         }
     }
 
@@ -238,46 +257,50 @@ impl NetworkLibOS {
     pub fn poll(&mut self) {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder(libos) => libos.poll(),
+            NetworkLibOS::Catpowder { runtime, libos: _ } => runtime.poll_and_advance_clock(),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOS::Catnap(libos) => libos.poll(),
+            NetworkLibOS::Catnap { runtime, libos: _ } => runtime.poll_and_advance_clock(),
             #[cfg(feature = "catcollar-libos")]
-            NetworkLibOS::Catcollar(libos) => libos.poll(),
+            NetworkLibOS::Catcollar { runtime, libos: _ } => runtime.poll_and_advance_clock(),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip(libos) => libos.poll(),
+            NetworkLibOS::Catnip { runtime, libos: _ } => runtime.poll_and_advance_clock(),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOS::Catloop(libos) => libos.poll(),
+            NetworkLibOS::Catloop { runtime, libos: _ } => runtime.poll_and_advance_clock(),
         }
     }
 
     /// Waits for any operation in an I/O queue.
-    pub fn schedule(&mut self, qt: QToken) -> Result<TaskHandle, Fail> {
+    pub fn from_task_id(&mut self, qt: QToken) -> Result<TaskHandle, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder(libos) => libos.schedule(qt),
+            NetworkLibOS::Catpowder { runtime, libos: _ } => runtime.from_task_id(qt),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOS::Catnap(libos) => libos.schedule(qt),
+            NetworkLibOS::Catnap { runtime, libos: _ } => runtime.from_task_id(qt),
             #[cfg(feature = "catcollar-libos")]
-            NetworkLibOS::Catcollar(libos) => libos.schedule(qt),
+            NetworkLibOS::Catcollar { runtime, libos: _ } => runtime.from_task_id(qt),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip(libos) => libos.schedule(qt),
+            NetworkLibOS::Catnip { runtime, libos: _ } => runtime.from_task_id(qt),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOS::Catloop(libos) => libos.schedule(qt),
+            NetworkLibOS::Catloop { runtime, libos: _ } => runtime.from_task_id(qt),
         }
     }
 
     pub fn pack_result(&mut self, handle: TaskHandle, qt: QToken) -> Result<demi_qresult_t, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder(libos) => libos.pack_result(handle, qt),
+            NetworkLibOS::Catpowder { runtime, libos: _ } => {
+                runtime.remove_coroutine_and_get_result(&handle, qt.into())
+            },
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOS::Catnap(libos) => libos.pack_result(handle, qt),
+            NetworkLibOS::Catnap { runtime, libos: _ } => runtime.remove_coroutine_and_get_result(&handle, qt.into()),
             #[cfg(feature = "catcollar-libos")]
-            NetworkLibOS::Catcollar(libos) => libos.pack_result(handle, qt),
+            NetworkLibOS::Catcollar { runtime, libos: _ } => {
+                runtime.remove_coroutine_and_get_result(&handle, qt.into())
+            },
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip(libos) => libos.pack_result(handle, qt),
+            NetworkLibOS::Catnip { runtime, libos: _ } => runtime.remove_coroutine_and_get_result(&handle, qt.into()),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOS::Catloop(libos) => libos.pack_result(handle, qt),
+            NetworkLibOS::Catloop { runtime, libos: _ } => runtime.remove_coroutine_and_get_result(&handle, qt.into()),
         }
     }
 
@@ -285,15 +308,19 @@ impl NetworkLibOS {
     pub fn sgaalloc(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder(libos) => libos.sgaalloc(size),
+            // TODO: Move this over to the transport once we set that up.
+            // FIXME: https://github.com/microsoft/demikernel/issues/1057
+            NetworkLibOS::Catpowder { runtime: _, libos } => libos.sgaalloc(size),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOS::Catnap(libos) => libos.sgaalloc(size),
+            NetworkLibOS::Catnap { runtime, libos: _ } => runtime.sgaalloc(size),
             #[cfg(feature = "catcollar-libos")]
-            NetworkLibOS::Catcollar(libos) => libos.sgaalloc(size),
+            NetworkLibOS::Catcollar { runtime, libos: _ } => runtime.sgaalloc(size),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip(libos) => libos.sgaalloc(size),
+            // TODO: Move this over to the transport once we set that up.
+            // FIXME: https://github.com/microsoft/demikernel/issues/1057
+            NetworkLibOS::Catnip { runtime: _, libos } => libos.sgaalloc(size),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOS::Catloop(libos) => libos.sgaalloc(size),
+            NetworkLibOS::Catloop { runtime, libos: _ } => runtime.sgaalloc(size),
         }
     }
 
@@ -301,15 +328,15 @@ impl NetworkLibOS {
     pub fn sgafree(&self, sga: demi_sgarray_t) -> Result<(), Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder(libos) => libos.sgafree(sga),
+            NetworkLibOS::Catpowder { runtime, libos: _ } => runtime.sgafree(sga),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOS::Catnap(libos) => libos.sgafree(sga),
+            NetworkLibOS::Catnap { runtime, libos: _ } => runtime.sgafree(sga),
             #[cfg(feature = "catcollar-libos")]
-            NetworkLibOS::Catcollar(libos) => libos.sgafree(sga),
+            NetworkLibOS::Catcollar { runtime, libos: _ } => runtime.sgafree(sga),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip(libos) => libos.sgafree(sga),
+            NetworkLibOS::Catnip { runtime, libos: _ } => runtime.sgafree(sga),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOS::Catloop(libos) => libos.sgafree(sga),
+            NetworkLibOS::Catloop { runtime, libos: _ } => runtime.sgafree(sga),
         }
     }
 }

--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -428,7 +428,7 @@ impl<const N: usize> SharedInetStack<N> {
 
         loop {
             // Poll first, so as to give pending operations a chance to complete.
-            self.poll();
+            self.runtime.poll_and_advance_clock();
 
             // The operation has completed, so extract the result and return.
             if handle.has_completed() {
@@ -446,7 +446,7 @@ impl<const N: usize> SharedInetStack<N> {
 
         loop {
             // Poll first, so as to give pending operations a chance to complete.
-            self.poll();
+            self.runtime.poll_and_advance_clock();
 
             // Search for any operation that has completed.
             for (i, &qt) in qts.iter().enumerate() {
@@ -528,10 +528,6 @@ impl<const N: usize> SharedInetStack<N> {
                 Err(_) => break,
             };
         }
-    }
-
-    pub fn poll(&mut self) {
-        self.runtime.poll_and_advance_clock();
     }
 }
 

--- a/src/rust/runtime/memory/mod.rs
+++ b/src/rust/runtime/memory/mod.rs
@@ -56,7 +56,7 @@ pub trait MemoryRuntime {
     }
 
     /// Allocates a scatter-gather array.
-    fn alloc_sgarray(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
+    fn sgaalloc(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
         // TODO: Allocate an array of buffers if requested size is too large for a single buffer.
 
         // We can't allocate more than a single buffer.
@@ -84,7 +84,7 @@ pub trait MemoryRuntime {
     }
 
     /// Releases a scatter-gather array.
-    fn free_sgarray(&self, sga: demi_sgarray_t) -> Result<(), Fail> {
+    fn sgafree(&self, sga: demi_sgarray_t) -> Result<(), Fail> {
         // Check arguments.
         // TODO: Drop this check once we support scatter-gather arrays with multiple segments.
         if sga.sga_numsegs != 1 {


### PR DESCRIPTION
This PR removes the following functions from the libOSes and directly calls the runtime:
* poll 
* schedule/from_task_id
* pack_result
* sgaalloc
* sgafree

Note that we have not moved the sgaalloc and free functions for the libOSes that need special memory. I have filed an issue for that: https://github.com/microsoft/demikernel/issues/1057