### PR TITLE
[inetstack] Move ARP cache to background polling model

### DIFF
--- a/src/rust/inetstack/protocols/arp/tests.rs
+++ b/src/rust/inetstack/protocols/arp/tests.rs
@@ -26,10 +26,7 @@ use ::futures::{
     },
     FutureExt,
 };
-use ::libc::{
-    EBADMSG,
-    ETIMEDOUT,
-};
+use ::libc::ETIMEDOUT;
 use ::std::{
     future::Future,
     task::Poll,
@@ -62,18 +59,16 @@ fn immediate_reply() -> Result<()> {
     alice.advance_clock(now);
     let request = alice.get_test_rig().pop_frame();
 
-    // bob hasn't heard of alice before, so he will ignore the request.
-    match bob.receive(request.clone()) {
-        Err(e) if e.errno == EBADMSG => {},
-        _ => anyhow::bail!("passing ARP request to bob should be ignored"),
-    };
-
+    // Since receive doesn't return anything, we should get an Ok here.
+    // TODO: remove  check for return value once all receives have moved to poliing.
+    bob.receive(request.clone())?;
+    // check the cache to make sure bob ignored the request.
     let cache = bob.export_arp_cache();
     crate::ensure_eq!(cache.get(&test_helpers::ALICE_IPV4), None);
 
-    if let Err(e) = carrie.receive(request) {
-        anyhow::bail!("receive returned error: {:?}", e);
-    }
+    // Since receive doesn't return anything, we should get an Ok here.
+    // TODO: remove  check for return value once all receives have moved to poliing.
+    carrie.receive(request)?;
     info!("passing ARP request to carrie...");
     let cache = carrie.export_arp_cache();
     crate::ensure_eq!(cache.get(&test_helpers::ALICE_IPV4), Some(&test_helpers::ALICE_MAC));
@@ -123,17 +118,16 @@ fn slow_reply() -> Result<()> {
     let request = alice.get_test_rig().pop_frame();
 
     // bob hasn't heard of alice before, so he will ignore the request.
-    match bob.receive(request.clone()) {
-        Err(e) if e.errno == EBADMSG => {},
-        _ => anyhow::bail!("passing ARP request to bob should be ignored"),
-    };
-
+    // Since receive doesn't return anything, we should get an Ok here.
+    // TODO: remove  check for return value once all receives have moved to poliing.
+    bob.receive(request.clone())?;
+    // check the cache to make sure bob ignored the request.
     let cache = bob.export_arp_cache();
     crate::ensure_eq!(cache.get(&test_helpers::ALICE_IPV4), None);
 
-    if let Err(e) = carrie.receive(request) {
-        anyhow::bail!("receive returned error: {:?}", e);
-    }
+    // Since receive doesn't return anything, we should get an Ok here.
+    // TODO: remove  check for return value once all receives have moved to poliing.
+    carrie.receive(request)?;
 
     info!("passing ARP request to carrie...");
     let cache = carrie.export_arp_cache();
@@ -148,9 +142,9 @@ fn slow_reply() -> Result<()> {
     carrie.advance_clock(now);
     let reply = carrie.get_test_rig().pop_frame();
 
-    if let Err(e) = alice.receive(reply) {
-        anyhow::bail!("receive returned error: {:?}", e);
-    }
+    // Since receive doesn't return anything, we should get an Ok here.
+    // TODO: remove  check for return value once all receives have moved to poliing.
+    alice.receive(reply)?;
 
     now += Duration::from_micros(1);
     alice.advance_clock(now);

--- a/src/rust/inetstack/test_helpers/engine.rs
+++ b/src/rust/inetstack/test_helpers/engine.rs
@@ -101,7 +101,13 @@ impl<const N: usize> SharedEngine<N> {
             return Err(Fail::new(EBADMSG, "physical destination address mismatch"));
         }
         match header.ether_type() {
-            EtherType2::Arp => self.arp.receive(payload),
+            EtherType2::Arp => {
+                // We no longer do the processing in this function.
+                self.arp.receive(payload);
+                // So poll the scheduler to do the processing.
+                self.test_rig.poll_scheduler();
+                Ok(())
+            },
             EtherType2::Ipv4 => self.ipv4.receive(payload),
             EtherType2::Ipv6 => Ok(()), // Ignore for now.
         }


### PR DESCRIPTION
For the inetstack, we want to unwrap and turn the state machine operations into a linear flow. In order to accommodate this, we need to move away from a polling receive model where we always call the receive function from the top every time. Instead, we will simply insert the new packet into an AsyncQueue and the inetstack will pick up that packet from wherever in the linear flow it is blocked. This also means that the receive function will not return a result because it does not know if the inetstack will drop the packet. 

This change impacts the ARP cache very little since it does not have a state machine and does not really flow through a protocol. It will be more important for TCP, especially during connection set up and close, when we are waiting for very specific next packets.