### PR TITLE
[inetstack] Add Warning Message on Data Drop for Data Carrying, SYN Segment

### DIFF
--- a/nettest/input/accept-syn-carrying-data.pkt
+++ b/nettest/input/accept-syn-carrying-data.pkt
@@ -1,0 +1,17 @@
+// Tests for successful completion of an accept system call, when a data-carrying, SYN segment is received.
+
+// Accept a connection.
+ .0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 500
++.0 bind(500, ..., ...) = 0
++.0 listen(500, 1) = 0
++.2 accept(500, ..., ...) = 0
+
+// Receive a data-carrying SYN segment.
++.2 < S seq 0(1000) win 65535 <mss 1450,wscale 0>
+// Send SYN-ACK segment, that does not ack the received data.
++.0 > S. seq 0(0) ack 1 win 65535 <mss 1450,wscale 0>
+// Receive ACK on SYN-ACK segment.
++.2 < . seq 1(0) ack 1 win 65535 <nop>
+
+// Succeed to accept connection.
++.0 wait(500, ...) = 0

--- a/src/rust/inetstack/protocols/tcp/passive_open.rs
+++ b/src/rust/inetstack/protocols/tcp/passive_open.rs
@@ -171,6 +171,16 @@ impl<N: NetworkRuntime> SharedPassiveSocket<N> {
                 continue;
             }
 
+            // Check if this SYN segment carries any data.
+            if !buf.is_empty() {
+                // RFC 793 allows connections to be established with data-carrying segments, but we do not support this.
+                // We simply drop the data and and proceed with the three-way handshake protocol, on the hope that the
+                // remote will retransmit the data after the connection is established.
+                // See: https://datatracker.ietf.org/doc/html/rfc793#section-3.4 fo more details.
+                warn!("Received SYN with data (len={})", buf.len());
+                // TODO: https://github.com/microsoft/demikernel/issues/1115
+            }
+
             // Start a new connection.
             self.handle_new_syn(remote, tcp_hdr);
         }


### PR DESCRIPTION
## Description

- This PR closes https://github.com/microsoft/demikernel/issues/238
- This PR opens https://github.com/microsoft/demikernel/issues/1115

## Summary of Changes

- Added a warn message on data drop for data carrying, SYN segments.
- Added test case for connection establishment with a data-carrying, SYN segment.