### PR TITLE
[dpdk-rs] Workaround: redefine RTE_TOOLCHAIN_XXX for host toolchain

### DIFF
--- a/dpdk-rs/inlined.c
+++ b/dpdk-rs/inlined.c
@@ -3,6 +3,35 @@
  * Licensed under the MIT license.
  */
 
+#include <rte_config.h>
+
+/*
+ * work around bug in dpdk headers where the toolchain preprocessor
+ * definition used to build dpdk retained and incorrectly directs
+ * conditional compilation during application build.
+ */
+#undef RTE_TOOLCHAIN
+#ifdef RTE_TOOLCHAIN_CLANG
+#undef RTE_TOOLCHAIN_CLANG
+#endif
+#ifdef RTE_TOOLCHAIN_GCC
+#undef RTE_TOOLCHAIN_GCC
+#endif
+#ifdef RTE_TOOLCHAIN_MSVC
+#undef RTE_TOOLCHAIN_MSVC
+#endif
+
+#ifdef __clang__
+#define RTE_TOOLCHAIN "clang"
+#define RTE_TOOLCHAIN_CLANG 1
+#elif __GNUC__
+#define RTE_TOOLCHAIN "gcc"
+#define RTE_TOOLCHAIN_GCC 1
+#elif _MSC_VER
+#define RTE_TOOLCHAIN "msvc"
+#define RTE_TOOLCHAIN_MSVC 1
+#endif
+
 #include <rte_errno.h>
 #include <rte_ethdev.h>
 #include <rte_ether.h>

--- a/dpdk-rs/wrapper.h
+++ b/dpdk-rs/wrapper.h
@@ -4,6 +4,25 @@
  */
 
 #include <rte_build_config.h>
+
+/*
+ * work around bug in dpdk headers where the toolchain preprocessor
+ * definition used to build dpdk retained and incorrectly directs
+ * conditional compilation during application build.
+ */
+#undef RTE_TOOLCHAIN
+#ifdef RTE_TOOLCHAIN_CLANG
+#undef RTE_TOOLCHAIN_CLANG
+#endif
+#ifdef RTE_TOOLCHAIN_GCC
+#undef RTE_TOOLCHAIN_GCC
+#endif
+#ifdef RTE_TOOLCHAIN_MSVC
+#undef RTE_TOOLCHAIN_MSVC
+#endif
+#define RTE_TOOLCHAIN "clang"
+#define RTE_TOOLCHAIN_CLANG 1
+
 #include <rte_ethdev.h>
 #include <rte_common.h>
 #include <rte_cycles.h>


### PR DESCRIPTION
there is a bug in dpdk headers where the toolchain preprocessor definition used to build dpdk is retained and then incorrectly directs conditional compilation during application builds.

redefine the RTE_TOOLCHAIN_XXX macros as appropriate using the host toolchain predefined macros to get correct conditional evaluation when consuming dpdk headers.

this is just a workaround for now, i will work with the dpdk community to upstream a fix which will eventually allow this change to be removed.