### PR TITLE
[dpdk-rs] Bug Fix: always include rte_config.h first

### DIFF
--- a/dpdk-rs/inlined.c
+++ b/dpdk-rs/inlined.c
@@ -3,6 +3,7 @@
  * Licensed under the MIT license.
  */
 
+#include <rte_config.h>
 #include <rte_errno.h>
 #include <rte_ethdev.h>
 #include <rte_ether.h>

--- a/dpdk-rs/wrapper.h
+++ b/dpdk-rs/wrapper.h
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-#include <rte_build_config.h>
+#include <rte_config.h>
 #include <rte_ethdev.h>
 #include <rte_common.h>
 #include <rte_cycles.h>


### PR DESCRIPTION
dpdk expects/requires you to include rte_config.h before any other header. don't include rte_build_config.h directly instead include rte_config.h which includes rte_build_config.h.