### PR TITLE
[dpdk-rs] adjust linking to mlx5 devx

### DIFF
--- a/dpdk-rs/build.rs
+++ b/dpdk-rs/build.rs
@@ -13,6 +13,7 @@ fn os_build() -> Result<()> {
     let out_dir_s: String = env::var("OUT_DIR")?;
     let out_dir: &Path = Path::new(&out_dir_s);
 
+    let devxlib_path: String = env::var("DEVX_LIB_PATH")?;
     let libdpdk_path: String = env::var("LIBDPDK_PATH")?;
 
     let include_path: String = format!("{}{}", libdpdk_path, "\\include");
@@ -64,18 +65,19 @@ fn os_build() -> Result<()> {
         "librte_stack",
         "librte_telemetry",
         "librte_timer",
-        "mlx5devx",
     ];
 
     let cflags: &str = "-mavx";
 
     // Step 1: Now that we've compiled and installed DPDK, point cargo to the libraries.
     println!("cargo:rustc-link-search={}", library_path);
+    println!("cargo:rustc-link-search={}", devxlib_path);
 
     for lib in &libraries {
         println!("cargo:rustc-link-lib=static:-bundle,+whole-archive={}", lib);
     }
 
+    println!("cargo:rustc-link-lib=dylib={}", "mlx5devx");
     println!("cargo:rustc-link-lib=dylib={}", "setupapi");
     println!("cargo:rustc-link-lib=dylib={}", "dbghelp");
     println!("cargo:rustc-link-lib=dylib={}", "mincore");


### PR DESCRIPTION
* use DEVX_LIB_PATH environment to locate the mlx5devx import library matching that used by DPDK. The environment variable is documented here https://doc.dpdk.org/guides-23.11/platform/mlx5.html

* do not /wholearchive mlx5devx, just link to the dll import library