### PR TITLE
[inetstack] Move TCP to receive polling coroutine

### DIFF
--- a/src/rust/collections/async_queue.rs
+++ b/src/rust/collections/async_queue.rs
@@ -39,7 +39,6 @@ pub struct AsyncQueue<T> {
     waiters: Vec<YielderHandle>,
 }
 
-#[derive(Clone)]
 pub struct SharedAsyncQueue<T>(SharedObject<AsyncQueue<T>>);
 
 //======================================================================================================================
@@ -160,5 +159,11 @@ impl<T> Deref for SharedAsyncQueue<T> {
 impl<T> DerefMut for SharedAsyncQueue<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0.deref_mut()
+    }
+}
+
+impl<T> Clone for SharedAsyncQueue<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
     }
 }

--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -516,11 +516,7 @@ impl<const N: usize> SharedInetStack<N> {
                                 // formatted.
                                 self.arp.receive(payload);
                             },
-                            EtherType2::Ipv4 => {
-                                if let Err(e) = self.ipv4.receive(payload) {
-                                    warn!("Dropped packet: {:?}", e);
-                                }
-                            },
+                            EtherType2::Ipv4 => self.ipv4.receive(payload),
                             EtherType2::Ipv6 => continue, // Ignore for now.
                         }
                     }

--- a/src/rust/inetstack/protocols/tcp/established/background/mod.rs
+++ b/src/rust/inetstack/protocols/tcp/established/background/mod.rs
@@ -11,18 +11,31 @@ use self::{
     sender::sender,
 };
 use crate::{
-    inetstack::protocols::tcp::established::ctrlblk::SharedControlBlock,
+    collections::async_queue::SharedAsyncQueue,
+    inetstack::protocols::{
+        ipv4::Ipv4Header,
+        tcp::{
+            established::ctrlblk::SharedControlBlock,
+            segment::TcpHeader,
+        },
+    },
     runtime::{
+        memory::DemiBuffer,
         scheduler::Yielder,
         QDesc,
     },
 };
 use ::futures::{
     channel::mpsc,
+    pin_mut,
     FutureExt,
 };
 
-pub async fn background<const N: usize>(cb: SharedControlBlock<N>, _dead_socket_tx: mpsc::UnboundedSender<QDesc>) {
+pub async fn background<const N: usize>(
+    cb: SharedControlBlock<N>,
+    mut recv_queue: SharedAsyncQueue<(Ipv4Header, TcpHeader, DemiBuffer)>,
+    _dead_socket_tx: mpsc::UnboundedSender<QDesc>,
+) {
     let yielder_acknowledger: Yielder = Yielder::new();
     let acknowledger = acknowledger(cb.clone(), yielder_acknowledger).fuse();
     futures::pin_mut!(acknowledger);
@@ -35,15 +48,24 @@ pub async fn background<const N: usize>(cb: SharedControlBlock<N>, _dead_socket_
     let sender = sender(cb.clone(), yielder_sender).fuse();
     futures::pin_mut!(sender);
 
+    let yielder_receiver: Yielder = Yielder::new();
+    let mut cb2: SharedControlBlock<N> = cb.clone();
+    let receiver = async move {
+        loop {
+            match recv_queue.pop(&yielder_receiver).await {
+                Ok((_, tcp_hdr, buf)) => cb2.receive(tcp_hdr, buf),
+                Err(e) => break Err(e),
+            }
+        }
+    }
+    .fuse();
+    pin_mut!(receiver);
+
     let r = futures::select_biased! {
+        r = receiver => r,
         r = acknowledger => r,
         r = retransmitter => r,
         r = sender => r,
     };
     error!("Connection terminated: {:?}", r);
-
-    // TODO Properly clean up Peer state for this connection.
-    // dead_socket_tx
-    //     .unbounded_send(fd)
-    //     .expect("Failed to terminate connection");
 }

--- a/src/rust/inetstack/protocols/tcp/tests/established.rs
+++ b/src/rust/inetstack/protocols/tcp/tests/established.rs
@@ -138,9 +138,7 @@ fn recv_data<const N: usize>(
         anyhow::bail!("receive returned error: {:?}", e);
     }
 
-    // Poll the coroutine.
     receiver.get_test_rig().poll_scheduler();
-
     // Pop completes
     match receiver
         .get_test_rig()

--- a/src/rust/inetstack/protocols/tcp/tests/setup.rs
+++ b/src/rust/inetstack/protocols/tcp/tests/setup.rs
@@ -40,7 +40,6 @@ use crate::{
     },
 };
 use ::anyhow::Result;
-use ::libc::EBADMSG;
 use ::std::{
     net::{
         Ipv4Addr,
@@ -163,10 +162,10 @@ fn test_refuse_connection_early_rst() -> Result<()> {
     advance_clock(Some(&mut server), Some(&mut client), &mut now);
 
     // Server: SYN_RCVD state at T(2).
-    match server.receive(buf) {
-        Err(error) if error.errno == EBADMSG => Ok(()),
-        _ => anyhow::bail!("server receive should have returned an error"),
-    }
+    server.receive(buf)?;
+    // TODO: Assert that we dropped the packet.
+    // FIXME: https://github.com/microsoft/demikernel/issues/1065
+    Ok(())
 }
 
 /// Refuse a connection.
@@ -227,10 +226,10 @@ fn test_refuse_connection_early_ack() -> Result<()> {
     advance_clock(Some(&mut server), Some(&mut client), &mut now);
 
     // Server: SYN_RCVD state at T(2).
-    match server.receive(buf) {
-        Err(error) if error.errno == EBADMSG => Ok(()),
-        _ => anyhow::bail!("server receive should have returned an error"),
-    }
+    server.receive(buf)?;
+    // TODO: Assert that we dropped the packet.
+    // FIXME: https://github.com/microsoft/demikernel/issues/1065
+    Ok(())
 }
 
 /// Tests connection refuse due to missing syn.
@@ -301,10 +300,10 @@ fn test_refuse_connection_missing_syn() -> Result<()> {
     advance_clock(Some(&mut server), Some(&mut client), &mut now);
 
     // Server: SYN_RCVD state at T(2).
-    match server.receive(buf) {
-        Err(error) if error.errno == EBADMSG => Ok(()),
-        _ => anyhow::bail!("server receive should have returned an error"),
-    }
+    server.receive(buf)?;
+    // TODO: Assert that we dropped the packet.
+    // FIXME: https://github.com/microsoft/demikernel/issues/1065
+    Ok(())
 }
 
 /// Tests basic 3-way connection setup.
@@ -423,6 +422,7 @@ fn connection_setup_sync_rcvd_established<const N: usize>(
     bytes: DemiBuffer,
 ) -> Result<()> {
     server.receive(bytes).unwrap();
+    server.get_test_rig().poll_scheduler();
     server.get_test_rig().poll_scheduler();
     Ok(())
 }

--- a/src/rust/inetstack/protocols/tcp/tests/simulator.rs
+++ b/src/rust/inetstack/protocols/tcp/tests/simulator.rs
@@ -790,6 +790,9 @@ impl Simulation {
         self.engine.receive(buf)?;
 
         self.engine.get_test_rig().poll_scheduler();
+        // Poll the scheduler again.
+        // TODO: Remove this once we have a way to poll the scheduler until there is no more work to be done.
+        self.engine.get_test_rig().poll_scheduler();
 
         Ok(())
     }

--- a/src/rust/inetstack/protocols/udp/queue.rs
+++ b/src/rust/inetstack/protocols/udp/queue.rs
@@ -156,11 +156,10 @@ impl<const N: usize> SharedUdpQueue<N> {
         }
     }
 
-    pub fn receive(&mut self, remote: SocketAddrV4, buf: DemiBuffer) -> Result<(), Fail> {
+    pub fn receive(&mut self, remote: SocketAddrV4, buf: DemiBuffer) {
         // Push data to the receiver-side shared queue. This will cause the
         // associated pool operation to be ready.
         self.recv_queue.push((remote, buf));
-        Ok(())
     }
 
     pub fn is_bound(&self) -> bool {

--- a/src/rust/inetstack/protocols/udp/tests.rs
+++ b/src/rust/inetstack/protocols/udp/tests.rs
@@ -24,7 +24,6 @@ use ::futures::task::{
 use ::libc::{
     EADDRINUSE,
     EBADF,
-    ENOTCONN,
 };
 use ::std::{
     convert::TryFrom,
@@ -564,11 +563,9 @@ fn udp_pop_not_bound() -> Result<()> {
     now += Duration::from_micros(1);
 
     // Receive data from Alice.
-    match bob.receive(alice.get_test_rig().pop_frame()) {
-        Err(e) if e.errno == ENOTCONN => {},
-        _ => anyhow::bail!("receive should have failed"),
-    };
-
+    // TODO: check that Bob drops this packet.
+    // FIXME: https://github.com/microsoft/demikernel/issues/1065
+    bob.receive(alice.get_test_rig().pop_frame())?;
     // Close peers.
     alice.udp_close(alice_fd)?;
     // Bob does not have a socket.

--- a/src/rust/inetstack/test_helpers/engine.rs
+++ b/src/rust/inetstack/test_helpers/engine.rs
@@ -101,22 +101,14 @@ impl<const N: usize> SharedEngine<N> {
             return Err(Fail::new(EBADMSG, "physical destination address mismatch"));
         }
         match header.ether_type() {
-            EtherType2::Arp => {
-                // We no longer do the processing in this function.
-                self.arp.receive(payload);
-                // So poll the scheduler to do the processing.
-                self.test_rig.poll_scheduler();
-                Ok(())
-            },
-            EtherType2::Ipv4 => {
-                // We no longer do the processing in this function.
-                self.ipv4.receive(payload)?;
-                // So poll the scheduler to do the processing.
-                self.test_rig.poll_scheduler();
-                Ok(())
-            },
-            EtherType2::Ipv6 => Ok(()), // Ignore for now.
-        }
+            EtherType2::Arp => self.arp.receive(payload),
+            EtherType2::Ipv4 => self.ipv4.receive(payload),
+            EtherType2::Ipv6 => (), // Ignore for now.
+        };
+        // So poll the scheduler to do the processing.
+        self.test_rig.poll_scheduler();
+
+        Ok(())
     }
 
     pub async fn ipv4_ping(&mut self, dest_ipv4_addr: Ipv4Addr, timeout: Option<Duration>) -> Result<Duration, Fail> {


### PR DESCRIPTION
This PR moves the remainder of the inetstack to AsyncQueues and doing network processing in a background coroutine instead of directly in the receive function. A few things to note:
1. We can no longer tell if the inetstack will drop the packet in the receive path. We need to wait for the stack to pick it up from the AsyncQueue and process it. This makes sense because whether the packet is valid depends on what state the inetstack is in. 
2. We use to check the state of the inetstack (or not check it if we decided it would be too expensive). Now the state of the inetstack will be encoded in the async coroutine and where it is blocked.
3. Because the receive path can no longer tell you if the packet will be dropped, some of our tests no longer work. I have filed an issue for this, but I wanted to wait and see what we want to do with these tests with our new nettest frame work.
4. This PR is just the very first step in removing the states from the inetstack and using the async/await framework to encode them instead. This will allow us to unroll the entire lifetime of a TCP socket into a single linear flow.