### PR TITLE
[dpdk-rs] link to dpdk librte_log

### DIFF
--- a/dpdk-rs/build.rs
+++ b/dpdk-rs/build.rs
@@ -42,6 +42,7 @@ fn os_build() -> Result<()> {
         "librte_hash",
         "librte_kvargs",
         "librte_latencystats",
+        "librte_log",
         "librte_mbuf",
         "librte_mempool",
         "librte_mempool_ring",


### PR DESCRIPTION
as of dpdk 23.11 release the logging facilities of dpdk have been split out of librte_eal and placed in its own library. the new library must now be added when linking to avoid link failure.