### PR TITLE
[demikernel] Consolidate yielder creation for all LibOS coroutines

### DIFF
--- a/src/rust/catcollar/mod.rs
+++ b/src/rust/catcollar/mod.rs
@@ -209,7 +209,7 @@ impl CatcollarLibOS {
         Ok(self
             .runtime
             .clone()
-            .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)?
+            .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)?
             .get_task_id()
             .into())
     }
@@ -300,7 +300,7 @@ impl CatcollarLibOS {
         Ok(self
             .runtime
             .clone()
-            .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)?
+            .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)?
             .get_task_id()
             .into())
     }
@@ -360,7 +360,7 @@ impl CatcollarLibOS {
         Ok(self
             .runtime
             .clone()
-            .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)?
+            .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)?
             .get_task_id()
             .into())
     }
@@ -433,7 +433,7 @@ impl CatcollarLibOS {
         Ok(self
             .runtime
             .clone()
-            .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)?
+            .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)?
             .get_task_id()
             .into())
     }
@@ -516,7 +516,7 @@ impl CatcollarLibOS {
                 Ok(self
                     .runtime
                     .clone()
-                    .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)?
+                    .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)?
                     .get_task_id()
                     .into())
             },
@@ -602,7 +602,7 @@ impl CatcollarLibOS {
         Ok(self
             .runtime
             .clone()
-            .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)?
+            .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)?
             .get_task_id()
             .into())
     }

--- a/src/rust/catloop/mod.rs
+++ b/src/rust/catloop/mod.rs
@@ -32,7 +32,6 @@ use crate::{
         scheduler::{
             TaskHandle,
             Yielder,
-            YielderHandle,
         },
         Operation,
         OperationResult,
@@ -213,11 +212,11 @@ impl SharedCatloopLibOS {
         let mut queue: SharedCatloopQueue = self.get_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catloop::accept for qd={:?}", qd);
-            let yielder: Yielder = Yielder::new();
-            let yielder_handle: YielderHandle = yielder.get_handle();
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().accept_coroutine(qd, new_port, yielder));
-            self.runtime
-                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
+            let coroutine_factory =
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().accept_coroutine(qd, new_port, yielder)) };
+            self.clone()
+                .runtime
+                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
         };
 
         queue.accept(coroutine_constructor)
@@ -273,11 +272,11 @@ impl SharedCatloopLibOS {
 
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catloop::connect for qd={:?}", qd);
-            let yielder: Yielder = Yielder::new();
-            let yielder_handle: YielderHandle = yielder.get_handle();
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().connect_coroutine(qd, remote, yielder));
-            self.runtime
-                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
+            let coroutine_factory =
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().connect_coroutine(qd, remote, yielder)) };
+            self.clone()
+                .runtime
+                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
         };
 
         queue.connect(coroutine_constructor)
@@ -313,11 +312,11 @@ impl SharedCatloopLibOS {
         // Note that this coroutine is only inserted if we do not allocate a Catmem coroutine.
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catloop::close for qd={:?}", qd);
-            let yielder: Yielder = Yielder::new();
-            let yielder_handle: YielderHandle = yielder.get_handle();
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().close_coroutine(qd, yielder));
-            self.runtime
-                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
+            let coroutine_factory =
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().close_coroutine(qd, yielder)) };
+            self.clone()
+                .runtime
+                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
         };
 
         queue.async_close(coroutine_constructor)
@@ -374,11 +373,11 @@ impl SharedCatloopLibOS {
         let mut queue: SharedCatloopQueue = self.get_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catloop::push for qd={:?}", qd);
-            let yielder: Yielder = Yielder::new();
-            let yielder_handle: YielderHandle = yielder.get_handle();
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().push_coroutine(qd, buf, yielder));
-            self.runtime
-                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
+            let coroutine_factory =
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().push_coroutine(qd, buf, yielder)) };
+            self.clone()
+                .runtime
+                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
         };
 
         queue.push(coroutine_constructor)
@@ -416,11 +415,11 @@ impl SharedCatloopLibOS {
         let mut queue: SharedCatloopQueue = self.get_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catloop::pop for qd={:?}", qd);
-            let yielder: Yielder = Yielder::new();
-            let yielder_handle: YielderHandle = yielder.get_handle();
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().pop_coroutine(qd, size, yielder));
-            self.runtime
-                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
+            let coroutine_factory =
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().pop_coroutine(qd, size, yielder)) };
+            self.clone()
+                .runtime
+                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
         };
 
         queue.pop(coroutine_constructor)

--- a/src/rust/catloop/mod.rs
+++ b/src/rust/catloop/mod.rs
@@ -216,7 +216,7 @@ impl SharedCatloopLibOS {
                 |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().accept_coroutine(qd, new_port, yielder)) };
             self.clone()
                 .runtime
-                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
+                .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
         };
 
         queue.accept(coroutine_constructor)
@@ -276,7 +276,7 @@ impl SharedCatloopLibOS {
                 |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().connect_coroutine(qd, remote, yielder)) };
             self.clone()
                 .runtime
-                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
+                .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
         };
 
         queue.connect(coroutine_constructor)
@@ -316,7 +316,7 @@ impl SharedCatloopLibOS {
                 |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().close_coroutine(qd, yielder)) };
             self.clone()
                 .runtime
-                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
+                .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
         };
 
         queue.async_close(coroutine_constructor)
@@ -377,7 +377,7 @@ impl SharedCatloopLibOS {
                 |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().push_coroutine(qd, buf, yielder)) };
             self.clone()
                 .runtime
-                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
+                .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
         };
 
         queue.push(coroutine_constructor)
@@ -419,7 +419,7 @@ impl SharedCatloopLibOS {
                 |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().pop_coroutine(qd, size, yielder)) };
             self.clone()
                 .runtime
-                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
+                .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
         };
 
         queue.pop(coroutine_constructor)

--- a/src/rust/catmem/mod.rs
+++ b/src/rust/catmem/mod.rs
@@ -119,7 +119,7 @@ impl SharedCatmemLibOS {
                 |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().close_coroutine(qd, yielder)) };
             self.clone()
                 .runtime
-                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
+                .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
         };
 
         queue.async_close(coroutine_constructor)
@@ -173,7 +173,7 @@ impl SharedCatmemLibOS {
                 |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().push_coroutine(qd, buf, yielder)) };
             self.clone()
                 .runtime
-                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
+                .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
         };
 
         queue.push(coroutine_constructor)
@@ -206,7 +206,7 @@ impl SharedCatmemLibOS {
                 |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().pop_coroutine(qd, size, yielder)) };
             self.clone()
                 .runtime
-                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
+                .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
         };
 
         queue.pop(coroutine_constructor)

--- a/src/rust/catmem/mod.rs
+++ b/src/rust/catmem/mod.rs
@@ -22,7 +22,6 @@ use crate::{
         scheduler::{
             TaskHandle,
             Yielder,
-            YielderHandle,
         },
         types::demi_sgarray_t,
         Operation,
@@ -116,11 +115,11 @@ impl SharedCatmemLibOS {
         let mut queue: SharedCatmemQueue = self.get_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catmem::async_close for qd={:?}", qd);
-            let yielder: Yielder = Yielder::new();
-            let yielder_handle: YielderHandle = yielder.get_handle();
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().close_coroutine(qd, yielder));
-            self.runtime
-                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
+            let coroutine_factory =
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().close_coroutine(qd, yielder)) };
+            self.clone()
+                .runtime
+                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
         };
 
         queue.async_close(coroutine_constructor)
@@ -170,11 +169,11 @@ impl SharedCatmemLibOS {
         let mut queue: SharedCatmemQueue = self.get_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catmem::push for qd={:?}", qd);
-            let yielder: Yielder = Yielder::new();
-            let yielder_handle: YielderHandle = yielder.get_handle();
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().push_coroutine(qd, buf, yielder));
-            self.runtime
-                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
+            let coroutine_factory =
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().push_coroutine(qd, buf, yielder)) };
+            self.clone()
+                .runtime
+                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
         };
 
         queue.push(coroutine_constructor)
@@ -203,11 +202,11 @@ impl SharedCatmemLibOS {
         let mut queue: SharedCatmemQueue = self.get_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catmem::pop for qd={:?}", qd);
-            let yielder: Yielder = Yielder::new();
-            let yielder_handle: YielderHandle = yielder.get_handle();
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().pop_coroutine(qd, size, yielder));
-            self.runtime
-                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
+            let coroutine_factory =
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().pop_coroutine(qd, size, yielder)) };
+            self.clone()
+                .runtime
+                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
         };
 
         queue.pop(coroutine_constructor)

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -36,7 +36,6 @@ use crate::{
         scheduler::{
             TaskHandle,
             Yielder,
-            YielderHandle,
         },
         types::demi_sgarray_t,
         QDesc,
@@ -185,11 +184,11 @@ impl SharedCatnapLibOS {
         let mut queue: SharedCatnapQueue = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::accept for qd={:?}", qd);
-            let yielder: Yielder = Yielder::new();
-            let yielder_handle: YielderHandle = yielder.get_handle();
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().accept_coroutine(qd, yielder));
-            self.runtime
-                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
+            let coroutine_factory =
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().accept_coroutine(qd, yielder)) };
+            self.clone()
+                .runtime
+                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
         };
 
         queue.accept(coroutine_constructor)
@@ -239,11 +238,11 @@ impl SharedCatnapLibOS {
         let mut queue: SharedCatnapQueue = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::connect for qd={:?}", qd);
-            let yielder: Yielder = Yielder::new();
-            let yielder_handle: YielderHandle = yielder.get_handle();
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().connect_coroutine(qd, remote, yielder));
-            self.runtime
-                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
+            let coroutine_factory =
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().connect_coroutine(qd, remote, yielder)) };
+            self.clone()
+                .runtime
+                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
         };
 
         queue.connect(coroutine_constructor)
@@ -281,11 +280,11 @@ impl SharedCatnapLibOS {
         let mut queue: SharedCatnapQueue = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::close for qd={:?}", qd);
-            let yielder: Yielder = Yielder::new();
-            let yielder_handle = yielder.get_handle();
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().close_coroutine(qd, yielder));
-            self.runtime
-                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
+            let coroutine_factory =
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().close_coroutine(qd, yielder)) };
+            self.clone()
+                .runtime
+                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
         };
 
         queue.async_close(coroutine_constructor)
@@ -341,11 +340,11 @@ impl SharedCatnapLibOS {
         let mut queue: SharedCatnapQueue = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::push for qd={:?}", qd);
-            let yielder: Yielder = Yielder::new();
-            let yielder_handle: YielderHandle = yielder.get_handle();
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().push_coroutine(qd, buf, yielder));
-            self.runtime
-                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
+            let coroutine_factory =
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().push_coroutine(qd, buf, yielder)) };
+            self.clone()
+                .runtime
+                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
         };
 
         queue.push(coroutine_constructor)
@@ -386,11 +385,11 @@ impl SharedCatnapLibOS {
         let mut queue: SharedCatnapQueue = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::pushto for qd={:?}", qd);
-            let yielder: Yielder = Yielder::new();
-            let yielder_handle: YielderHandle = yielder.get_handle();
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().pushto_coroutine(qd, buf, remote, yielder));
-            self.runtime
-                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
+            let coroutine_factory =
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().pushto_coroutine(qd, buf, remote, yielder)) };
+            self.clone()
+                .runtime
+                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
         };
 
         queue.push(coroutine_constructor)
@@ -435,11 +434,11 @@ impl SharedCatnapLibOS {
         let mut queue: SharedCatnapQueue = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("Catnap::pop for qd={:?}", qd);
-            let yielder: Yielder = Yielder::new();
-            let yielder_handle: YielderHandle = yielder.get_handle();
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().pop_coroutine(qd, size, yielder));
-            self.runtime
-                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
+            let coroutine_factory =
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().pop_coroutine(qd, size, yielder)) };
+            self.clone()
+                .runtime
+                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
         };
 
         queue.pop(coroutine_constructor)

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -188,7 +188,7 @@ impl SharedCatnapLibOS {
                 |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().accept_coroutine(qd, yielder)) };
             self.clone()
                 .runtime
-                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
+                .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
         };
 
         queue.accept(coroutine_constructor)
@@ -242,7 +242,7 @@ impl SharedCatnapLibOS {
                 |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().connect_coroutine(qd, remote, yielder)) };
             self.clone()
                 .runtime
-                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
+                .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
         };
 
         queue.connect(coroutine_constructor)
@@ -284,7 +284,7 @@ impl SharedCatnapLibOS {
                 |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().close_coroutine(qd, yielder)) };
             self.clone()
                 .runtime
-                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
+                .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
         };
 
         queue.async_close(coroutine_constructor)
@@ -344,7 +344,7 @@ impl SharedCatnapLibOS {
                 |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().push_coroutine(qd, buf, yielder)) };
             self.clone()
                 .runtime
-                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
+                .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
         };
 
         queue.push(coroutine_constructor)
@@ -389,7 +389,7 @@ impl SharedCatnapLibOS {
                 |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().pushto_coroutine(qd, buf, remote, yielder)) };
             self.clone()
                 .runtime
-                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
+                .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
         };
 
         queue.push(coroutine_constructor)
@@ -438,7 +438,7 @@ impl SharedCatnapLibOS {
                 |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().pop_coroutine(qd, size, yielder)) };
             self.clone()
                 .runtime
-                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
+                .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
         };
 
         queue.pop(coroutine_constructor)

--- a/src/rust/inetstack/protocols/tcp/peer.rs
+++ b/src/rust/inetstack/protocols/tcp/peer.rs
@@ -215,7 +215,7 @@ impl SharedTcpPeer {
                 |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().accept_coroutine(qd, yielder)) };
             self.clone()
                 .runtime
-                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
+                .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
         };
 
         queue.accept(coroutine_constructor)
@@ -290,7 +290,7 @@ impl SharedTcpPeer {
                 |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().connect_coroutine(qd, yielder)) };
             self.clone()
                 .runtime
-                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
+                .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
         };
 
         queue.connect(local, remote, local_isn, coroutine_constructor)
@@ -327,7 +327,7 @@ impl SharedTcpPeer {
                 |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().push_coroutine(qd, yielder)) };
             self.clone()
                 .runtime
-                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
+                .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
         };
 
         queue.push(buf, coroutine_constructor)
@@ -361,7 +361,7 @@ impl SharedTcpPeer {
                 |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().pop_coroutine(qd, size, yielder)) };
             self.clone()
                 .runtime
-                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
+                .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
         };
 
         queue.pop(coroutine_constructor)
@@ -393,7 +393,7 @@ impl SharedTcpPeer {
                 |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().close_coroutine(qd, yielder)) };
             self.clone()
                 .runtime
-                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
+                .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
         };
 
         queue.async_close(coroutine_constructor)

--- a/src/rust/inetstack/protocols/tcp/peer.rs
+++ b/src/rust/inetstack/protocols/tcp/peer.rs
@@ -212,11 +212,11 @@ impl SharedTcpPeer {
         let mut queue: SharedTcpQueue = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("inetstack::tcp::accept for qd={:?}", qd);
-            let yielder: Yielder = Yielder::new();
-            let yielder_handle: YielderHandle = yielder.get_handle();
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().accept_coroutine(qd, yielder));
-            self.runtime
-                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
+            let coroutine_factory =
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().accept_coroutine(qd, yielder)) };
+            self.clone()
+                .runtime
+                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
         };
 
         queue.accept(coroutine_constructor)
@@ -287,11 +287,11 @@ impl SharedTcpPeer {
         let local_isn: SeqNumber = self.isn_generator.generate(&local, &remote);
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("inetstack::tcp::connect for qd={:?}", qd);
-            let yielder: Yielder = Yielder::new();
-            let yielder_handle: YielderHandle = yielder.get_handle();
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().connect_coroutine(qd, yielder));
-            self.runtime
-                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
+            let coroutine_factory =
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().connect_coroutine(qd, yielder)) };
+            self.clone()
+                .runtime
+                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
         };
 
         queue.connect(local, remote, local_isn, coroutine_constructor)
@@ -324,11 +324,11 @@ impl SharedTcpPeer {
         let mut queue: SharedTcpQueue = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("inetstack::tcp::push for qd={:?}", qd);
-            let yielder: Yielder = Yielder::new();
-            let yielder_handle: YielderHandle = yielder.get_handle();
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().push_coroutine(qd, yielder));
-            self.runtime
-                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
+            let coroutine_factory =
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().push_coroutine(qd, yielder)) };
+            self.clone()
+                .runtime
+                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
         };
 
         queue.push(buf, coroutine_constructor)
@@ -358,11 +358,11 @@ impl SharedTcpPeer {
         let mut queue: SharedTcpQueue = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("inetstack::tcp::pop for qd={:?}", qd);
-            let yielder: Yielder = Yielder::new();
-            let yielder_handle: YielderHandle = yielder.get_handle();
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().pop_coroutine(qd, size, yielder));
-            self.runtime
-                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
+            let coroutine_factory =
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().pop_coroutine(qd, size, yielder)) };
+            self.clone()
+                .runtime
+                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
         };
 
         queue.pop(coroutine_constructor)
@@ -390,11 +390,11 @@ impl SharedTcpPeer {
         let mut queue: SharedTcpQueue = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<TaskHandle, Fail> {
             let task_name: String = format!("inetstack::tcp::close for qd={:?}", qd);
-            let yielder: Yielder = Yielder::new();
-            let yielder_handle: YielderHandle = yielder.get_handle();
-            let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().close_coroutine(qd, yielder));
-            self.runtime
-                .insert_coroutine_with_tracking(&task_name, coroutine, yielder_handle, qd)
+            let coroutine_factory =
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().close_coroutine(qd, yielder)) };
+            self.clone()
+                .runtime
+                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)
         };
 
         queue.async_close(coroutine_constructor)

--- a/src/rust/inetstack/protocols/tcp/peer.rs
+++ b/src/rust/inetstack/protocols/tcp/peer.rs
@@ -29,7 +29,6 @@ use crate::{
         scheduler::{
             TaskHandle,
             Yielder,
-            YielderHandle,
         },
         Operation,
         OperationResult,

--- a/src/rust/inetstack/protocols/udp/peer.rs
+++ b/src/rust/inetstack/protocols/udp/peer.rs
@@ -173,7 +173,7 @@ impl SharedUdpPeer {
         let task_handle: TaskHandle =
             self.clone()
                 .runtime
-                .insert_coroutine_with_tracking_callback(&task_name, coroutine_factory, qd)?;
+                .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)?;
 
         let qt: QToken = task_handle.get_task_id().into();
 

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -173,31 +173,9 @@ impl SharedDemiRuntime {
         }
     }
 
-    /// Inserts the `coroutine` named `task_name` into the scheduler. This function also tracks the qd, coroutine and
-    /// it's yielder_handle.
-    pub fn insert_coroutine_with_tracking(
-        &mut self,
-        task_name: &str,
-        coroutine: Pin<Box<Operation>>,
-        yielder_handle: YielderHandle,
-        qd: QDesc,
-    ) -> Result<TaskHandle, Fail> {
-        match self.insert_coroutine(task_name, coroutine) {
-            Ok(task_handle) => {
-                // This allows to keep track of currently running coroutines.
-                self.pending_ops
-                    .entry(qd)
-                    .or_insert(HashMap::new())
-                    .insert(task_handle.clone(), yielder_handle.clone());
-                Ok(task_handle)
-            },
-            Err(e) => Err(e),
-        }
-    }
-
     /// The coroutine factory is a function that takes a yielder and returns a future. The future is then inserted into
     /// the scheduler.
-    pub fn insert_coroutine_with_tracking_callback<F>(
+    pub fn insert_coroutine_with_tracking<F>(
         &mut self,
         task_name: &str,
         coroutine_factory: F,


### PR DESCRIPTION
This PR removes the Yielder and YielderHandle creation from the LibOS level and now does it at a centralized place in the runtime.

It only focuses on the LibOS level.
- This PR is not applicable for background coroutines.
- Does not cover the complete inetstack.