### PR TITLE
[catnap] Enhancement: add overlapped I/O implementation for Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,14 @@ liburing = { git = "https://github.com/demikernel/liburing-rs", rev = "780827ee3
 windows = { version = "0.52.0", features = [
     "Win32_Foundation",
     "Win32_Networking_WinSock",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_IO",
+    "Win32_System_Pipes",
+    "Win32_System_Threading",
 ] }
+# for interacting with socket2.
+windows-sys = { version = "0.48.0", features = ["Win32_Networking_WinSock"] }
 
 #=======================================================================================================================
 # Targets

--- a/scripts/config/default.yaml
+++ b/scripts/config/default.yaml
@@ -24,5 +24,13 @@ catnip:
     "ff:ff:ff:ff:ff:ff": "YY.YY.YY.YY"
 dpdk:
   eal_init: ["", "-c", "0xff", "-n", "4", "-a", "WW:WW.W","--proc-type=auto"]
+catnap:
+  tcp_keepalive:
+    enabled: false
+    time_millis: 0
+    interval: 0
+  linger:
+    enabled: true
+    time_seconds: 0
 
 # vim: set tabstop=2 shiftwidth=2

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -92,7 +92,7 @@ impl CatnapLibOS {
     pub fn new(config: &Config, runtime: SharedDemiRuntime) -> Self {
         Self {
             runtime: runtime.clone(),
-            transport: SharedCatnapTransport::new(config, runtime),
+            transport: SharedCatnapTransport::new(&config, runtime),
         }
     }
 }

--- a/src/rust/catnap/win/config.rs
+++ b/src/rust/catnap/win/config.rs
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use crate::{
+    demikernel::config::Config,
+    runtime::fail::Fail,
+};
+use ::yaml_rust::Yaml;
+use std::{
+    ops::{
+        Fn,
+        Index,
+    },
+    time::Duration,
+};
+use windows::Win32::Networking::WinSock::tcp_keepalive;
+
+//======================================================================================================================
+// Constants
+//======================================================================================================================
+
+/// Name for the libos in configs.
+const LIBOS: &str = "catnap";
+
+//======================================================================================================================
+// Associated Functions
+//======================================================================================================================
+
+/// Windows-specific configuration for Demikernel configuration object.
+impl Config {
+    /// Reads TCP keepalive settings as a `tcp_keepalive` structure from "tcp_keepalive" subsection.
+    pub fn tcp_keepalive(&self) -> Result<tcp_keepalive, Fail> {
+        const SECTION: &str = "tcp_keepalive";
+        let section: &Yaml = Self::require_subsection(self.get_libos_section()?, SECTION)?;
+
+        let onoff: bool = Self::require_bool_option(section, "enabled")?;
+        let keepalivetime: u32 = Self::require_int_option(section, "time_millis")?;
+        let keepaliveinterval: u32 = Self::require_int_option(section, "interval")?;
+
+        Ok(tcp_keepalive {
+            onoff: if onoff { 1 } else { 0 },
+            keepalivetime,
+            keepaliveinterval,
+        })
+    }
+
+    /// Reads socket linger settings from "linger" subsection. Returned value is Some(_) if enabled; otherwise, None.
+    /// The linger duration will be no larger than u16::MAX seconds.
+    pub fn linger_time(&self) -> Result<Option<Duration>, Fail> {
+        const SECTION: &str = "linger";
+        let section: &Yaml = Self::require_subsection(self.get_libos_section()?, SECTION)?;
+
+        let enabled: bool = Self::require_bool_option(section, "enabled")?;
+        let time_seconds: u16 = Self::require_int_option(section, "time_seconds")?;
+
+        if enabled {
+            Ok(Some(Duration::new(time_seconds as u64, 0)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Get the libos subsection, requiring that it exists and is a Hash.
+    fn get_libos_section(&self) -> Result<&Yaml, Fail> {
+        Self::require_subsection(&self.0, LIBOS)
+    }
+
+    /// Index `yaml` to find the value at `index`, validating that the index exists.
+    fn require_option<'a>(yaml: &'a Yaml, index: &str) -> Result<&'a Yaml, Fail> {
+        match yaml.index(index) {
+            Yaml::BadValue => {
+                let message: String = format!("missing configuration option \"{}\"", index);
+                Err(Fail::new(libc::EINVAL, message.as_str()))
+            },
+            value => Ok(value),
+        }
+    }
+
+    /// Index `yaml` to find the value at `index`, validating that it exists and that the receiver returns Some(_).
+    fn require_typed_option<T>(yaml: &Yaml, index: &str, receiver: &dyn Fn(&Yaml) -> Option<T>) -> Result<T, Fail> {
+        let option: &Yaml = Self::require_option(yaml, index)?;
+        match receiver(option) {
+            Some(value) => Ok(value),
+            None => {
+                let message: String = format!("parameter \"{}\" has unexpected type", index);
+                Err(Fail::new(libc::EINVAL, message.as_str()))
+            },
+        }
+    }
+
+    /// Similar to `require_typed_option` using `Yaml::as_hash` receiver. This method returns a `&Yaml` instead of
+    /// yaml::Hash, and Yaml is more natural for indexing.
+    fn require_subsection<'a>(yaml: &'a Yaml, index: &str) -> Result<&'a Yaml, Fail> {
+        let section: &Yaml = Self::require_option(yaml, index)?;
+        match section {
+            Yaml::Hash(_) => Ok(section),
+            _ => {
+                let message: String = format!("parameter \"{}\" has unexpected type", index);
+                Err(Fail::new(libc::EINVAL, message.as_str()))
+            },
+        }
+    }
+
+    /// Similar to `require_typed_option` using `Yaml::as_i64` as the receiver, but additionally verifies that the
+    /// destination type may hold the i64 value.
+    fn require_int_option<T: TryFrom<i64>>(yaml: &Yaml, index: &str) -> Result<T, Fail> {
+        let val: i64 = Self::require_typed_option(yaml, index, &Yaml::as_i64)?;
+        match T::try_from(val) {
+            Ok(val) => Ok(val),
+            _ => {
+                let message: String = format!("parameter \"{}\" is out of range", index);
+                Err(Fail::new(libc::ERANGE, message.as_str()))
+            },
+        }
+    }
+
+    /// Same as `Self::require_typed_option` using `Yaml::as_bool` as the receiver.
+    fn require_bool_option(yaml: &Yaml, index: &str) -> Result<bool, Fail> {
+        Self::require_typed_option(yaml, index, &Yaml::as_bool)
+    }
+}

--- a/src/rust/catnap/win/error.rs
+++ b/src/rust/catnap/win/error.rs
@@ -1,0 +1,283 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//==============================================================================
+// Imports
+//==============================================================================
+
+use windows::{
+    core::{
+        HRESULT,
+        HSTRING,
+    },
+    Win32::{
+        Foundation::{
+            RtlNtStatusToDosError,
+            ERROR_ABANDONED_WAIT_0,
+            ERROR_ACCESS_DENIED,
+            ERROR_ALREADY_EXISTS,
+            ERROR_INSUFFICIENT_BUFFER,
+            ERROR_INVALID_HANDLE,
+            ERROR_INVALID_PARAMETER,
+            ERROR_IO_INCOMPLETE,
+            ERROR_IO_PENDING,
+            ERROR_MORE_DATA,
+            ERROR_NOT_ENOUGH_MEMORY,
+            ERROR_OPERATION_ABORTED,
+            ERROR_SUCCESS,
+            NTSTATUS,
+            STATUS_ABANDONED,
+            STATUS_SUCCESS,
+            STATUS_TIMEOUT,
+            WAIT_IO_COMPLETION,
+            WAIT_TIMEOUT,
+            WIN32_ERROR,
+        },
+        Networking::WinSock::{
+            self,
+            WSAGetLastError,
+            WSABASEERR,
+            WSA_ERROR,
+            WSA_IO_PENDING,
+        },
+    },
+};
+
+use crate::runtime::fail::Fail;
+
+//======================================================================================================================
+// Associated Functions
+//======================================================================================================================
+impl Fail {
+    pub fn from_win32_error(error: &windows::core::Error, is_wait_error: bool) -> Fail {
+        let cause: String = format!("{}", error);
+        let errno: libc::errno_t = match WIN32_ERROR::from_error(error) {
+            Some(error) => translate_win32_error(error, is_wait_error),
+            None => libc::EFAULT,
+        };
+        Fail::new(errno, cause.as_str())
+    }
+}
+
+//======================================================================================================================
+// Functions
+//======================================================================================================================
+
+/// Translate win32 errors which are not also winsock errors to errnos. Winsock errors are all values not smaller than
+/// WSABASEERR. Some WSA_ERROR names overlap with WIN32_ERROR names. Those names are translated by this method.
+pub fn try_translate_win32_error(err: WIN32_ERROR, is_wait_api: bool) -> Option<libc::errno_t> {
+    // WAIT_TIMEOUT is a WAIT_EVENT, but the error code is a WIN32_ERROR.
+    const ERROR_WAIT_TIMEOUT: WIN32_ERROR = WIN32_ERROR(WAIT_TIMEOUT.0);
+    const ERROR_WAIT_IO_COMPLETION: WIN32_ERROR = WIN32_ERROR(WAIT_IO_COMPLETION.0);
+
+    let errno: libc::errno_t = match err {
+        ERROR_ACCESS_DENIED => libc::EACCES,
+        ERROR_NOT_ENOUGH_MEMORY => libc::ENOMEM,
+        ERROR_ALREADY_EXISTS => libc::EEXIST,
+        ERROR_INVALID_HANDLE => libc::EINVAL,
+        ERROR_INVALID_PARAMETER => libc::EINVAL,
+        ERROR_IO_INCOMPLETE => libc::EIO,
+        ERROR_IO_PENDING => libc::EINPROGRESS,
+        ERROR_OPERATION_ABORTED => libc::ECANCELED,
+        ERROR_INSUFFICIENT_BUFFER => libc::EOVERFLOW,
+        ERROR_MORE_DATA => libc::EOVERFLOW,
+
+        // Wait APIs return some code which overlap with other API return codes. The following are only valid for wait
+        // APIs (e.g., GetOverlappedResultEx, GetQueuedCompletionStateEx).
+        ERROR_WAIT_TIMEOUT if is_wait_api => libc::ETIMEDOUT,
+        ERROR_WAIT_IO_COMPLETION if is_wait_api => libc::EAGAIN,
+
+        // This can have multiple meanings; generally it is associated with a wait object which is closed while some
+        // thread is waiting. EBADF indicates the handle is now invalid.
+        ERROR_ABANDONED_WAIT_0 => libc::EBADF,
+
+        _ => {
+            return None;
+        },
+    };
+
+    Some(errno)
+}
+
+/// Translate winsock errors which are not also win32 errors to errno codes. Note that WIN32_ERROR and WSA_ERROR exist
+/// in the same domain and some errors have multiple aliases. This method only translates errors not smaller than
+/// WSABASEERR, which are winsock-specific errors; other errors overlap with win32 error codes and should be validated
+/// by try_translate_win32_error. Most WSA errors have direct equivalence to errno codes.
+pub fn try_translate_wsa_error(err: WSA_ERROR) -> Option<libc::errno_t> {
+    if err.0 < WSABASEERR.0 {
+        return None;
+    }
+
+    let value: libc::errno_t = match err {
+        // Winsock errors with errno equivalents
+        WinSock::WSAEINTR => libc::EINTR,
+        WinSock::WSAEBADF => libc::EBADF,
+        WinSock::WSAEACCES => libc::EACCES,
+        WinSock::WSAEFAULT => libc::EFAULT,
+        WinSock::WSAEINVAL => libc::EINVAL,
+        WinSock::WSAEMFILE => libc::EMFILE,
+        WinSock::WSAEWOULDBLOCK => libc::EWOULDBLOCK,
+        WinSock::WSAEINPROGRESS => libc::EINPROGRESS,
+        WinSock::WSAEALREADY => libc::EALREADY,
+        WinSock::WSAENOTSOCK => libc::ENOTSOCK,
+        WinSock::WSAEDESTADDRREQ => libc::EDESTADDRREQ,
+        WinSock::WSAEMSGSIZE => libc::EMSGSIZE,
+        WinSock::WSAEPROTOTYPE => libc::EPROTOTYPE,
+        WinSock::WSAENOPROTOOPT => libc::ENOPROTOOPT,
+        WinSock::WSAEPROTONOSUPPORT => libc::EPROTONOSUPPORT,
+        WinSock::WSAEOPNOTSUPP => libc::EOPNOTSUPP,
+        WinSock::WSAEAFNOSUPPORT => libc::EAFNOSUPPORT,
+        WinSock::WSAEADDRINUSE => libc::EADDRINUSE,
+        WinSock::WSAEADDRNOTAVAIL => libc::EADDRNOTAVAIL,
+        WinSock::WSAENETDOWN => libc::ENETDOWN,
+        WinSock::WSAENETUNREACH => libc::ENETUNREACH,
+        WinSock::WSAENETRESET => libc::ENETRESET,
+        WinSock::WSAECONNABORTED => libc::ECONNABORTED,
+        WinSock::WSAECONNRESET => libc::ECONNRESET,
+        WinSock::WSAENOBUFS => libc::ENOBUFS,
+        WinSock::WSAEISCONN => libc::EISCONN,
+        WinSock::WSAENOTCONN => libc::ENOTCONN,
+        WinSock::WSAETIMEDOUT => libc::ETIMEDOUT,
+        WinSock::WSAECONNREFUSED => libc::ECONNREFUSED,
+        WinSock::WSAELOOP => libc::ELOOP,
+        WinSock::WSAENAMETOOLONG => libc::ENAMETOOLONG,
+        WinSock::WSAEHOSTUNREACH => libc::EHOSTUNREACH,
+        WinSock::WSAENOTEMPTY => libc::ENOTEMPTY,
+        WinSock::WSAESOCKTNOSUPPORT => libc::EPROTONOSUPPORT,
+        WinSock::WSAEPFNOSUPPORT => libc::EPROTONOSUPPORT,
+
+        // Winsock errors with errno equivalents missing from Rust libc
+        WinSock::WSAESHUTDOWN => libc::EINVAL,       /*libc::ESHUTDOWN*/
+        WinSock::WSAETOOMANYREFS => libc::EINVAL,    /*libc::ETOOMANYREFS*/
+        WinSock::WSAEHOSTDOWN => libc::EHOSTUNREACH, /*libc::EHOSTDOWN*/
+        WinSock::WSAEPROCLIM => libc::ENOMEM,        /*libc::EPROCLIM*/
+        WinSock::WSAEUSERS => libc::ENOMEM,          /*libc::EUSERS*/
+        WinSock::WSAEDQUOT => libc::ENOSPC,          /*libc::EDQUOT*/
+        WinSock::WSAESTALE => libc::EINVAL,          /*libc::ESTALE*/
+        WinSock::WSAEREMOTE => libc::EINVAL,         /*libc::EREMOTE*/
+
+        // Winsock errors without direct errno equivalence.
+        //
+        // System state errors
+        WinSock::WSASYSNOTREADY => libc::EFAULT,
+        WinSock::WSAVERNOTSUPPORTED => libc::EFAULT,
+        WinSock::WSANOTINITIALISED => libc::ENODEV,
+        WinSock::WSAEPROVIDERFAILEDINIT => libc::ENODEV,
+        WinSock::WSASERVICE_NOT_FOUND => libc::ENODEV,
+        WinSock::WSATYPE_NOT_FOUND => libc::ENODEV,
+
+        // Operation state errors
+        WinSock::WSATRY_AGAIN => libc::EAGAIN,
+        WinSock::WSA_E_CANCELLED => libc::ECANCELED,
+        WinSock::WSANO_RECOVERY => libc::EFAULT,
+        WinSock::WSAEDISCON => libc::ENOTCONN,
+
+        // Condition/invariant violation
+        WinSock::WSASYSCALLFAILURE => libc::EFAULT,
+
+        /* The following codes are WIN32_ERROR codes which are aliased as winsock errors, so they are below WSABASEERR.
+        WSA_INVALID_HANDLE is ERROR_INVALID_HANDLE
+        WSA_INVALID_PARAMETER is ERROR_INVALID_PARAMETER
+        WSA_IO_INCOMPLETE is ERROR_IO_INCOMPLETE
+        WSA_IO_PENDING is WSA_IO_PENDING
+        WSA_OPERATION_ABORTED is ERROR_OPERATION_ABORTED
+        WSA_NOT_ENOUGH_MEMORY is ERROR_NOT_ENOUGH_MEMORY */
+        // Everything else.
+        _ => return None,
+    };
+
+    Some(value)
+}
+
+/// Translate an NTSTATUS into a WIN32_ERROR.
+pub fn translate_ntstatus(status: NTSTATUS) -> WIN32_ERROR {
+    match status {
+        // A few common error codes to skip for fast path.
+        STATUS_SUCCESS => ERROR_SUCCESS,
+        STATUS_TIMEOUT => WIN32_ERROR(WAIT_TIMEOUT.0),
+        STATUS_ABANDONED => ERROR_ABANDONED_WAIT_0,
+
+        // Lookup via Windows API.
+        status => unsafe { WIN32_ERROR(RtlNtStatusToDosError(status)) },
+    }
+}
+
+/// Translate a small subset of Win32 or Winsock error codes which we may be interested in distinguishing to errno_t.
+/// Unrecognized codes translate to EFAULT.
+pub fn translate_win32_error(error: WIN32_ERROR, is_wait_api: bool) -> libc::errno_t {
+    // WSA_ERROR and WIN32_ERROR share a domain. As HRESULTs, they are in the same class.
+    if let Some(err) = try_translate_wsa_error(WSA_ERROR(error.0 as i32)) {
+        return err;
+    }
+
+    if let Some(err) = try_translate_win32_error(error, is_wait_api) {
+        return err;
+    }
+
+    // Default for unknown errors.
+    libc::EFAULT
+}
+
+/// Translate a win32 error stored as a WSA_ERROR into a windows crate Error type.
+fn wsa_error_to_win_error(err: WSA_ERROR) -> windows::core::Error {
+    let hresult: HRESULT = WIN32_ERROR(err.0 as u32).into();
+    windows::core::Error::new(hresult, HSTRING::new())
+}
+
+/// Get the result of the most recent winsock overlapped operation, interpreting WSAGetLastError and handling
+/// IO_PENDING non-errors.
+pub fn last_overlapped_wsa_error() -> Result<(), Fail> {
+    let wsa_error: WSA_ERROR = unsafe { WSAGetLastError() };
+    if wsa_error == WSA_IO_PENDING {
+        Ok(())
+    } else {
+        let error: windows::core::Error = wsa_error_to_win_error(wsa_error);
+        if error.code().is_ok() {
+            Ok(())
+        } else {
+            Err(error.into())
+        }
+    }
+}
+
+/// Get a Result for the most recent winsock overlapped operation from WSAGetLastError as well as the API's return code.
+pub fn get_overlapped_api_result(api_success: bool) -> Result<(), Fail> {
+    if api_success {
+        Ok(())
+    } else {
+        last_overlapped_wsa_error()
+    }
+}
+
+/// Expect that WSAGetLastError indicates an error condition, and return it as a Fail operation. If error code is
+/// ERROR_SUCCESS, the failure message will indicate such. Note: no errno represents this status accurately.
+pub fn expect_last_wsa_error() -> Fail {
+    // Safety: FFI; no major considerations.
+    wsa_error_to_win_error(unsafe { WSAGetLastError() }).into()
+}
+
+//======================================================================================================================
+// Traits
+//======================================================================================================================
+
+/// Convert from WIN32_ERROR to Fail.
+impl From<WIN32_ERROR> for Fail {
+    fn from(value: WIN32_ERROR) -> Self {
+        let error: windows::core::Error = windows::core::Error::new(value.into(), HSTRING::new());
+        error.into()
+    }
+}
+
+/// Convert from windows crate error type to Fail (reference version).
+impl From<&windows::core::Error> for Fail {
+    fn from(value: &windows::core::Error) -> Self {
+        Fail::from_win32_error(value, false)
+    }
+}
+
+/// Convert from windows crate error type to Fail (value version).
+impl From<windows::core::Error> for Fail {
+    fn from(value: windows::core::Error) -> Self {
+        Self::from(&value)
+    }
+}

--- a/src/rust/catnap/win/overlapped.rs
+++ b/src/rust/catnap/win/overlapped.rs
@@ -1,0 +1,816 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//==============================================================================
+// Imports
+//==============================================================================
+
+use std::{
+    cell::{
+        Cell,
+        UnsafeCell,
+    },
+    marker::{
+        PhantomData,
+        PhantomPinned,
+    },
+    pin::Pin,
+};
+
+use windows::Win32::{
+    Foundation::{
+        CloseHandle,
+        FALSE,
+        HANDLE,
+        INVALID_HANDLE_VALUE,
+        NTSTATUS,
+        WAIT_TIMEOUT,
+        WIN32_ERROR,
+    },
+    Networking::WinSock::SOCKET,
+    System::IO::{
+        CreateIoCompletionPort,
+        GetQueuedCompletionStatusEx,
+        OVERLAPPED,
+        OVERLAPPED_ENTRY,
+    },
+};
+
+use crate::{
+    catnap::transport::error::translate_ntstatus,
+    runtime::{
+        fail::Fail,
+        scheduler::{
+            Yielder,
+            YielderHandle,
+        },
+    },
+};
+
+//======================================================================================================================
+// Structures
+//======================================================================================================================
+
+/// A structure to represent the results of an overlapped I/O operation.
+#[derive(Clone, Copy)]
+pub struct OverlappedResult {
+    /// The completion key for the operation, as set with `IoCompletionPort::associate`.
+    pub completion_key: usize,
+    /// Status result of the operation.
+    pub result: NTSTATUS,
+    /// Number of bytes transferred, if applicable.
+    pub bytes_transferred: u32,
+}
+
+/// Data required by the I/O completion port processor to process I/O completions.
+#[repr(C)]
+struct OverlappedCompletion {
+    /// OVERLAPPED must be first; the implementation casts between the outer structure and this type.
+    overlapped: OVERLAPPED,
+    /// If set, indicates a coroutine in waiting. Cleared by the I/O processor to signal completion. If unset when an
+    /// overlapped is dequeued from the completion port, the completion is abandoned.
+    yielder_handle: Option<YielderHandle>,
+    /// Set by the I/O processor to indicate overlapped result.
+    completion_key: usize,
+    /// A callback to free all resources associated with the completion for abandoned waits.
+    free: unsafe fn(*mut OVERLAPPED) -> (),
+    /// Ensure the data stays pinned since the OVERLAPPED must be pinned.
+    _marker: PhantomPinned,
+}
+
+/// The set of data which must live as long as the I/O operation, including any optional state from the caller.
+#[repr(C)]
+struct StatefulOverlappedCompletion<S> {
+    /// Inner data required by the completion processor; must be first to "downcast" to OVERLAPPED.
+    inner: OverlappedCompletion,
+    /// Caller state, encased in a cell for interior mutability.
+    state: UnsafeCell<S>,
+}
+
+/// This struct encapsulates the behavior of Windows I/O completion ports. This implementation exposes a single
+/// threaded interface for invoking and processing the results of overlapped I/O via idiomatic start-cancel-finish
+/// operations. While this type implements `Send`, multiple threads should avoid calling `process_events`, as there may
+/// be overhead or OS limitations on the number of such threads. This type cannot be shared among threads.
+pub struct IoCompletionPort {
+    /// The OS handle to the completion port.
+    iocp: HANDLE,
+
+    /// Marker to prevent this type from implementing `Sync`.
+    _marker: PhantomData<Cell<()>>,
+}
+
+//======================================================================================================================
+// Associated Functions
+//======================================================================================================================
+
+impl OverlappedResult {
+    /// Create an OverlappedResult from the completed OVERLAPPED structure and the completion key returned from the
+    /// I/O completion port.
+    pub fn new(overlapped: &OVERLAPPED, completion_key: usize) -> OverlappedResult {
+        Self {
+            completion_key,
+            result: NTSTATUS(overlapped.Internal as i32),
+            bytes_transferred: overlapped.InternalHigh as u32,
+        }
+    }
+
+    /// Convert the OverlappedResult into a Result<...> indicating success or failure of the referent operation.
+    pub fn ok(&self) -> Result<(), Fail> {
+        let win32_error: WIN32_ERROR = translate_ntstatus(self.result);
+        if win32_error.is_ok() {
+            Ok(())
+        } else {
+            Err(win32_error.into())
+        }
+    }
+}
+
+impl IoCompletionPort {
+    /// Create a new I/O completion port.
+    pub fn new() -> Result<IoCompletionPort, Fail> {
+        let iocp: HANDLE = match unsafe { CreateIoCompletionPort(INVALID_HANDLE_VALUE, None, 0, 1) } {
+            Ok(handle) => handle,
+            Err(err) => return Err(err.into()),
+        };
+
+        if iocp.is_invalid() {
+            const MSG: &str = "CreateIoCompletionPort succeeded by returned handle is invalid";
+            error!("{}", MSG);
+            return Err(Fail::new(libc::EFAULT, MSG));
+        }
+
+        Ok(IoCompletionPort {
+            iocp,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Associate socket `s` with this I/O completion port. All overlapped I/O operations for `s` which complete on this
+    /// completion port will return `completion_key` in the `OverlappedResults` structure.
+    #[allow(unused)]
+    pub fn associate_socket(&self, s: SOCKET, completion_key: usize) -> Result<(), Fail> {
+        self.associate_handle(HANDLE(s.0 as isize), completion_key)
+    }
+
+    /// Associate a file handle with this I/O completion port. All overlapped I/O operations for `handle` which complete
+    /// on this completion port will return `completion_key` in the `OverlappedResults` structure.
+    pub fn associate_handle(&self, handle: HANDLE, completion_key: usize) -> Result<(), Fail> {
+        match unsafe { CreateIoCompletionPort(handle, self.iocp, completion_key, 0) } {
+            Ok(_) => Ok(()),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    /// Perform an asynchronous overlapped I/O operation. This method requires three functions: one to start the I/O
+    /// (`start`), one to cancel the I/O on cancellation (`cancel`), and one to finish/clean up and interpret the
+    /// results (`finish`). `start` and `cancel` accept an OVERLAPPED pointer for controlling the I/O operation as
+    /// well as the state value (initialized by `state`). If `start` fails, this method will abort without calling
+    /// `cancel` or `finish`. In this instance, the OVERLAPPED passed to `start` must never be dequeued from the I/O
+    /// completion port. If `start` must fail in a way that may result in the OVERLAPPED being dequeued, the method must
+    /// return Ok(()) and indicate failure via the `finish` callback (presumably using `state`). `cancel` is invoked iff
+    /// the Yielder wakes with an `ECANCELLED` error. When the OVERLAPPED passed to `start` is dequeued from the
+    /// completion port, `finish` is invoked with the OverlappedResult type and the state (the same reference passed to
+    /// `start`). The return of `finish` is returned from the method.
+    ///
+    /// Note that the state type S is bound to the `'static` lifetime. The state object is dynamically allocated and may
+    /// outlive this function. An example here may be a failed cancellation: a call to `ReadFile` or `WSARecv` may be in
+    /// the process of filling the receive buffer when a cancellation occurs (presumably kept alive by S). In this case,
+    /// `CancelIo` will fail. Assuming the caller returns before the OVERLAPPED is dequeued, S may live longer than the
+    /// calling method.
+    ///
+    /// Safety: `start` should return Ok(...) iff the I/O is started and the OVERLAPPED parameter will
+    /// eventually be dequeued from the completion port; if this requirement is not met, resources will leak. Likewise,
+    /// `cancel` should return Ok(...) iff the operation is cancelled and the OVERLAPPED parameter will never be
+    /// dequeued from the completion port.  Waking the Yielder for errors which are no ECANCELLED will abandon the wait.
+    /// While OVERLAPPED resources will be freed in a non-exceptional scenario, this may cause unsound behavior I/O on
+    /// the same file/socket.
+    pub async unsafe fn do_io_with<F1, F2, F3, R, S>(
+        &mut self,
+        state: S,
+        yielder: &Yielder,
+        start: F1,
+        cancel: F2,
+        finish: F3,
+    ) -> Result<R, Fail>
+    where
+        S: 'static,
+        for<'a> F1: FnOnce(Pin<&'a mut S>, *mut OVERLAPPED) -> Result<(), Fail>,
+        for<'a> F2: FnOnce(Pin<&'a mut S>, *mut OVERLAPPED) -> Result<(), Fail>,
+        for<'a> F3: FnOnce(Pin<&'a mut S>, OverlappedResult) -> Result<R, Fail>,
+    {
+        let mut completion: Pin<Box<StatefulOverlappedCompletion<S>>> = Box::pin(StatefulOverlappedCompletion {
+            inner: OverlappedCompletion {
+                overlapped: OVERLAPPED::default(),
+                yielder_handle: Some(yielder.get_handle()),
+                completion_key: 0,
+                free: StatefulOverlappedCompletion::<S>::drop_overlapped,
+                _marker: PhantomPinned,
+            },
+            state: UnsafeCell::new(state),
+        });
+
+        let overlapped: *mut OVERLAPPED = completion.as_mut().marshal();
+        match start(completion.get_state_ref(), overlapped) {
+            // Operation in progress, pending overlapped completion.
+            Ok(()) => loop {
+                let status: Result<(), Fail> = yielder.yield_until_wake().await;
+
+                // NB If the yielder handle is cleared, the event was dequeued from the completion port and
+                // processed. If the coroutine was also cancelled, depending on the order of scheduling the result
+                // may still indicate failure. YielderHandler absence takes higher precedence here -- no need to
+                // signal failure if it's not semantically useful.
+                if completion.inner.yielder_handle.is_none() {
+                    return finish(
+                        completion.get_state_ref(),
+                        OverlappedResult::new(&completion.inner.overlapped, completion.inner.completion_key),
+                    );
+                }
+
+                match status {
+                    Ok(()) => {
+                        // Spurious wake-up.
+                        continue;
+                    },
+
+                    Err(err) => {
+                        if err.errno == libc::ECANCELED {
+                            if let Err(cancel_err) = cancel(completion.get_state_ref(), overlapped) {
+                                warn!("cancellation failed: {}", cancel_err);
+                            } else {
+                                return Err(err);
+                            }
+                        }
+
+                        completion.abandon();
+                        return Err(err);
+                    },
+                }
+            },
+
+            // Operation failed to start.
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Same as `do_io_with`, but does not use an intermediate state value.
+    pub async unsafe fn do_io<F1, F2, F3, R>(
+        &mut self,
+        yielder: &Yielder,
+        start: F1,
+        cancel: F2,
+        finish: F3,
+    ) -> Result<R, Fail>
+    where
+        F1: FnOnce(*mut OVERLAPPED) -> Result<(), Fail>,
+        F2: FnOnce(*mut OVERLAPPED) -> Result<(), Fail>,
+        F3: FnOnce(OverlappedResult) -> Result<R, Fail>,
+    {
+        self.do_io_with(
+            (),
+            yielder,
+            |_, overlapped: *mut OVERLAPPED| -> Result<(), Fail> { start(overlapped) },
+            |_, overlapped: *mut OVERLAPPED| -> Result<(), Fail> { cancel(overlapped) },
+            |_, result: OverlappedResult| -> Result<R, Fail> { finish(result) },
+        )
+        .await
+    }
+
+    /// Process a single overlapped entry.
+    #[allow(unused)]
+    fn process_overlapped(&mut self, entry: &OVERLAPPED_ENTRY) {
+        if let Some(overlapped) = std::ptr::NonNull::new(entry.lpOverlapped) {
+            // Safety: this is valid as long as the caller follows the contract: all queued OVERLAPPED instances are
+            // generated by `IoCompletionPort` API.
+            let overlapped: Pin<&mut OverlappedCompletion> = OverlappedCompletion::unmarshal(overlapped);
+
+            // Safety: the OVERLAPPED does not need to be pinned after being dequeued from the completion port.
+            let overlapped: &mut OverlappedCompletion = unsafe { overlapped.get_unchecked_mut() };
+            if let Some(mut yielder_handle) = overlapped.yielder_handle.take() {
+                debug_assert!(entry.dwNumberOfBytesTransferred as usize == overlapped.overlapped.InternalHigh);
+                overlapped.completion_key = entry.lpCompletionKey;
+                yielder_handle.wake_with(Ok(()));
+            } else {
+                // This can happen due to a failed cancellation or any other error on the do_overlapped path.
+                trace!("I/O dropped for completion key {}", entry.lpCompletionKey);
+                let free_fn: unsafe fn(*mut OVERLAPPED) = overlapped.free;
+                unsafe { (free_fn)(entry.lpOverlapped) };
+            }
+        }
+    }
+
+    /// Process entries by peeking the completion port.
+    #[allow(unused)]
+    pub fn process_events(&mut self) -> Result<(), Fail> {
+        // Arbitrarily chosen batch size; should be updated after tuning.
+        const BATCH_SIZE: usize = 4;
+        let mut entries: [OVERLAPPED_ENTRY; BATCH_SIZE] = [OVERLAPPED_ENTRY::default(); BATCH_SIZE];
+
+        loop {
+            let mut dequeued: u32 = 0;
+            match unsafe { GetQueuedCompletionStatusEx(self.iocp, entries.as_mut_slice(), &mut dequeued, 0, FALSE) } {
+                Ok(()) => {
+                    for i in 0..dequeued {
+                        self.process_overlapped(&entries[i as usize]);
+                    }
+
+                    if dequeued < BATCH_SIZE as u32 {
+                        return Ok(());
+                    }
+                },
+
+                // WAIT_TIMEOUT is a not an error condition.
+                Err(err) if err.code() == WIN32_ERROR(WAIT_TIMEOUT.0).into() => return Ok(()),
+
+                // All other errors are error conditions. Note that GetQueuedCompletionStatusEx can set wait errors as
+                // win32 errors.
+                Err(err) => return Err(Fail::from_win32_error(&err, true)),
+            }
+        }
+    }
+}
+
+impl OverlappedCompletion {
+    /// Marshal an OVERLAPPED pointer back into an OverlappedCompletion.
+    fn unmarshal<'a>(overlapped: std::ptr::NonNull<OVERLAPPED>) -> Pin<&'a mut Self> {
+        unsafe { Pin::new_unchecked(&mut *(overlapped.as_ptr() as *mut Self)) }
+    }
+}
+
+impl<S> StatefulOverlappedCompletion<S> {
+    /// Marshal a StatefulOverlappedCompletion into an OVERLAPPED pointer. This type must be pinned for marshaling.
+    fn marshal(mut self: Pin<&mut Self>) -> *mut OVERLAPPED {
+        unsafe { self.as_mut().get_unchecked_mut() as *mut Self }.cast()
+    }
+
+    /// Called by the I/O event processor to free this instance if the completion is abandoned by the waiter.
+    unsafe fn drop_overlapped(overlapped: *mut OVERLAPPED) {
+        if overlapped != std::ptr::null_mut() {
+            let overlapped: *mut Self = overlapped.cast();
+            let overlapped: Box<Self> = unsafe { Box::from_raw(overlapped) };
+            std::mem::drop(overlapped);
+        }
+    }
+
+    /// Structural pinning (required) for `inner`.
+    fn get_inner<'a>(self: &'a mut Pin<Box<Self>>) -> Pin<&'a mut OverlappedCompletion> {
+        unsafe { Pin::new_unchecked(&mut self.as_mut().get_unchecked_mut().inner) }
+    }
+
+    /// Structure pinning (probably required) for `state`.
+    fn get_state_ref<'a>(self: &Pin<Box<Self>>) -> Pin<&'a mut S> {
+        unsafe { Pin::new_unchecked(&mut *self.state.get()) }
+    }
+
+    /// Set the yielder handle for the waiter. The yielder handle is not structurally pinned.
+    fn set_yielder(self: &mut Pin<Box<Self>>, yielder_handle: Option<YielderHandle>) {
+        // Safety: updating the yielder does not violate pinning invariants.
+        unsafe { self.get_inner().get_unchecked_mut() }.yielder_handle = yielder_handle;
+    }
+
+    /// Abandon this overlapped instance. This will consume and forget `self` so that the waiter may return without
+    /// invalidating memory needed by the I/O event processor. This method should only be called when the OVERLAPPED
+    /// has not yet been dequeued from the completion port.
+    unsafe fn abandon(mut self: Pin<Box<Self>>) {
+        self.set_yielder(None);
+        std::mem::forget(self)
+    }
+}
+
+//======================================================================================================================
+// Traits
+//======================================================================================================================
+
+impl Drop for IoCompletionPort {
+    /// Close the underlying handle when the completion port is dropped. The underlying primitive will not be freed
+    /// until until all `associate`d handles are closed.
+    fn drop(&mut self) {
+        let _ = unsafe { CloseHandle(self.iocp) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        iter,
+        pin::pin,
+        ptr::NonNull,
+        rc::Rc,
+        sync::atomic::{
+            AtomicU32,
+            Ordering,
+        },
+    };
+
+    use crate::{
+        ensure_eq,
+        runtime::scheduler::{
+            Scheduler,
+            TaskHandle,
+            TaskWithResult,
+        },
+    };
+
+    use super::*;
+    use anyhow::{
+        anyhow,
+        bail,
+        ensure,
+        Result,
+    };
+    use futures::Future;
+    use windows::{
+        core::{
+            s,
+            HRESULT,
+            PCSTR,
+        },
+        Win32::{
+            Foundation::{
+                ERROR_IO_PENDING,
+                GENERIC_WRITE,
+            },
+            Storage::FileSystem::{
+                CreateFileA,
+                ReadFile,
+                WriteFile,
+                FILE_FLAGS_AND_ATTRIBUTES,
+                FILE_FLAG_FIRST_PIPE_INSTANCE,
+                FILE_FLAG_OVERLAPPED,
+                FILE_SHARE_NONE,
+                OPEN_EXISTING,
+                PIPE_ACCESS_DUPLEX,
+            },
+            System::{
+                Pipes::{
+                    ConnectNamedPipe,
+                    CreateNamedPipeA,
+                    PIPE_READMODE_MESSAGE,
+                    PIPE_REJECT_REMOTE_CLIENTS,
+                    PIPE_TYPE_MESSAGE,
+                },
+                IO::{
+                    CancelIoEx,
+                    PostQueuedCompletionStatus,
+                },
+            },
+        },
+    };
+
+    struct SafeHandle(HANDLE);
+
+    impl Drop for SafeHandle {
+        fn drop(&mut self) {
+            let _ = unsafe { CloseHandle(self.0) };
+        }
+    }
+
+    /// Create an I/O completion port, mapping the error return to
+    fn make_iocp() -> Result<IoCompletionPort> {
+        IoCompletionPort::new().map_err(|err: Fail| anyhow!("Failed to create I/O completion port: {}", err))
+    }
+
+    /// Post an overlapped instance to the I/O completion port.
+    fn post_completion(iocp: &IoCompletionPort, overlapped: *const OVERLAPPED, completion_key: usize) -> Result<()> {
+        unsafe { PostQueuedCompletionStatus(iocp.iocp, 0, completion_key, Some(overlapped)) }
+            .map_err(|err| anyhow!("PostQueuedCompletionStatus failed: {}", err))
+    }
+
+    // Turn an anyhow Error into a Fail.
+    fn anyhow_fail(error: anyhow::Error) -> Fail {
+        Fail::new(libc::EFAULT, error.to_string().as_str())
+    }
+
+    // Check if an overlapped Result is ok, turning ERROR_IO_PENDING into an Ok(()).
+    fn is_overlapped_ok(result: Result<(), windows::core::Error>) -> Result<(), Fail> {
+        if let Err(err) = result {
+            if err.code() == HRESULT::from(ERROR_IO_PENDING) {
+                Ok(())
+            } else {
+                Err(err.into())
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_marshal_unmarshal() -> Result<()> {
+        let mut completion: Pin<&mut StatefulOverlappedCompletion<()>> = pin!(StatefulOverlappedCompletion {
+            inner: OverlappedCompletion {
+                overlapped: OVERLAPPED::default(),
+                yielder_handle: None,
+                completion_key: 0,
+                free: StatefulOverlappedCompletion::<()>::drop_overlapped,
+                _marker: PhantomPinned,
+            },
+            state: UnsafeCell::new(()),
+        });
+
+        // Ensure that the marshal returns the address of the overlapped member.
+        ensure_eq!(
+            completion.as_mut().marshal() as *const OVERLAPPED as usize,
+            &completion.inner.overlapped as *const OVERLAPPED as usize
+        );
+
+        // Ensure that marshal returns the address of the completion.
+        ensure_eq!(
+            completion.as_mut().marshal() as usize,
+            completion.as_ref().get_ref() as *const StatefulOverlappedCompletion<()> as usize
+        );
+
+        // This can be inferred transitively from above. The overlapped member must be at offset 0.
+        ensure_eq!(
+            (&completion.inner.overlapped as *const OVERLAPPED) as usize,
+            (completion.as_ref().get_ref() as *const StatefulOverlappedCompletion<()>) as usize
+        );
+
+        let overlapped_ptr: NonNull<OVERLAPPED> = NonNull::new(completion.as_mut().marshal()).unwrap();
+        let unmarshalled: Pin<&mut OverlappedCompletion> = OverlappedCompletion::unmarshal(overlapped_ptr);
+
+        // Test that unmarshal returns an address which is the same as the OVERLAPPED, which is the same as the original
+        // StatefulOverlappedCompletion. This implies that OVERLAPPED is at member offset 0 in all structs.
+        ensure_eq!(
+            unmarshalled.as_ref().get_ref() as *const OverlappedCompletion as usize,
+            completion.as_ref().get_ref() as *const StatefulOverlappedCompletion<()> as usize
+        );
+
+        Ok(())
+    }
+
+    /// Test that the event processor can dequeue an overlapped event from the completion port.
+    #[test]
+    fn test_event_processor() -> Result<()> {
+        const COMPLETION_KEY: usize = 123;
+        let mut iocp: IoCompletionPort = make_iocp()?;
+        let mut yielder_handle: YielderHandle = YielderHandle::new();
+        let mut overlapped: Pin<&mut StatefulOverlappedCompletion<()>> = pin!(StatefulOverlappedCompletion {
+            inner: OverlappedCompletion {
+                overlapped: OVERLAPPED::default(),
+                yielder_handle: Some(yielder_handle.clone()),
+                completion_key: 0,
+                free: StatefulOverlappedCompletion::<()>::drop_overlapped,
+                _marker: PhantomPinned,
+            },
+            state: UnsafeCell::new(()),
+        });
+
+        post_completion(&iocp, overlapped.as_mut().marshal(), COMPLETION_KEY)?;
+
+        iocp.process_events()?;
+
+        let unpinned_overlapped: &mut StatefulOverlappedCompletion<()> = unsafe { overlapped.get_unchecked_mut() };
+
+        ensure!(
+            unpinned_overlapped.inner.yielder_handle.is_none(),
+            "yielder should be cleared by iocp"
+        );
+        ensure_eq!(
+            unpinned_overlapped.inner.completion_key,
+            COMPLETION_KEY,
+            "completion key not updated"
+        );
+
+        let result: Option<Result<(), Fail>> = yielder_handle.get_result();
+        ensure!(result.is_some(), "yielder handle not woken");
+        ensure!(result.unwrap().is_ok(), "yielder handle result not success");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_overlapped_named_pipe() -> Result<()> {
+        const MESSAGE: &str = "Hello world!";
+        const PIPE_NAME: PCSTR = s!(r"\\.\pipe\demikernel-test-pipe");
+        const BUFFER_SIZE: u32 = 128;
+        const COMPLETION_KEY: usize = 0xFEEDF00D;
+        let server_pipe: SafeHandle = SafeHandle(unsafe {
+            CreateNamedPipeA(
+                PIPE_NAME,
+                PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE | FILE_FLAG_OVERLAPPED,
+                PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_REJECT_REMOTE_CLIENTS,
+                1,
+                BUFFER_SIZE,
+                BUFFER_SIZE,
+                0,
+                None,
+            )
+        }?);
+        let server_state: Rc<AtomicU32> = Rc::new(AtomicU32::new(0));
+        let server_state_view: Rc<AtomicU32> = server_state.clone();
+        let mut iocp: UnsafeCell<IoCompletionPort> = UnsafeCell::new(make_iocp().map_err(anyhow_fail)?);
+        iocp.get_mut().associate_handle(server_pipe.0, COMPLETION_KEY)?;
+        let iocp_ref: &mut IoCompletionPort = unsafe { &mut *iocp.get() };
+
+        let server: Pin<Box<dyn Future<Output = Result<(), Fail>>>> = Box::pin(async move {
+            let yielder: Yielder = Yielder::new();
+
+            unsafe {
+                iocp_ref.do_io(
+                    &yielder,
+                    |overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
+                        server_state.fetch_add(1, Ordering::Relaxed);
+                        is_overlapped_ok(ConnectNamedPipe(server_pipe.0, Some(overlapped)))
+                    },
+                    |_| -> Result<(), Fail> { Err(Fail::new(libc::ENOTSUP, "cannot cancel")) },
+                    |result: OverlappedResult| -> Result<(), Fail> { result.ok() },
+                )
+            }
+            .await?;
+
+            server_state.fetch_add(1, Ordering::Relaxed);
+
+            let mut buffer: Rc<Vec<u8>> = Rc::new(iter::repeat(0u8).take(BUFFER_SIZE as usize).collect::<Vec<u8>>());
+            buffer = unsafe {
+                iocp_ref.do_io_with(
+                    buffer,
+                    &yielder,
+                    |state: Pin<&mut Rc<Vec<u8>>>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
+                        let vec: &mut Vec<u8> = Rc::get_mut(state.get_mut()).unwrap();
+                        vec.resize(BUFFER_SIZE as usize, 0u8);
+                        is_overlapped_ok(ReadFile(
+                            server_pipe.0,
+                            Some(vec.as_mut_slice()),
+                            None,
+                            Some(overlapped),
+                        ))
+                    },
+                    |_, _| -> Result<(), Fail> { Err(Fail::new(libc::ENOTSUP, "cannot cancel")) },
+                    |mut state: Pin<&mut Rc<Vec<u8>>>, result: OverlappedResult| -> Result<Rc<Vec<u8>>, Fail> {
+                        match result.ok() {
+                            Ok(()) => {
+                                if result.bytes_transferred == 0 {
+                                    Err(Fail::new(libc::EINVAL, "not bytes received"))
+                                } else {
+                                    Rc::get_mut(state.as_mut().get_mut())
+                                        .unwrap()
+                                        .resize(result.bytes_transferred as usize, 0u8);
+                                    Ok(Rc::clone(Pin::get_mut(state)))
+                                }
+                            },
+
+                            Err(fail) => Err(fail),
+                        }
+                    },
+                )
+            }
+            .await?;
+
+            let message: &str = std::str::from_utf8(buffer.as_slice())
+                .map_err(|_| Fail::new(libc::EINVAL, "utf8 conversion failed"))?;
+            if message != MESSAGE {
+                let err_msg: String = format!("expected \"{}\", got \"{}\"", MESSAGE, message);
+                Err(Fail::new(libc::EINVAL, err_msg.as_str()))
+            } else {
+                Ok(())
+            }
+        });
+
+        let mut scheduler: Scheduler = Scheduler::default();
+        let server_handle: TaskHandle = scheduler
+            .insert(TaskWithResult::<Result<(), Fail>>::new("server".into(), server))
+            .unwrap();
+
+        let get_server_result = |scheduler: &mut Scheduler| {
+            TaskWithResult::<Result<(), Fail>>::from(scheduler.remove(&server_handle).unwrap().as_any())
+                .get_result()
+                .unwrap()
+        };
+
+        let mut wait_for_state = |scheduler: &mut Scheduler, state| -> Result<(), Fail> {
+            while server_state_view.load(Ordering::Relaxed) < state {
+                iocp.get_mut().process_events()?;
+                scheduler.poll();
+                if server_handle.has_completed() {
+                    return Err(get_server_result(scheduler).unwrap_err());
+                }
+            }
+            Ok(())
+        };
+
+        wait_for_state(&mut scheduler, 1)?;
+
+        let client_handle: SafeHandle = SafeHandle(unsafe {
+            CreateFileA(
+                PIPE_NAME,
+                GENERIC_WRITE.0,
+                FILE_SHARE_NONE,
+                None,
+                OPEN_EXISTING,
+                FILE_FLAGS_AND_ATTRIBUTES::default(),
+                HANDLE(0),
+            )
+        }?);
+
+        wait_for_state(&mut scheduler, 2)?;
+
+        let mut bytes_written: u32 = 0;
+        unsafe {
+            WriteFile(
+                client_handle.0,
+                Some(MESSAGE.as_bytes()),
+                Some(&mut bytes_written),
+                None,
+            )?;
+        }
+
+        std::mem::drop(client_handle);
+
+        while !server_handle.has_completed() {
+            iocp.get_mut().process_events()?;
+            scheduler.poll();
+        }
+
+        get_server_result(&mut scheduler)?;
+
+        Ok(())
+    }
+
+    /// Test I/O cancellation.
+    #[test]
+
+    fn test_cancel_io() -> Result<()> {
+        const PIPE_NAME: PCSTR = s!(r"\\.\pipe\demikernel-test-cancel-pipe");
+        const BUFFER_SIZE: u32 = 128;
+        const COMPLETION_KEY: usize = 0xFEEDF00D;
+        let server_pipe: SafeHandle = SafeHandle(unsafe {
+            CreateNamedPipeA(
+                PIPE_NAME,
+                PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE | FILE_FLAG_OVERLAPPED,
+                PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_REJECT_REMOTE_CLIENTS,
+                1,
+                BUFFER_SIZE,
+                BUFFER_SIZE,
+                0,
+                None,
+            )
+        }?);
+        let server_state: Rc<AtomicU32> = Rc::new(AtomicU32::new(0));
+        let server_state_view: Rc<AtomicU32> = server_state.clone();
+        let mut iocp: UnsafeCell<IoCompletionPort> = UnsafeCell::new(make_iocp().map_err(anyhow_fail)?);
+        iocp.get_mut().associate_handle(server_pipe.0, COMPLETION_KEY)?;
+        let iocp_ref: &mut IoCompletionPort = unsafe { &mut *iocp.get() };
+        let yielder: Yielder = Yielder::new();
+        let mut yielder_handle: YielderHandle = yielder.get_handle();
+
+        let server: Pin<Box<dyn Future<Output = Result<(), Fail>>>> = Box::pin(async move {
+            let result: Result<(), Fail> = unsafe {
+                iocp_ref.do_io(
+                    &yielder,
+                    |overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
+                        server_state.fetch_add(1, Ordering::Relaxed);
+                        is_overlapped_ok(ConnectNamedPipe(server_pipe.0, Some(overlapped)))
+                    },
+                    |overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
+                        CancelIoEx(server_pipe.0, Some(overlapped)).map_err(Fail::from)
+                    },
+                    |result: OverlappedResult| -> Result<(), Fail> { result.ok() },
+                )
+            }
+            .await;
+
+            result
+        });
+
+        let mut scheduler: Scheduler = Scheduler::default();
+        let server_handle: TaskHandle = scheduler
+            .insert(TaskWithResult::<Result<(), Fail>>::new("server".into(), server))
+            .unwrap();
+
+        let get_server_result = |scheduler: &mut Scheduler| {
+            TaskWithResult::<Result<(), Fail>>::from(scheduler.remove(&server_handle).unwrap().as_any())
+                .get_result()
+                .unwrap()
+        };
+
+        let mut wait_for_state = |scheduler: &mut Scheduler, state| -> Result<(), Fail> {
+            while server_state_view.load(Ordering::Relaxed) < state {
+                iocp.get_mut().process_events()?;
+                scheduler.poll();
+                if server_handle.has_completed() {
+                    return Err(get_server_result(scheduler).unwrap_err());
+                }
+            }
+            Ok(())
+        };
+
+        wait_for_state(&mut scheduler, 1)?;
+
+        yielder_handle.wake_with(Err(Fail::new(libc::ECANCELED, "I/O cancelled")));
+
+        while !server_handle.has_completed() {
+            iocp.get_mut().process_events()?;
+            scheduler.poll();
+        }
+
+        let result: Result<(), Fail> = get_server_result(&mut scheduler);
+        if let Err(err) = result {
+            if err.errno == libc::ECANCELED {
+                Ok(())
+            } else {
+                bail!("coroutine failed with unexpected code: {:?}", err)
+            }
+        } else {
+            bail!("expected coroutine to fail")
+        }
+    }
+}

--- a/src/rust/catnap/win/socket.rs
+++ b/src/rust/catnap/win/socket.rs
@@ -1,0 +1,578 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//==============================================================================
+// Imports
+//==============================================================================
+
+use std::{
+    fmt::Debug,
+    marker::PhantomPinned,
+    mem::MaybeUninit,
+    net::{
+        Ipv4Addr,
+        Ipv6Addr,
+        SocketAddr,
+        SocketAddrV4,
+        SocketAddrV6,
+    },
+    pin::Pin,
+    rc::Rc,
+    time::Duration,
+};
+
+use windows::{
+    core::PSTR,
+    Win32::{
+        Foundation::{
+            ERROR_NOT_FOUND,
+            HANDLE,
+        },
+        Networking::WinSock::{
+            bind,
+            closesocket,
+            listen,
+            shutdown,
+            tcp_keepalive,
+            WSAGetLastError,
+            WSARecvFrom,
+            WSASendTo,
+            FROM_PROTOCOL_INFO,
+            INVALID_SOCKET,
+            IPPROTO_TCP,
+            LINGER,
+            SD_BOTH,
+            SIO_KEEPALIVE_VALS,
+            SOCKADDR,
+            SOCKADDR_IN,
+            SOCKADDR_IN6,
+            SOCKADDR_INET,
+            SOCKADDR_STORAGE,
+            SOCKET,
+            SOCKET_ERROR,
+            SOL_SOCKET,
+            SO_KEEPALIVE,
+            SO_LINGER,
+            SO_PROTOCOL_INFOW,
+            SO_UPDATE_ACCEPT_CONTEXT,
+            SO_UPDATE_CONNECT_CONTEXT,
+            WSABUF,
+            WSAEINVAL,
+            WSAPROTOCOL_INFOW,
+            WSA_FLAG_OVERLAPPED,
+        },
+        System::IO::{
+            CancelIoEx,
+            OVERLAPPED,
+        },
+    },
+};
+
+use crate::{
+    catnap::transport::{
+        error::{
+            expect_last_wsa_error,
+            get_overlapped_api_result,
+        },
+        overlapped::{
+            IoCompletionPort,
+            OverlappedResult,
+        },
+        winsock::{
+            SocketExtensions,
+            WinsockRuntime,
+        },
+        WinConfig,
+    },
+    runtime::{
+        fail::Fail,
+        memory::DemiBuffer,
+    },
+};
+
+//======================================================================================================================
+// Constants
+//======================================================================================================================
+
+// Per AcceptEx documentation, the accept address storage buffer must be at least the size of the relevant socket
+// address type plus 16 bytes.
+const SOCKADDR_BUF_SIZE: usize = std::mem::size_of::<SOCKADDR_STORAGE>() + 16;
+
+// AcceptEx buffer returns two addresses.
+const ACCEPT_BUFFER_LEN: usize = (SOCKADDR_BUF_SIZE) * 2;
+
+//======================================================================================================================
+// Structures
+//======================================================================================================================
+
+pub struct Socket {
+    s: SOCKET,
+    extensions: Rc<SocketExtensions>,
+}
+
+/// State type used by `Socket::start_accept` and `Socket::finish_accept`.
+pub struct AcceptState {
+    new_socket: Option<Socket>,
+    buffer: [u8; ACCEPT_BUFFER_LEN],
+    _marker: PhantomPinned,
+}
+
+/// State type used by `Socket::start_pop` and `Socket::finish_pop`.
+pub struct PopState {
+    buffer: DemiBuffer,
+    address: MaybeUninit<SOCKADDR_STORAGE>,
+    addr_len: i32,
+    _marker: PhantomPinned,
+}
+
+//======================================================================================================================
+// Associated Functions
+//======================================================================================================================
+
+impl AcceptState {
+    /// Create a new, empty `AcceptState``.
+    pub fn new() -> Self {
+        Self {
+            new_socket: None,
+            buffer: [0u8; ACCEPT_BUFFER_LEN],
+            _marker: PhantomPinned,
+        }
+    }
+}
+
+impl PopState {
+    /// Create a new, empty `PopState` using the specified receive buffer.
+    pub fn new(buffer: DemiBuffer) -> PopState {
+        Self {
+            buffer,
+            address: MaybeUninit::zeroed(),
+            addr_len: 0,
+            _marker: PhantomPinned,
+        }
+    }
+}
+
+impl Socket {
+    /// Create a new socket, wrapping the underlying OS `SOCKET` handle.
+    pub(super) fn new(
+        s: SOCKET,
+        protocol: libc::c_int,
+        config: &WinConfig,
+        extensions: Rc<SocketExtensions>,
+        iocp: &IoCompletionPort,
+    ) -> Result<Socket, Fail> {
+        let s: Socket = Socket { s, extensions };
+        s.setup_socket(protocol, config)?;
+        iocp.associate_socket(s.s, 0)?;
+        Ok(s)
+    }
+
+    /// Translate a SocketAddr to SOCKADDR_INET and byte length.
+    fn translate_address(addr: SocketAddr) -> (SOCKADDR_INET, i32) {
+        match addr {
+            SocketAddr::V4(addr) => (addr.into(), std::mem::size_of::<SOCKADDR_IN>() as i32),
+            SocketAddr::V6(addr) => (addr.into(), std::mem::size_of::<SOCKADDR_IN6>() as i32),
+        }
+    }
+
+    /// Setup relevant socket options according to the configuration.
+    fn setup_socket(&self, protocol: libc::c_int, config: &WinConfig) -> Result<(), Fail> {
+        self.set_linger(config.linger_time)?;
+        if protocol == IPPROTO_TCP.0 {
+            self.set_tcp_keepalive(&config.keepalive_params)?;
+        }
+        Ok(())
+    }
+
+    /// Set linger socket options.
+    fn set_linger(&self, linger_time: Option<Duration>) -> Result<(), Fail> {
+        let l: LINGER = LINGER {
+            l_onoff: if linger_time.is_some() { 1 } else { 0 },
+            l_linger: linger_time.unwrap_or(Duration::ZERO).as_secs() as u16,
+        };
+
+        unsafe { WinsockRuntime::do_setsockopt(self.s, SOL_SOCKET, SO_LINGER, Some(&l)) }?;
+        Ok(())
+    }
+
+    /// Set TCP keepalive socket options.
+    fn set_tcp_keepalive(&self, keepalive_params: &tcp_keepalive) -> Result<(), Fail> {
+        unsafe { WinsockRuntime::do_setsockopt(self.s, SOL_SOCKET, SO_KEEPALIVE, Some(&keepalive_params.onoff)) }?;
+
+        if keepalive_params.onoff != 0 {
+            // Safety: SIO_KEEPALIVE_VALS uses tcp_keepalive structure as ABI.
+            unsafe {
+                WinsockRuntime::do_ioctl::<tcp_keepalive, ()>(self.s, SIO_KEEPALIVE_VALS, Some(&keepalive_params), None)
+            }?;
+        }
+
+        Ok(())
+    }
+
+    /// Make a new socket like some template socket.
+    pub fn new_like(template: &Socket) -> Result<Socket, Fail> {
+        // Safety: SO_PROTOCOL_INFOW fills out a WSAPROTOCOL_INFOW structure.
+        let protocol: WSAPROTOCOL_INFOW =
+            unsafe { WinsockRuntime::do_getsockopt(template.s, SOL_SOCKET, SO_PROTOCOL_INFOW) }?;
+
+        let extensions: Rc<SocketExtensions> = template.extensions.clone();
+
+        // Safety: SOCKET handle is transferred to a Socket instance, which will safely close the handle on drop.
+        let s: SOCKET = unsafe {
+            WinsockRuntime::raw_socket(
+                FROM_PROTOCOL_INFO,
+                FROM_PROTOCOL_INFO,
+                FROM_PROTOCOL_INFO,
+                Some(&protocol),
+                WSA_FLAG_OVERLAPPED,
+            )
+        }?;
+
+        Ok(Socket { s, extensions })
+    }
+
+    /// Begin disconnecting a connection-oriented socket. If called on a non-stream-based socket or an unconnected
+    /// stream-based socket, this method will return an `ENOTCONN` failure.
+    pub fn start_disconnect(&self, overlapped: *mut OVERLAPPED) -> Result<(), Fail> {
+        let result: bool = unsafe { self.extensions.disconnectex.unwrap()(self.s, overlapped, 0, 0).as_bool() };
+
+        get_overlapped_api_result(result)
+    }
+
+    /// Call once the overlapped operation started by `start_disconnect` has completed to finish disconnecting and
+    /// shutdown the socket.
+    pub fn finish_disconnect(&self, result: OverlappedResult) -> Result<(), Fail> {
+        self.shutdown().and(result.ok())
+    }
+
+    /// Shutdown communication on the socket. For better asynchronous behavior on connection-oriented sockets,
+    /// `start_disconnect` will start an asynchronous disconnect operation. If the socket is not disconnected prior to
+    /// this call, this call may block for socket teardown, depending on the linger settings.
+    pub fn shutdown(&self) -> Result<(), Fail> {
+        if unsafe { shutdown(self.s, SD_BOTH) } == 0 {
+            Ok(())
+        } else {
+            Err(expect_last_wsa_error().into())
+        }
+    }
+
+    /// Call `bind` winsock API on self.
+    pub fn bind(&self, local: SocketAddr) -> Result<(), Fail> {
+        let sockaddr: socket2::SockAddr = local.into();
+        let result: i32 = unsafe { bind(self.s, sockaddr.as_ptr().cast(), sockaddr.len()) };
+
+        if result == 0 {
+            Ok(())
+        } else {
+            Err(expect_last_wsa_error().into())
+        }
+    }
+
+    /// Call `listen` winsock API on self.
+    pub fn listen(&self, backlog: usize) -> Result<(), Fail> {
+        let backlog: i32 = i32::try_from(backlog).unwrap_or(i32::MAX);
+        if unsafe { listen(self.s, backlog) } == 0 {
+            Ok(())
+        } else {
+            Err(expect_last_wsa_error().into())
+        }
+    }
+
+    /// Cancel an overlapped I/O operation. If the operation completed prior to the cancellation attempt, or if the
+    /// OVERLAPPED structure is not associated with a known operation, this method will fail with EINPROGRESS. If the
+    /// method succeeds, the OVERLAPPED will never be dequed from the completion port associated with the operation.
+    /// Other failures indicate that the operation might still complete.
+    pub fn cancel_io(&self, overlapped: *mut OVERLAPPED) -> Result<(), Fail> {
+        unsafe { CancelIoEx(HANDLE(self.s.0 as isize), Some(overlapped)) }.map_err(|win_err| {
+            if win_err.code() == ERROR_NOT_FOUND.into() {
+                Fail::new(libc::EINPROGRESS, "cannot cancel this operation")
+            } else {
+                win_err.into()
+            }
+        })
+    }
+
+    /// Start an overlapped accept operation; this must be called from inside IoCompletionPort::do_io/do_socket_io.
+    /// Once the operation completes, the AcceptState can be given to `finish_accept` to finish the operation.
+    pub fn start_accept(
+        &self,
+        mut accept_result: Pin<&mut AcceptState>,
+        overlapped: *mut OVERLAPPED,
+    ) -> Result<(), Fail> {
+        let new_socket: Socket = Socket::new_like(self)?;
+
+        // Safety: getting the buffer pointer does not violate pinning invariants.
+        let buf_ptr: *mut u8 = unsafe { accept_result.as_mut().get_unchecked_mut() }
+            .buffer
+            .as_mut_ptr();
+        let mut bytes_out: u32 = 0;
+
+        // Safety: buffer pointers refer to valid, live locations for the duration of the call iff accept_result stays
+        // alive until the completion.
+        let success: bool = unsafe {
+            self.extensions.acceptex.unwrap()(
+                self.s,
+                new_socket.s,
+                buf_ptr.cast(),
+                0,
+                SOCKADDR_BUF_SIZE as u32,
+                SOCKADDR_BUF_SIZE as u32,
+                &mut bytes_out,
+                overlapped,
+            )
+        }
+        .as_bool();
+
+        get_overlapped_api_result(success).and_then(|_| {
+            // Safety: the socket does not require structural pinning.
+            unsafe { accept_result.as_mut().get_unchecked_mut() }.new_socket = Some(new_socket);
+            Ok(())
+        })
+    }
+
+    /// Finish an accept operation, once the overlapped accept call has completed. Calling this method before the I/O
+    /// operation is complete is unsound and may result in undefined behavior. The method returns the new socket along
+    /// with the (local, remote) address pair.
+    pub fn finish_accept(
+        &self,
+        mut accept_result: Pin<&mut AcceptState>,
+        iocp: &IoCompletionPort,
+        result: OverlappedResult,
+    ) -> Result<(Socket, SocketAddr, SocketAddr), Fail> {
+        if let Err(err) = result.ok() {
+            return Err(err);
+        }
+
+        // NB Windows docs are unclear whether the "bytes transferred" overlapped result should be 0 for AcceptEx with
+        // no receive, or whether it is equal to the local+remote address buffer length. It is safe to assume addresses
+        // were provisioned correctly by the API.
+        // Safety: the socket does not require structural pinning.
+        let new_socket = unsafe { accept_result.as_mut().get_unchecked_mut() }
+            .new_socket
+            .take()
+            .ok_or_else(|| Fail::new(libc::EINVAL, "invalid state"))?;
+
+        // Required to update user mode attributes of the socket after AcceptEx completes. This will propagate socket
+        // options from listening socket to accepted socket, as if accept(...) was called.
+        // Safety: FFI call to Windows API; no specific considerations.
+        unsafe { WinsockRuntime::do_setsockopt(new_socket.s, SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT, Some(&self.s)) }?;
+
+        iocp.associate_socket(new_socket.s, 0)?;
+
+        let (local_addr, remote_addr) = unsafe {
+            // NB socket2 uses the windows-sys crate, so type names are qualified here to prevent confusion with Windows
+            // crate.
+            let mut localsockaddr: MaybeUninit<*mut windows_sys::Win32::Networking::WinSock::SOCKADDR_STORAGE> =
+                MaybeUninit::zeroed();
+            let mut localsockaddrlength: i32 = 0;
+            let mut remotesockaddr: MaybeUninit<*mut windows_sys::Win32::Networking::WinSock::SOCKADDR_STORAGE> =
+                MaybeUninit::zeroed();
+            let mut remotesockaddrlength: i32 = 0;
+
+            self.extensions.get_acceptex_sockaddrs.unwrap()(
+                accept_result.buffer.as_ptr().cast(),
+                0,
+                SOCKADDR_BUF_SIZE as u32,
+                SOCKADDR_BUF_SIZE as u32,
+                localsockaddr.as_mut_ptr().cast(),
+                &mut localsockaddrlength,
+                remotesockaddr.as_mut_ptr().cast(),
+                &mut remotesockaddrlength,
+            );
+
+            // Postcondition: if a buffer of valid size is passed to GetAcceptExSockaddrs, the returned pointers will
+            // be non-null.
+            assert!(!localsockaddr.assume_init_ref().is_null() && !remotesockaddr.assume_init_ref().is_null());
+
+            (
+                socket2::SockAddr::new(*localsockaddr.assume_init(), localsockaddrlength),
+                socket2::SockAddr::new(*remotesockaddr.assume_init(), remotesockaddrlength),
+            )
+        };
+
+        let local_addr: SocketAddr = local_addr
+            .as_socket()
+            .ok_or_else(|| Fail::new(libc::EAFNOSUPPORT, "bad local socket address from accept"))?;
+
+        let remote_addr: SocketAddr = remote_addr
+            .as_socket()
+            .ok_or_else(|| Fail::new(libc::EAFNOSUPPORT, "bad remote socket address from accept"))?;
+
+        Ok((new_socket, local_addr, remote_addr))
+    }
+
+    /// Start an overlapped connect operation.
+    pub fn start_connect(&self, remote: SocketAddr, overlapped: *mut OVERLAPPED) -> Result<(), Fail> {
+        // Constants missing from windows crate.
+        const IN6ADDR_ANY: SocketAddrV6 = SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0);
+        const INADDR_ANY: SocketAddrV4 = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
+
+        let (remote_addr, remote_len): (SOCKADDR_INET, i32) = Self::translate_address(remote);
+        let success: bool = unsafe {
+            // NB ConnectEx requires the socket to be explicitly bound.
+            let (localaddr, locallen): (SOCKADDR_INET, i32) = match remote {
+                SocketAddr::V4(_) => Self::translate_address(INADDR_ANY.into()),
+                SocketAddr::V6(_) => Self::translate_address(IN6ADDR_ANY.into()),
+            };
+            if bind(self.s, (&localaddr as *const SOCKADDR_INET).cast(), locallen) != 0 {
+                // WSAEINVAL indicates the socket is already bound. Try to connect.
+                if WSAGetLastError() != WSAEINVAL {
+                    return Err(expect_last_wsa_error());
+                }
+            }
+
+            self.extensions.connectex.unwrap()(
+                self.s,
+                (&remote_addr as *const SOCKADDR_INET).cast(),
+                remote_len,
+                std::ptr::null(),     // No send data
+                0,                    // Ignored
+                std::ptr::null_mut(), // Ignored
+                overlapped,
+            )
+            .as_bool()
+        };
+
+        get_overlapped_api_result(success)
+    }
+
+    /// Finish a connect operation started by start_connect.
+    pub fn finish_connect(&self, result: OverlappedResult) -> Result<(), Fail> {
+        if let Err(err) = result.ok() {
+            return Err(err);
+        }
+
+        // Required to update user mode attributes of the socket after ConnectEx completes.
+        unsafe { WinsockRuntime::do_setsockopt::<()>(self.s, SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT, None) }
+    }
+
+    /// Start a pop operation, as intended for use with `IoCompletionPort::do_io_with`. The operation may complete
+    /// immediately, in which case an overlapped completion is not scheduled. To indicate this case, this method will
+    /// return EAGAIN and update `buffer` according to the number of bytes received.
+    pub fn start_pop(&self, mut pop_state: Pin<&mut PopState>, overlapped: *mut OVERLAPPED) -> Result<(), Fail> {
+        let mut bytes_transferred: u32 = 0;
+        let mut flags: u32 = 0;
+        let success: bool = unsafe {
+            let wsa_buffer: WSABUF = WSABUF {
+                len: pop_state.buffer.len() as u32,
+                // Safety: loading the buffer pointer won't violate pinning invariants.
+                buf: PSTR::from_raw(pop_state.as_mut().get_unchecked_mut().buffer.as_mut_ptr()),
+            };
+
+            // NB winsock service providers are required to capture the entire WSABUF array inline with the call, so
+            // wsa_buffer and the derivative slice can safely drop after the call.
+            let result: i32 = WSARecvFrom(
+                self.s,
+                std::slice::from_ref(&wsa_buffer),
+                Some(&mut bytes_transferred),
+                &mut flags,
+                Some(pop_state.as_mut().get_unchecked_mut().address.as_mut_ptr() as *mut SOCKADDR),
+                Some(&mut pop_state.as_mut().get_unchecked_mut().addr_len),
+                Some(overlapped),
+                None,
+            );
+
+            result != SOCKET_ERROR
+        };
+
+        get_overlapped_api_result(success)
+    }
+
+    /// Finish an overlapped pop operation started with start_pop.
+    pub fn finish_pop(
+        &self,
+        mut pop_state: Pin<&mut PopState>,
+        result: OverlappedResult,
+    ) -> Result<(usize, Option<SocketAddr>), Fail> {
+        // Note: the `flags` output of WSARecvFrom is not immediately avialable as written. These can be rehydrated by
+        // calling WSAGetOverlappedResult on the OVERLAPPED; however, the overlapped is not immediately available. The
+        // flags seem (determined experimentally) to be derived from the NTSTATUS of the resulting overlapped. The
+        // WSA/GetOverlappedResult API should be avoided, as it seems to incur some synchronization overhead which is
+        // not useful for this implementation.
+        if let Err(err) = result.ok() {
+            return Err(err);
+        }
+
+        let addr: Option<SocketAddr> = if pop_state.addr_len > 0 {
+            // Safety: since we are done with the overlapped API, pinning is no longer required for pop_state. The
+            // returned address and addr_len values come from the OS, so they will be valid to pass to socket2.
+            unsafe {
+                socket2::SockAddr::new(
+                    std::mem::transmute(std::mem::take(
+                        pop_state.as_mut().get_unchecked_mut().address.assume_init_mut(),
+                    )),
+                    pop_state.addr_len,
+                )
+            }
+            .as_socket()
+        } else {
+            None
+        };
+
+        Ok((result.bytes_transferred as usize, addr))
+    }
+
+    /// Start a push operation, as intended for use with `IoCompletionPort::do_io_with`.
+    pub fn start_push(
+        &self,
+        buffer: Pin<&mut DemiBuffer>,
+        addr: Option<SocketAddr>,
+        overlapped: *mut OVERLAPPED,
+    ) -> Result<(), Fail> {
+        let mut bytes_transferred: u32 = 0;
+        let success: bool = unsafe {
+            let wsa_buffer: WSABUF = WSABUF {
+                len: buffer.len() as u32,
+                // Safety: loading the buffer pointer won't violate pinning invariants.
+                buf: PSTR::from_raw(buffer.get_unchecked_mut().as_mut_ptr()),
+            };
+
+            let addr: Option<socket2::SockAddr> = addr.map(socket2::SockAddr::from);
+
+            // NB winsock service providers are required to capture the entire WSABUF array inline with the call, so
+            // wsa_buffer and the derivative slice can safely drop after the call.
+            // Per Windows documentation, WSASendTo ignores the destination address for connection oriented sockets and
+            // functions equivalently to WSASend.
+            let result: i32 = WSASendTo(
+                self.s,
+                std::slice::from_ref(&wsa_buffer),
+                Some(&mut bytes_transferred),
+                0,
+                addr.as_ref()
+                    .map(|addr: &socket2::SockAddr| -> *const SOCKADDR { addr.as_ptr().cast() }),
+                addr.as_ref()
+                    .map(|addr: &socket2::SockAddr| -> i32 { addr.len() })
+                    .unwrap_or(0),
+                Some(overlapped),
+                None,
+            );
+
+            result != SOCKET_ERROR
+        };
+
+        get_overlapped_api_result(success)
+    }
+
+    /// Finish a push operation started with start_push.
+    pub fn finish_push(&self, _buffer: Pin<&mut DemiBuffer>, result: OverlappedResult) -> Result<usize, Fail> {
+        result.ok().and(Ok(result.bytes_transferred as usize))
+    }
+}
+
+//======================================================================================================================
+// Traits
+//======================================================================================================================
+
+impl Drop for Socket {
+    /// Close socket handle.
+    fn drop(&mut self) {
+        unsafe { closesocket(self.s) };
+        self.s = INVALID_SOCKET;
+    }
+}
+
+impl Debug for Socket {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Socket").field("s", &self.s).finish()
+    }
+}

--- a/src/rust/catnap/win/transport.rs
+++ b/src/rust/catnap/win/transport.rs
@@ -1,103 +1,311 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+mod config;
+mod error;
+mod overlapped;
+mod socket;
+mod winsock;
+
+//==============================================================================
+// Imports
+//==============================================================================
+
+use std::{
+    net::SocketAddr,
+    pin::Pin,
+    time::Duration,
+};
+
+use libc::ENOTSUP;
+use windows::Win32::{
+    Networking::WinSock::{
+        tcp_keepalive,
+        IPPROTO,
+        IPPROTO_TCP,
+        IPPROTO_UDP,
+    },
+    System::IO::OVERLAPPED,
+};
+
 use crate::{
+    catnap::transport::{
+        overlapped::{
+            IoCompletionPort,
+            OverlappedResult,
+        },
+        socket::{
+            AcceptState,
+            PopState,
+            Socket,
+        },
+        winsock::WinsockRuntime,
+    },
     demikernel::config::Config,
     runtime::{
         fail::Fail,
         memory::DemiBuffer,
-        scheduler::{
-            Yielder,
-            YielderHandle,
-        },
+        scheduler::Yielder,
+        DemiRuntime,
         SharedDemiRuntime,
         SharedObject,
     },
 };
-use ::socket2::{
-    Domain,
-    Type,
-};
-use ::std::{
-    collections::HashMap,
-    net::SocketAddr,
-};
 
-pub type SocketDescriptor = usize;
+//======================================================================================================================
+// Types
+//======================================================================================================================
+
+pub type SocketDescriptor = Socket;
 
 //======================================================================================================================
 // Structures
 //======================================================================================================================
 
-/// Underlying network transport.
-pub struct CatnapTransport {
-    _handles: HashMap<usize, YielderHandle>,
+/// Structured configuration values loaded from `Config`.
+pub(super) struct WinConfig {
+    /// TCP keepalive parameters.
+    keepalive_params: tcp_keepalive,
+
+    /// Linger socket options.
+    linger_time: Option<Duration>,
 }
 
+/// Underlying network transport.
+pub struct CatnapTransport {
+    /// Winsock runtime instance.
+    winsock: WinsockRuntime,
+
+    /// I/O completion port for overlapped I/O.
+    iocp: IoCompletionPort,
+
+    /// Configuration values.
+    config: WinConfig,
+}
+
+/// A network transport built on top of Windows overlapped I/O.
 #[derive(Clone)]
 pub struct SharedCatnapTransport(SharedObject<CatnapTransport>);
 
+//======================================================================================================================
+// Associated Functions
+//======================================================================================================================
+
 impl SharedCatnapTransport {
-    pub fn new(_config: &Config, mut _runtime: SharedDemiRuntime) -> Self {
-        unimplemented!("this function is missing")
+    /// Create a new transport instance.
+    pub fn new(config: &Config, mut runtime: SharedDemiRuntime) -> Self {
+        let config: WinConfig = WinConfig {
+            keepalive_params: config.tcp_keepalive().expect("failed to load TCP settings"),
+            linger_time: config.linger_time().expect("failed to load linger settings"),
+        };
+
+        let me: Self = Self(SharedObject::new(CatnapTransport {
+            winsock: WinsockRuntime::new().expect("failed to initialize WinSock"),
+            iocp: IoCompletionPort::new().expect("failed to setup I/O completion port"),
+            config,
+        }));
+
+        runtime
+            .insert_background_coroutine(
+                "catnap::transport::epoll",
+                Box::pin({
+                    let mut me: Self = me.clone();
+                    async move { me.run_event_processor().await }
+                }),
+            )
+            .expect("should be able to insert background coroutine");
+
+        me
     }
 
-    pub fn socket(&mut self, _domain: Domain, _typ: Type) -> Result<SocketDescriptor, Fail> {
-        unimplemented!("this function is missing")
+    /// Run a coroutine which pulls the I/O completion port for events.
+    async fn run_event_processor(&mut self) {
+        let yielder: Yielder = Yielder::new();
+        loop {
+            if let Err(err) = self.0.iocp.process_events() {
+                error!("Completion port error: {}", err);
+            }
+
+            match yielder.yield_once().await {
+                Ok(()) => continue,
+                Err(_) => break,
+            }
+        }
     }
 
-    pub fn bind(&mut self, _sd: &mut SocketDescriptor, _local: SocketAddr) -> Result<(), Fail> {
-        unimplemented!("this function is missing")
+    /// Create a new socket for the specified domain and type.
+    pub fn socket(&mut self, domain: socket2::Domain, typ: socket2::Type) -> Result<Socket, Fail> {
+        // Select protocol.
+        let protocol: IPPROTO = match typ {
+            socket2::Type::STREAM => IPPROTO_TCP,
+            socket2::Type::DGRAM => IPPROTO_UDP,
+            _ => {
+                let cause: String = format!("socket type not supported: {}", libc::c_int::from(typ));
+                error!("transport::socket(): {}", &cause);
+                return Err(Fail::new(ENOTSUP, &cause));
+            },
+        };
+
+        let me: &mut CatnapTransport = &mut self.0;
+
+        // Create socket.
+        let s: Socket = me
+            .winsock
+            .socket(domain.into(), typ.into(), protocol.0, &me.config, &me.iocp)?;
+        Ok(s)
     }
 
-    pub fn listen(&mut self, _sd: &mut SocketDescriptor, _backlog: usize) -> Result<(), Fail> {
-        unimplemented!("this function is missing")
+    /// Synchronously shut down the specified socket.
+    pub fn close(&mut self, socket: &Socket) -> Result<(), Fail> {
+        socket.shutdown()
     }
 
-    pub async fn accept(
-        &mut self,
-        _sd: &mut SocketDescriptor,
-        _yielder: Yielder,
-    ) -> Result<(SocketDescriptor, SocketAddr), Fail> {
-        unimplemented!("this function is missing")
+    /// Asynchronously disconnect and shut down a socket.
+    pub async fn async_close(&mut self, socket: &Socket, yielder: Yielder) -> Result<(), Fail> {
+        match unsafe {
+            self.0.iocp.do_io(
+                &yielder,
+                |overlapped: *mut OVERLAPPED| socket.start_disconnect(overlapped),
+                |_| Err(Fail::new(libc::EFAULT, "cannot cancel a disconnect")),
+                |result: OverlappedResult| socket.finish_disconnect(result),
+            )
+        }
+        .await
+        {
+            Err(err) if err.errno == libc::ENOTCONN => socket.shutdown(),
+            r => r,
+        }
     }
 
-    pub async fn connect(
-        &mut self,
-        _sd: &mut SocketDescriptor,
-        _remote: SocketAddr,
-        _yielder: Yielder,
-    ) -> Result<(), Fail> {
-        unimplemented!("this function is missing")
+    /// Bind a socket to a local address.
+    pub fn bind(&self, socket: &Socket, local: SocketAddr) -> Result<(), Fail> {
+        trace!("Bind to {:?}", local);
+        socket.bind(local)
     }
 
-    pub async fn push(
-        &mut self,
-        _sd: &mut SocketDescriptor,
-        _buf: &mut DemiBuffer,
-        _addr: Option<SocketAddr>,
-        _yielder: Yielder,
-    ) -> Result<(), Fail> {
-        unimplemented!("this function is missing")
+    /// Listen on the specified socket.
+    pub fn listen(&mut self, socket: &mut Socket, backlog: usize) -> Result<(), Fail> {
+        socket.listen(backlog)
     }
 
+    /// Accept a connection on the specified socket. The coroutine will not finish until a connection is successfully
+    /// accepted or `yielder` is cancelled.
+    pub async fn accept(&mut self, socket: &Socket, yielder: Yielder) -> Result<(Socket, SocketAddr), Fail> {
+        let start = |accept_result: Pin<&mut AcceptState>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
+            socket.start_accept(accept_result, overlapped)
+        };
+        let cancel = |_: Pin<&mut AcceptState>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
+            socket.cancel_io(overlapped)
+        };
+        let me_finish: Self = self.clone();
+        let finish = |accept_result: Pin<&mut AcceptState>,
+                      result: OverlappedResult|
+         -> Result<(Socket, SocketAddr, SocketAddr), Fail> {
+            socket.finish_accept(accept_result, &me_finish.0.iocp, result)
+        };
+
+        let (socket, _local_addr, remote_addr) = unsafe {
+            self.0
+                .iocp
+                .do_io_with(AcceptState::new(), &yielder, start, cancel, finish)
+        }
+        .await?;
+
+        Ok((socket, remote_addr))
+    }
+
+    /// Connect a socket to a remote address.
+    pub async fn connect(&mut self, socket: &Socket, remote: SocketAddr, yielder: Yielder) -> Result<(), Fail> {
+        unsafe {
+            self.0.iocp.do_io(
+                &yielder,
+                |overlapped: *mut OVERLAPPED| -> Result<(), Fail> { socket.start_connect(remote, overlapped) },
+                |overlapped: *mut OVERLAPPED| -> Result<(), Fail> { socket.cancel_io(overlapped) },
+                |result: OverlappedResult| -> Result<(), Fail> { socket.finish_connect(result) },
+            )
+        }
+        .await
+    }
+
+    /// Pop data from the socket into `buf`. This method will return the remote address iff the socket is not connected.
     pub async fn pop(
         &mut self,
-        _sd: &mut SocketDescriptor,
-        _buf: &mut DemiBuffer,
-        _size: usize,
-        _yielder: Yielder,
+        socket: &Socket,
+        buf: &mut DemiBuffer,
+        size: usize,
+        yielder: Yielder,
     ) -> Result<Option<SocketAddr>, Fail> {
-        unimplemented!("this function is missing")
+        unsafe {
+            self.0.iocp.do_io_with(
+                PopState::new(buf.clone()),
+                &yielder,
+                |pop_state: Pin<&mut PopState>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
+                    socket.start_pop(pop_state, overlapped)
+                },
+                |_pop_state: Pin<&mut PopState>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
+                    socket.cancel_io(overlapped)
+                },
+                |pop_state: Pin<&mut PopState>,
+                 result: OverlappedResult|
+                 -> Result<(usize, Option<SocketAddr>), Fail> { socket.finish_pop(pop_state, result) },
+            )
+        }
+        .await
+        .and_then(|(nbytes, sockaddr)| {
+            buf.trim(buf.len() - nbytes)?;
+            if nbytes > 0 {
+                trace!("data received ({:?}/{:?} bytes)", nbytes, size);
+            } else {
+                trace!("not data received");
+            }
+            Ok(sockaddr)
+        })
     }
 
-    pub fn close(&mut self, _sd: &mut SocketDescriptor) -> Result<(), Fail> {
-        unimplemented!("this function is missing")
-    }
+    /// Push `buf` to the remote endpoint. `addr` is used iff the socket is not connection-oriented. For message-
+    /// oriented sockets which were previously `connect`ed, `addr` overrides the previously specified remote address.
+    /// For connection-oriented sockets, `addr` is ignored.
+    pub async fn push(
+        &mut self,
+        socket: &Socket,
+        buf: &mut DemiBuffer,
+        addr: Option<SocketAddr>,
+        yielder: Yielder,
+    ) -> Result<(), Fail> {
+        loop {
+            let result: Result<usize, Fail> = unsafe {
+                self.0.iocp.do_io_with(
+                    buf.clone(),
+                    &yielder,
+                    |buffer: Pin<&mut DemiBuffer>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
+                        socket.start_push(buffer, addr, overlapped)
+                    },
+                    |_buffer: Pin<&mut DemiBuffer>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
+                        socket.cancel_io(overlapped)
+                    },
+                    |buffer: Pin<&mut DemiBuffer>, result: OverlappedResult| -> Result<usize, Fail> {
+                        socket.finish_push(buffer, result)
+                    },
+                )
+            }
+            .await;
 
-    pub async fn async_close(&mut self, _sd: &mut SocketDescriptor, _yielder: Yielder) -> Result<(), Fail> {
-        unimplemented!("this function is missing")
-    }
+            match result {
+                Ok(nbytes) => {
+                    trace!("data pushed ({:?}/{:?} bytes)", nbytes, buf.len());
+                    buf.adjust(nbytes)?;
+                    if buf.is_empty() {
+                        return Ok(());
+                    }
+                },
 
-    #[allow(dead_code)]
-    pub async fn poll(&mut self) {
-        unimplemented!("this function is missing")
+                Err(fail) => {
+                    if !DemiRuntime::should_retry(fail.errno) {
+                        let message: String = format!("push failed: {}", fail.cause);
+                        return Err(Fail::new(fail.errno, message.as_str()));
+                    }
+                },
+            }
+        }
     }
 }

--- a/src/rust/catnap/win/winsock.rs
+++ b/src/rust/catnap/win/winsock.rs
@@ -1,0 +1,357 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//==============================================================================
+// Imports
+//==============================================================================
+
+use std::{
+    collections::HashMap,
+    mem::MaybeUninit,
+    rc::{
+        Rc,
+        Weak,
+    },
+};
+
+use crate::{
+    catnap::transport::{
+        error::expect_last_wsa_error,
+        overlapped::IoCompletionPort,
+        socket::Socket,
+        WinConfig,
+    },
+    runtime::fail::Fail,
+};
+use windows::{
+    core::{
+        GUID,
+        PSTR,
+    },
+    Win32::Networking::WinSock::{
+        closesocket,
+        getsockopt,
+        setsockopt,
+        WSACleanup,
+        WSAIoctl,
+        WSASocketW,
+        WSAStartup,
+        INVALID_SOCKET,
+        LPFN_ACCEPTEX,
+        LPFN_CONNECTEX,
+        LPFN_DISCONNECTEX,
+        LPFN_GETACCEPTEXSOCKADDRS,
+        RIO_EXTENSION_FUNCTION_TABLE,
+        SIO_GET_EXTENSION_FUNCTION_POINTER,
+        SIO_GET_MULTIPLE_EXTENSION_FUNCTION_POINTER,
+        SOCKET,
+        SOL_SOCKET,
+        SO_PROTOCOL_INFOW,
+        WSADATA,
+        WSAID_ACCEPTEX,
+        WSAID_CONNECTEX,
+        WSAID_DISCONNECTEX,
+        WSAID_GETACCEPTEXSOCKADDRS,
+        WSAPROTOCOL_INFOW,
+        WSA_FLAG_OVERLAPPED,
+    },
+};
+
+//======================================================================================================================
+// Constants
+//======================================================================================================================
+
+// TODO: update to use value from windows crate once exposed.
+const WSAID_MULTIPLE_RIO: ::windows::core::GUID =
+    ::windows::core::GUID::from_u128(0x8509e081_96dd_4005_b165_9e2ee8c79e3f);
+
+//======================================================================================================================
+// Structures
+//======================================================================================================================
+
+/// This structure stores Winsock extension functions.
+#[derive(Default, Clone, Copy)]
+pub(super) struct SocketExtensions {
+    /// AcceptEx function pointer.
+    pub acceptex: LPFN_ACCEPTEX,
+
+    /// GetAcceptExSockaddrs function pointer.
+    pub get_acceptex_sockaddrs: LPFN_GETACCEPTEXSOCKADDRS,
+
+    /// ConnectEx function pointer.
+    pub connectex: LPFN_CONNECTEX,
+
+    /// DisconnectEx function pointer.
+    pub disconnectex: LPFN_DISCONNECTEX,
+
+    /// Registered I/O function table.
+    // Note: RIO extensions are preserved for future use.
+    #[allow(unused)]
+    pub rio_fns: RIO_EXTENSION_FUNCTION_TABLE,
+}
+
+/// This structure manages the state of the Winsock runtime. Winsock state is managed internally by the Winsock runtime.
+/// While this struct holds limited Winsock runtime data, a valid instance of this struct predicates initialization of
+/// the Winsock runtime.
+pub struct WinsockRuntime {
+    /// A map of `SocketExtensions` keyed by Winsock provider GUID. Providers will be shared by multiple sockets;
+    /// generally we expect a socket with the same creation parameters to be served by the same provider, although this
+    /// is not required. System configuration changes can trigger new providers for new sockets.
+    extensions_by_provider: HashMap<GUID, Weak<SocketExtensions>>,
+}
+
+//======================================================================================================================
+// Associated Functions
+//======================================================================================================================
+
+impl SocketExtensions {
+    /// Create an instance of SocketExtensions, with all extensions resolved for the socket provider.
+    pub fn new(s: SOCKET) -> Result<Rc<SocketExtensions>, Fail> {
+        Ok(Rc::new(SocketExtensions {
+            acceptex: Self::lookup_single_fn(s, &WSAID_ACCEPTEX)?,
+            get_acceptex_sockaddrs: Self::lookup_single_fn(s, &WSAID_GETACCEPTEXSOCKADDRS)?,
+            connectex: Self::lookup_single_fn(s, &WSAID_CONNECTEX)?,
+            disconnectex: Self::lookup_single_fn(s, &WSAID_DISCONNECTEX)?,
+            rio_fns: Self::resolve_rio_fn_table(s)?,
+        }))
+    }
+
+    /// Resolve the RIO function table, which uses a different I/O control code than individual functions.
+    fn resolve_rio_fn_table(s: SOCKET) -> Result<RIO_EXTENSION_FUNCTION_TABLE, Fail> {
+        let mut result: RIO_EXTENSION_FUNCTION_TABLE = RIO_EXTENSION_FUNCTION_TABLE::default();
+        result.cbSize = std::mem::size_of::<RIO_EXTENSION_FUNCTION_TABLE>() as u32;
+
+        // Safety: SIO_GET_MULTIPLE_EXTENSION_FUNCTION_POINTER expects input of type GUID and output of type
+        // RIO_EXTENSION_FUNCTION_TABLE.
+        unsafe {
+            WinsockRuntime::do_ioctl(
+                s,
+                SIO_GET_MULTIPLE_EXTENSION_FUNCTION_POINTER,
+                Some(&WSAID_MULTIPLE_RIO),
+                Some(&mut result),
+            )
+        }?;
+
+        if result.cbSize != std::mem::size_of::<RIO_EXTENSION_FUNCTION_TABLE>() as u32 {
+            Err(Fail::new(
+                libc::EFAULT,
+                "Winsock did not return enough data for RIO_EXTENSION_FUNCTION_TABLE",
+            ))
+        } else {
+            Ok(result)
+        }
+    }
+
+    /// Lookup a single function pointer using SIO_GET_EXTENSION_FUNCTION_POINTER ioctl. To be sound, T must be a `fn`
+    /// type.
+    fn lookup_single_fn<T>(s: SOCKET, guid: &GUID) -> Result<Option<T>, Fail> {
+        let mut fn_ptr: Option<T> = None;
+
+        // Safety: SIO_GET_EXTENSION_FUNCTION_POINTER expects type GUID for input. Option<fn()> is compatible with C
+        // output type for this ioctl.
+        unsafe {
+            WinsockRuntime::do_ioctl(s, SIO_GET_EXTENSION_FUNCTION_POINTER, Some(guid), Some(&mut fn_ptr)).map_err(
+                |err| {
+                    let msg: String = format!("{} for function lookup {:?}", err.cause, guid);
+                    Fail::new(err.errno, msg.as_str())
+                },
+            )?;
+        }
+
+        if fn_ptr.is_some() {
+            Ok(fn_ptr)
+        } else {
+            Err(Fail::new(libc::ENOTSUP, "Winsock extension not supported"))
+        }
+    }
+}
+
+impl WinsockRuntime {
+    /// Start up the Winsock runtime, creating a new instance of WinsockRuntime. While it is not functionally useful,
+    /// it is valid to instantiate multiple instances of this struct.
+    pub fn new() -> Result<Self, Fail> {
+        let mut data: WSADATA = WSADATA::default();
+        if unsafe { WSAStartup(0x202u16, &mut data as *mut WSADATA) } != 0 {
+            return Err(expect_last_wsa_error());
+        }
+
+        Ok(WinsockRuntime {
+            extensions_by_provider: HashMap::new(),
+        })
+    }
+
+    /// Implementation of `ioctl`
+    pub(super) unsafe fn do_ioctl<T, U>(
+        s: SOCKET,
+        control_code: u32,
+        input: Option<&T>,
+        output: Option<&mut U>,
+    ) -> Result<(), Fail> {
+        let input: Option<*const libc::c_void> = input.map(|t: &T| -> *const libc::c_void { (t as *const T).cast() });
+        let input_size: usize = input.map(|_| std::mem::size_of::<T>()).unwrap_or(0);
+
+        let output: Option<*mut libc::c_void> = output.map(|u: &mut U| -> *mut libc::c_void { (u as *mut U).cast() });
+        let output_size: usize = output.map(|_| std::mem::size_of::<U>()).unwrap_or(0);
+
+        if input_size > u32::MAX as usize {
+            return Err(Fail::new(
+                libc::E2BIG,
+                "\"input_size\" parameter to WSAIoctl parameter is too big",
+            ));
+        }
+        if output_size > u32::MAX as usize {
+            return Err(Fail::new(
+                libc::E2BIG,
+                "\"output_size\" parameter to WSAIoctl parameter is too big",
+            ));
+        }
+
+        let mut bytes_returned: u32 = 0;
+        let ret: i32 = unsafe {
+            WSAIoctl(
+                s,
+                control_code,
+                input,
+                input_size as u32,
+                output,
+                output_size as u32,
+                &mut bytes_returned,
+                None,
+                None,
+            )
+        };
+
+        if ret == 0 {
+            if bytes_returned == output_size as u32 {
+                Ok(())
+            } else {
+                let s: String = format!("WSAIoctl returned {} bytes; expected {}", bytes_returned, output_size);
+                Err(Fail::new(libc::EFAULT, s.as_str()))
+            }
+        } else {
+            Err(expect_last_wsa_error())
+        }
+    }
+
+    /// Execute an I/O control syscall on the socket.
+    /// Safety: the I/O control code must match the expected input/output parameter types. If `output` is provided, the
+    /// I/O control operation must write a valid value of type U on success, or nothing on failure.
+    #[allow(unused)]
+    pub unsafe fn ioctl<T, U>(
+        &self,
+        s: SOCKET,
+        control_code: u32,
+        input: Option<&T>,
+        output: Option<&mut U>,
+    ) -> Result<(), Fail> {
+        Self::do_ioctl(s, control_code, input, output)
+    }
+
+    /// Implementation of setsockopt.
+    pub(super) unsafe fn do_setsockopt<'a, T>(s: SOCKET, level: i32, opt: i32, val: Option<&'a T>) -> Result<(), Fail> {
+        let val: Option<&'a [u8]> = match val {
+            Some(val) => {
+                Some(unsafe { std::slice::from_raw_parts((val as *const T).cast(), std::mem::size_of::<T>()) })
+            },
+            None => None,
+        };
+
+        if unsafe { setsockopt(s, level, opt, val) } == 0 {
+            Ok(())
+        } else {
+            Err(expect_last_wsa_error())
+        }
+    }
+
+    /// Set a socket option (via setsockopt) from a structured value `val`.
+    /// Safety: the requested socket option must agree with the ABI of T.
+    #[allow(unused)]
+    pub unsafe fn setsockopt<'a, T>(&self, s: SOCKET, level: i32, opt: i32, val: Option<&'a T>) -> Result<(), Fail> {
+        Self::do_setsockopt(s, level, opt, val)
+    }
+
+    /// Implementation of getsockopt.
+    pub(super) unsafe fn do_getsockopt<T>(s: SOCKET, level: i32, optname: i32) -> Result<T, Fail> {
+        let mut out: MaybeUninit<T> = MaybeUninit::zeroed();
+        let optval: PSTR = PSTR::from_raw(out.as_mut_ptr().cast());
+        let mut optlen: i32 =
+            i32::try_from(std::mem::size_of::<T>()).map_err(|_| Fail::new(libc::E2BIG, "option type too large"))?;
+        if unsafe { getsockopt(s, level, optname, optval, &mut optlen) } == 0 {
+            Ok(unsafe { out.assume_init() })
+        } else {
+            Err(expect_last_wsa_error())
+        }
+    }
+
+    /// Get a socket option (via getsockopt) and return the option as a structure type.
+    /// Safety: the requested socket option must initialize a value of type T.
+    pub unsafe fn getsockopt<T>(&self, s: SOCKET, level: i32, optname: i32) -> Result<T, Fail> {
+        Self::do_getsockopt(s, level, optname)
+    }
+
+    /// Get or initialize a new `SocketExtensions` instance for a  socket. Extensions are stored by socket provider,
+    /// which may be shared by multiple sockets.
+    fn get_or_init_extensions(&mut self, s: SOCKET) -> Result<Rc<SocketExtensions>, Fail> {
+        let protocol: WSAPROTOCOL_INFOW = unsafe { self.getsockopt(s, SOL_SOCKET, SO_PROTOCOL_INFOW) }?;
+
+        let extensions: &mut Weak<SocketExtensions> = self
+            .extensions_by_provider
+            .entry(protocol.ProviderId)
+            .or_insert(Weak::default());
+        if let Some(extensions) = extensions.upgrade() {
+            return Ok(extensions);
+        }
+
+        let new_extensions: Rc<SocketExtensions> = SocketExtensions::new(s)?;
+        *extensions = Rc::downgrade(&new_extensions);
+
+        Ok(new_extensions)
+    }
+
+    /// Create a raw Winsock socket.
+    pub(super) unsafe fn raw_socket(
+        domain: libc::c_int,
+        typ: libc::c_int,
+        protocol: libc::c_int,
+        protocol_info: Option<&WSAPROTOCOL_INFOW>,
+        flags: u32,
+    ) -> Result<SOCKET, Fail> {
+        let protocol_info: Option<*const WSAPROTOCOL_INFOW> = protocol_info.map(|i| i as *const WSAPROTOCOL_INFOW);
+        match unsafe { WSASocketW(domain, typ, protocol, protocol_info, 0, flags) } {
+            INVALID_SOCKET => Err(expect_last_wsa_error()),
+            socket => Ok(socket),
+        }
+    }
+
+    /// Create a new socket.
+    pub fn socket(
+        &mut self,
+        domain: libc::c_int,
+        typ: libc::c_int,
+        protocol: libc::c_int,
+        config: &WinConfig,
+        iocp: &IoCompletionPort,
+    ) -> Result<Socket, Fail> {
+        // Safety: SOCKET is a loose handle; it must be closed with `closesocket` to clean up resources. Socket struct
+        // will take ownership by end of method; failures after this call need to be cause a `closesocket` call.
+        let s: SOCKET = unsafe { Self::raw_socket(domain, typ, protocol, None, WSA_FLAG_OVERLAPPED) }?;
+
+        self.get_or_init_extensions(s)
+            .and_then(|extensions: Rc<SocketExtensions>| Socket::new(s, protocol, config, extensions, iocp))
+            .or_else(|err: Fail| {
+                unsafe { closesocket(s) };
+                Err(err)
+            })
+    }
+}
+
+//======================================================================================================================
+// Traits
+//======================================================================================================================
+
+impl Drop for WinsockRuntime {
+    fn drop(&mut self) {
+        self.extensions_by_provider.clear();
+        unsafe { WSACleanup() };
+    }
+}

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -78,13 +78,6 @@ use ::std::{
 };
 
 #[cfg(target_os = "windows")]
-use windows::Win32::Networking::WinSock::{
-    WSAEALREADY,
-    WSAEINPROGRESS,
-    WSAEWOULDBLOCK,
-};
-
-#[cfg(target_os = "windows")]
 use crate::pal::functions::socketaddrv4_to_sockaddr;
 
 #[cfg(target_os = "linux")]
@@ -141,17 +134,10 @@ pub struct SharedBox<T: ?Sized>(SharedObject<Box<T>>);
 impl DemiRuntime {
     /// Checks if an operation should be retried based on the error code `err`.
     pub fn should_retry(errno: i32) -> bool {
-        #[cfg(target_os = "linux")]
         if errno == libc::EINPROGRESS || errno == libc::EWOULDBLOCK || errno == libc::EAGAIN || errno == libc::EALREADY
         {
             return true;
         }
-
-        #[cfg(target_os = "windows")]
-        if errno == WSAEWOULDBLOCK.0 || errno == WSAEINPROGRESS.0 || errno == WSAEALREADY.0 {
-            return true;
-        }
-
         false
     }
 }


### PR DESCRIPTION
This PR adds a Windows transport implementation to the catnap libos based on overlapped I/O. The implementation uses a single I/O completion port which is polled by a background coroutine. This allows coroutines to be written on top of overlapped I/O using the `IoCompletionPort::do_io` and `do_io_with` methods. This PR additionally contains extensive logic for translating Win32 error, Winsock error, and NTSTATUS codes into errno error codes. As such, I removed the common references to Windows error codes, as in `DemiRuntime::should_retry`.