### PR TITLE
[inetstack] Move TCP close to a linear flow and remove synchronous close

### DIFF
--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -255,24 +255,6 @@ impl LibOS {
         result
     }
 
-    #[cfg(any(feature = "catpowder-libos", feature = "catnip-libos"))]
-    /// Closes an I/O queue.
-    pub fn close(&mut self, qd: QDesc) -> Result<(), Fail> {
-        let result: Result<(), Fail> = {
-            #[cfg(feature = "profiler")]
-            timer!("demikernel::close");
-            match self {
-                LibOS::NetworkLibOS(libos) => libos.close(qd),
-                LibOS::MemoryLibOS(_) => Err(Fail::new(libc::ENOTSUP, "close() is not supported on memory liboses")),
-            }
-        };
-
-        self.poll();
-
-        result
-    }
-
-    #[cfg(not(any(feature = "catpowder-libos", feature = "catnip-libos")))]
     /// Closes an I/O queue.
     /// async_close() + wait() achieves the same effect as synchronous close.
     pub fn close(&mut self, qd: QDesc) -> Result<(), Fail> {

--- a/src/rust/demikernel/libos/network.rs
+++ b/src/rust/demikernel/libos/network.rs
@@ -174,18 +174,6 @@ impl NetworkLibOS {
         }
     }
 
-    /// Closes a socket.
-    #[allow(unused_variables)]
-    pub fn close(&mut self, sockqd: QDesc) -> Result<(), Fail> {
-        match self {
-            #[cfg(feature = "catpowder-libos")]
-            NetworkLibOS::Catpowder { runtime: _, libos } => libos.close(sockqd),
-            #[cfg(feature = "catnip-libos")]
-            NetworkLibOS::Catnip { runtime: _, libos } => libos.close(sockqd),
-            _ => Err(Fail::new(libc::ENOTSUP, "operation not supported")),
-        }
-    }
-
     pub fn async_close(&mut self, sockqd: QDesc) -> Result<QToken, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]

--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -284,26 +284,6 @@ impl<const N: usize> SharedInetStack<N> {
     ///
     /// **Brief**
     ///
-    /// Closes a connection referred to by `qd`.
-    ///
-    /// **Return Value**
-    ///
-    /// Upon successful completion, `Ok(())` is returned. Upon failure, `Fail` is
-    /// returned instead.
-    ///
-    pub fn close(&mut self, qd: QDesc) -> Result<(), Fail> {
-        trace!("close(): qd={:?}", qd);
-
-        match self.runtime.get_queue_type(&qd)? {
-            QType::TcpSocket => self.ipv4.tcp.close(qd),
-            QType::UdpSocket => self.ipv4.udp.close(qd),
-            _ => Err(Fail::new(libc::EINVAL, "invalid queue type")),
-        }
-    }
-
-    ///
-    /// **Brief**
-    ///
     /// Asynchronously closes a connection referred to by `qd`.
     ///
     /// **Return Value**

--- a/src/rust/inetstack/protocols/tcp/established/background/mod.rs
+++ b/src/rust/inetstack/protocols/tcp/established/background/mod.rs
@@ -11,16 +11,8 @@ use self::{
     sender::sender,
 };
 use crate::{
-    collections::async_queue::SharedAsyncQueue,
-    inetstack::protocols::{
-        ipv4::Ipv4Header,
-        tcp::{
-            established::ctrlblk::SharedControlBlock,
-            segment::TcpHeader,
-        },
-    },
+    inetstack::protocols::tcp::established::ctrlblk::SharedControlBlock,
     runtime::{
-        memory::DemiBuffer,
         scheduler::Yielder,
         QDesc,
     },
@@ -31,11 +23,7 @@ use ::futures::{
     FutureExt,
 };
 
-pub async fn background<const N: usize>(
-    cb: SharedControlBlock<N>,
-    mut recv_queue: SharedAsyncQueue<(Ipv4Header, TcpHeader, DemiBuffer)>,
-    _dead_socket_tx: mpsc::UnboundedSender<QDesc>,
-) {
+pub async fn background<const N: usize>(cb: SharedControlBlock<N>, _dead_socket_tx: mpsc::UnboundedSender<QDesc>) {
     let yielder_acknowledger: Yielder = Yielder::new();
     let acknowledger = acknowledger(cb.clone(), yielder_acknowledger).fuse();
     futures::pin_mut!(acknowledger);
@@ -50,15 +38,7 @@ pub async fn background<const N: usize>(
 
     let yielder_receiver: Yielder = Yielder::new();
     let mut cb2: SharedControlBlock<N> = cb.clone();
-    let receiver = async move {
-        loop {
-            match recv_queue.pop(&yielder_receiver).await {
-                Ok((_, tcp_hdr, buf)) => cb2.receive(tcp_hdr, buf),
-                Err(e) => break Err(e),
-            }
-        }
-    }
-    .fuse();
+    let receiver = cb2.poll(yielder_receiver).fuse();
     pin_mut!(receiver);
 
     let r = futures::select_biased! {

--- a/src/rust/inetstack/protocols/tcp/established/background/sender.rs
+++ b/src/rust/inetstack/protocols/tcp/established/background/sender.rs
@@ -168,7 +168,6 @@ pub async fn sender<const N: usize>(mut cb: SharedControlBlock<N>, yielder: Yiel
         header.seq_num = send_next;
         if segment_data_len == 0 {
             // This buffer is the end-of-send marker.
-            debug_assert!(cb.user_is_done_sending);
             // Set FIN and adjust sequence number consumption accordingly.
             header.fin = true;
             segment_data_len = 1;

--- a/src/rust/inetstack/protocols/tcp/established/mod.rs
+++ b/src/rust/inetstack/protocols/tcp/established/mod.rs
@@ -96,10 +96,11 @@ impl<const N: usize> EstablishedSocket<N> {
             sender_mss,
             cc_constructor,
             congestion_control_options,
+            recv_queue.clone(),
         );
         let handle: TaskHandle = runtime.insert_background_coroutine(
             "Inetstack::TCP::established::background",
-            Box::pin(background::background(cb.clone(), recv_queue.clone(), dead_socket_tx)),
+            Box::pin(background::background(cb.clone(), dead_socket_tx)),
         )?;
         Ok(Self {
             cb,
@@ -121,12 +122,8 @@ impl<const N: usize> EstablishedSocket<N> {
         self.cb.pop(size, yielder).await
     }
 
-    pub fn close(&mut self) -> Result<(), Fail> {
-        self.cb.close()
-    }
-
-    pub async fn async_close(&mut self, yielder: Yielder) -> Result<(), Fail> {
-        self.cb.async_close(yielder).await
+    pub async fn close(&mut self, yielder: Yielder) -> Result<(), Fail> {
+        self.cb.close(yielder).await
     }
 
     pub fn remote_mss(&self) -> usize {

--- a/src/rust/inetstack/protocols/tcp/established/sender.rs
+++ b/src/rust/inetstack/protocols/tcp/established/sender.rs
@@ -153,10 +153,6 @@ impl<const N: usize> Sender<N> {
     //
     pub fn send(&mut self, buf: DemiBuffer, mut cb: SharedControlBlock<N>) -> Result<(), Fail> {
         // If the user is done sending (i.e. has called close on this connection), then they shouldn't be sending.
-        //
-        if cb.user_is_done_sending {
-            return Err(Fail::new(EINVAL, "Connection is closing"));
-        }
 
         // Our API supports send buffers up to usize (variable, depends upon architecture) in size.  While we could
         // allow for larger send buffers, it is simpler and more practical to limit a single send to 1 GiB, which is

--- a/src/rust/inetstack/protocols/tcp/peer.rs
+++ b/src/rust/inetstack/protocols/tcp/peer.rs
@@ -384,24 +384,6 @@ impl<const N: usize> SharedTcpPeer<N> {
     }
 
     /// Closes a TCP socket.
-    pub fn close(&mut self, qd: QDesc) -> Result<(), Fail> {
-        trace!("Closing socket: qd={:?}", qd);
-        // TODO: Currently we do not handle close correctly because we continue to receive packets at this point to finish the TCP close protocol.
-        // 1. We do not remove the endpoint from the addresses table
-        // 2. We do not remove the queue from the queue table.
-        // As a result, we have stale closed queues that are labelled as closing. We should clean these up.
-        // look up socket
-        let mut queue: SharedTcpQueue<N> = self.get_shared_queue(&qd)?;
-        if let Some(socket_id) = queue.close()? {
-            match self.runtime.remove_socket_id_to_qd(&socket_id) {
-                Some(existing_qd) if existing_qd == qd => {},
-                _ => return Err(Fail::new(libc::EINVAL, "socket id did not map to this qd!")),
-            };
-        }
-        Ok(())
-    }
-
-    /// Closes a TCP socket.
     pub fn async_close(&mut self, qd: QDesc) -> Result<QToken, Fail> {
         trace!("Closing socket: qd={:?}", qd);
 

--- a/tests/rust/tcp.rs
+++ b/tests/rust/tcp.rs
@@ -758,7 +758,7 @@ fn tcp_bad_close() -> Result<()> {
         };
 
         // Close bad queue descriptor.
-        match libos.close(QDesc::from(2)) {
+        match libos.async_close(QDesc::from(2)) {
             Ok(_) => anyhow::bail!("close() invalid file descriptir should fail"),
             Err(_) => (),
         };
@@ -768,7 +768,7 @@ fn tcp_bad_close() -> Result<()> {
         safe_close_passive(&mut libos, sockqd)?;
 
         // Double close queue descriptor.
-        match libos.close(qd) {
+        match libos.async_close(qd) {
             Ok(_) => anyhow::bail!("double close() should fail"),
             Err(_) => (),
         };
@@ -800,7 +800,7 @@ fn tcp_bad_close() -> Result<()> {
         }
 
         // Close bad queue descriptor.
-        match libos.close(QDesc::from(2)) {
+        match libos.async_close(QDesc::from(2)) {
             // Should not be able to close bad queue descriptor.
             Ok(_) => anyhow::bail!("close() invalid queue descriptor should fail"),
             Err(_) => (),
@@ -810,7 +810,7 @@ fn tcp_bad_close() -> Result<()> {
         safe_close_active(&mut libos, sockqd)?;
 
         // Double close queue descriptor.
-        match libos.close(sockqd) {
+        match libos.async_close(sockqd) {
             // Should not be able to double close.
             Ok(_) => anyhow::bail!("double close() should fail"),
             Err(_) => (),
@@ -1173,16 +1173,16 @@ fn safe_wait2<const N: usize>(libos: &mut SharedInetStack<N>, qt: QToken) -> Res
 
 /// Safe call to `close()` on passive socket.
 fn safe_close_passive<const N: usize>(libos: &mut SharedInetStack<N>, sockqd: QDesc) -> Result<()> {
-    match libos.close(sockqd) {
+    match libos.async_close(sockqd) {
         Ok(_) => anyhow::bail!("close() on listening socket should have failed (this is a known bug)"),
         Err(_) => Ok(()),
     }
 }
 
 /// Safe call to `close()` on active socket.
-fn safe_close_active<const N: usize>(libos: &mut SharedInetStack<N>, qd: QDesc) -> Result<()> {
-    match libos.close(qd) {
-        Ok(_) => Ok(()),
+fn safe_close_active<const N: usize>(libos: &mut SharedInetStack<N>, qd: QDesc) -> Result<(QDesc, OperationResult)> {
+    match libos.async_close(qd) {
+        Ok(qt) => safe_wait2(libos, qt),
         Err(_) => anyhow::bail!("close() on active socket has failed"),
     }
 }

--- a/tests/rust/udp.rs
+++ b/tests/rust/udp.rs
@@ -75,8 +75,11 @@ fn do_udp_setup<const N: usize>(libos: &mut SharedInetStack<N>) -> Result<()> {
         },
     };
 
-    match libos.close(sockfd) {
-        Ok(_) => Ok(()),
+    match libos.async_close(sockfd) {
+        Ok(qt) => {
+            safe_wait2(libos, qt)?;
+            Ok(())
+        },
         Err(e) => anyhow::bail!("close() failed: {:?}", e),
     }
 }
@@ -98,8 +101,11 @@ fn do_udp_setup_ephemeral<const N: usize>(libos: &mut SharedInetStack<N>) -> Res
         },
     };
 
-    match libos.close(sockfd) {
-        Ok(_) => Ok(()),
+    match libos.async_close(sockfd) {
+        Ok(qt) => {
+            safe_wait2(libos, qt)?;
+            Ok(())
+        },
         Err(e) => anyhow::bail!("close() failed: {:?}", e),
     }
 }
@@ -120,8 +126,11 @@ fn do_udp_setup_wildcard_ephemeral<const N: usize>(libos: &mut SharedInetStack<N
         },
     };
 
-    match libos.close(sockfd) {
-        Ok(_) => Ok(()),
+    match libos.async_close(sockfd) {
+        Ok(qt) => {
+            safe_wait2(libos, qt)?;
+            Ok(())
+        },
         Err(e) => anyhow::bail!("close() failed: {:?}", e),
     }
 }
@@ -168,8 +177,11 @@ fn udp_connect_loopback() -> Result<()> {
         },
     };
 
-    match libos.close(sockfd) {
-        Ok(_) => Ok(()),
+    match libos.async_close(sockfd) {
+        Ok(qt) => {
+            safe_wait2(&mut libos, qt)?;
+            Ok(())
+        },
         Err(e) => anyhow::bail!("close() failed: {:?}", e),
     }
 }
@@ -253,8 +265,11 @@ fn udp_push_remote() -> Result<()> {
         }
 
         // Close connection.
-        match libos.close(sockfd) {
-            Ok(_) => Ok(()),
+        match libos.async_close(sockfd) {
+            Ok(qt) => {
+                safe_wait2(&mut libos, qt)?;
+                Ok(())
+            },
             Err(e) => anyhow::bail!("close() failed: {:?}", e),
         }
     });
@@ -319,8 +334,11 @@ fn udp_push_remote() -> Result<()> {
         }
 
         // Close connection.
-        match libos.close(sockfd) {
-            Ok(_) => Ok(()),
+        match libos.async_close(sockfd) {
+            Ok(qt) => {
+                safe_wait2(&mut libos, qt)?;
+                Ok(())
+            },
             Err(e) => anyhow::bail!("close() failed: {:?}", e),
         }
     });
@@ -406,8 +424,11 @@ fn udp_loopback() -> Result<()> {
         }
 
         // Close connection.
-        match libos.close(sockfd) {
-            Ok(_) => Ok(()),
+        match libos.async_close(sockfd) {
+            Ok(qt) => {
+                safe_wait2(&mut libos, qt)?;
+                Ok(())
+            },
             Err(e) => anyhow::bail!("close() failed: {:?}", e),
         }
     });
@@ -464,8 +485,11 @@ fn udp_loopback() -> Result<()> {
         }
 
         // Close connection.
-        match libos.close(sockfd) {
-            Ok(_) => Ok(()),
+        match libos.async_close(sockfd) {
+            Ok(qt) => {
+                safe_wait2(&mut libos, qt)?;
+                Ok(())
+            },
             Err(e) => anyhow::bail!("close() failed: {:?}", e),
         }
     });


### PR DESCRIPTION
This PR moves the TCP close protocol to a linear flow and cleans up background tasks once we move out of the established state, closing #988
