### PR TITLE
[runtime] Move to FusedFuture

### DIFF
--- a/src/rust/catloop/mod.rs
+++ b/src/rust/catloop/mod.rs
@@ -39,6 +39,7 @@ use crate::{
     },
     QType,
 };
+use ::futures::FutureExt;
 use ::std::{
     net::{
         Ipv4Addr,
@@ -206,8 +207,9 @@ impl SharedCatloopLibOS {
         let mut queue: SharedCatloopQueue = self.get_queue(&qd)?;
         let coroutine_constructor = || -> Result<QToken, Fail> {
             let task_name: String = format!("Catloop::accept for qd={:?}", qd);
-            let coroutine_factory =
-                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().accept_coroutine(qd, new_port, yielder)) };
+            let coroutine_factory = |yielder| -> Pin<Box<Operation>> {
+                Box::pin(self.clone().accept_coroutine(qd, new_port, yielder).fuse())
+            };
             self.runtime
                 .clone()
                 .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
@@ -266,8 +268,9 @@ impl SharedCatloopLibOS {
 
         let coroutine_constructor = || -> Result<QToken, Fail> {
             let task_name: String = format!("Catloop::connect for qd={:?}", qd);
-            let coroutine_factory =
-                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().connect_coroutine(qd, remote, yielder)) };
+            let coroutine_factory = |yielder| -> Pin<Box<Operation>> {
+                Box::pin(self.clone().connect_coroutine(qd, remote, yielder).fuse())
+            };
             self.runtime
                 .clone()
                 .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
@@ -307,7 +310,7 @@ impl SharedCatloopLibOS {
         let coroutine_constructor = || -> Result<QToken, Fail> {
             let task_name: String = format!("Catloop::close for qd={:?}", qd);
             let coroutine_factory =
-                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().close_coroutine(qd, yielder)) };
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().close_coroutine(qd, yielder).fuse()) };
             self.runtime
                 .clone()
                 .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
@@ -368,7 +371,7 @@ impl SharedCatloopLibOS {
         let coroutine_constructor = || -> Result<QToken, Fail> {
             let task_name: String = format!("Catloop::push for qd={:?}", qd);
             let coroutine_factory =
-                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().push_coroutine(qd, buf, yielder)) };
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().push_coroutine(qd, buf, yielder).fuse()) };
             self.runtime
                 .clone()
                 .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
@@ -410,7 +413,7 @@ impl SharedCatloopLibOS {
         let coroutine_constructor = || -> Result<QToken, Fail> {
             let task_name: String = format!("Catloop::pop for qd={:?}", qd);
             let coroutine_factory =
-                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().pop_coroutine(qd, size, yielder)) };
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().pop_coroutine(qd, size, yielder).fuse()) };
             self.runtime
                 .clone()
                 .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)

--- a/src/rust/catmem/mod.rs
+++ b/src/rust/catmem/mod.rs
@@ -29,6 +29,7 @@ use crate::{
     QDesc,
     QToken,
 };
+use ::futures::FutureExt;
 use ::std::{
     ops::{
         Deref,
@@ -110,7 +111,7 @@ impl SharedCatmemLibOS {
         let coroutine_constructor = || -> Result<QToken, Fail> {
             let task_name: String = format!("Catmem::async_close for qd={:?}", qd);
             let coroutine_factory =
-                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().close_coroutine(qd, yielder)) };
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().close_coroutine(qd, yielder).fuse()) };
             self.runtime
                 .clone()
                 .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
@@ -162,7 +163,7 @@ impl SharedCatmemLibOS {
 
         let task_name: String = format!("Catmem::push for qd={:?}", qd);
         let coroutine_factory =
-            |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().push_coroutine(qd, buf, yielder)) };
+            |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().push_coroutine(qd, buf, yielder).fuse()) };
 
         self.runtime
             .clone()
@@ -191,7 +192,7 @@ impl SharedCatmemLibOS {
 
         let task_name: String = format!("Catmem::pop for qd={:?}", qd);
         let coroutine_factory =
-            |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().pop_coroutine(qd, size, yielder)) };
+            |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().pop_coroutine(qd, size, yielder).fuse()) };
 
         self.runtime
             .clone()

--- a/src/rust/catnap/linux/transport.rs
+++ b/src/rust/catnap/linux/transport.rs
@@ -22,6 +22,7 @@ use crate::{
         SharedObject,
     },
 };
+use ::futures::FutureExt;
 use ::slab::Slab;
 use ::socket2::{
     Domain,
@@ -391,7 +392,7 @@ impl SharedCatnapTransport {
         runtime
             .insert_background_coroutine(
                 "catnap::transport::epoll",
-                Box::pin(async move { me2.poll(yielder).await }),
+                Box::pin(async move { me2.poll(yielder).await }.fuse()),
             )
             .expect("should be able to insert background coroutine");
         me

--- a/src/rust/catnap/win/transport.rs
+++ b/src/rust/catnap/win/transport.rs
@@ -52,6 +52,7 @@ use crate::{
         SharedObject,
     },
 };
+use ::futures::FutureExt;
 
 //======================================================================================================================
 // Structures
@@ -109,7 +110,7 @@ impl SharedCatnapTransport {
                 "catnap::transport::epoll",
                 Box::pin({
                     let mut me: Self = me.clone();
-                    async move { me.run_event_processor().await }
+                    async move { me.run_event_processor().await }.fuse()
                 }),
             )
             .expect("should be able to insert background coroutine");

--- a/src/rust/demikernel/libos/network/libos.rs
+++ b/src/rust/demikernel/libos/network/libos.rs
@@ -35,6 +35,7 @@ use crate::{
     },
     QType,
 };
+use ::futures::FutureExt;
 use ::socket2::{
     Domain,
     Protocol,
@@ -194,7 +195,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
         let coroutine_constructor = || -> Result<QToken, Fail> {
             let task_name: String = format!("NetworkLibOS::accept for qd={:?}", qd);
             let coroutine_factory =
-                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().accept_coroutine(qd, yielder)) };
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().accept_coroutine(qd, yielder).fuse()) };
             self.runtime
                 .clone()
                 .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
@@ -247,8 +248,9 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
         let mut queue: SharedNetworkQueue<T> = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<QToken, Fail> {
             let task_name: String = format!("NetworkLibOS::connect for qd={:?}", qd);
-            let coroutine_factory =
-                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().connect_coroutine(qd, remote, yielder)) };
+            let coroutine_factory = |yielder| -> Pin<Box<Operation>> {
+                Box::pin(self.clone().connect_coroutine(qd, remote, yielder).fuse())
+            };
             self.runtime
                 .clone()
                 .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
@@ -290,7 +292,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
         let coroutine_constructor = || -> Result<QToken, Fail> {
             let task_name: String = format!("NetworkLibOS::close for qd={:?}", qd);
             let coroutine_factory =
-                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().close_coroutine(qd, yielder)) };
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().close_coroutine(qd, yielder).fuse()) };
             self.runtime
                 .clone()
                 .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
@@ -361,7 +363,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
         let coroutine_constructor = || -> Result<QToken, Fail> {
             let task_name: String = format!("NetworkLibOS::push for qd={:?}", qd);
             let coroutine_factory =
-                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().push_coroutine(qd, buf, yielder)) };
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().push_coroutine(qd, buf, yielder).fuse()) };
             self.runtime
                 .clone()
                 .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
@@ -405,8 +407,9 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
         let mut queue: SharedNetworkQueue<T> = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<QToken, Fail> {
             let task_name: String = format!("NetworkLibOS::pushto for qd={:?}", qd);
-            let coroutine_factory =
-                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().pushto_coroutine(qd, buf, remote, yielder)) };
+            let coroutine_factory = |yielder| -> Pin<Box<Operation>> {
+                Box::pin(self.clone().pushto_coroutine(qd, buf, remote, yielder).fuse())
+            };
             self.runtime
                 .clone()
                 .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)
@@ -455,7 +458,7 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
         let coroutine_constructor = || -> Result<QToken, Fail> {
             let task_name: String = format!("NetworkLibOS::pop for qd={:?}", qd);
             let coroutine_factory =
-                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().pop_coroutine(qd, size, yielder)) };
+                |yielder| -> Pin<Box<Operation>> { Box::pin(self.clone().pop_coroutine(qd, size, yielder).fuse()) };
             self.runtime
                 .clone()
                 .insert_coroutine_with_tracking(&task_name, coroutine_factory, qd)

--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -46,6 +46,7 @@ use ::std::{
     time::Duration,
 };
 
+use ::futures::FutureExt;
 use ::std::{
     fmt::Debug,
     net::{
@@ -144,7 +145,7 @@ impl<N: NetworkRuntime> SharedInetStack<N> {
         }));
         let yielder: Yielder = Yielder::new();
         let background_task: String = format!("inetstack::poll_recv");
-        runtime.insert_background_coroutine(&background_task, Box::pin(me.clone().poll(yielder)))?;
+        runtime.insert_background_coroutine(&background_task, Box::pin(me.clone().poll(yielder).fuse()))?;
         Ok(me)
     }
 

--- a/src/rust/inetstack/protocols/arp/peer.rs
+++ b/src/rust/inetstack/protocols/arp/peer.rs
@@ -110,7 +110,7 @@ impl<N: NetworkRuntime> SharedArpPeer<N> {
             recv_queue: AsyncQueue::<DemiBuffer>::default(),
         }));
         // This is a future returned by the async function.
-        runtime.insert_background_coroutine("Inetstack::arp::background", Box::pin(peer.clone().poll()))?;
+        runtime.insert_background_coroutine("Inetstack::arp::background", Box::pin(peer.clone().poll().fuse()))?;
         Ok(peer.clone())
     }
 

--- a/src/rust/inetstack/protocols/icmpv4/peer.rs
+++ b/src/rust/inetstack/protocols/icmpv4/peer.rs
@@ -128,7 +128,10 @@ impl<N: NetworkRuntime> SharedIcmpv4Peer<N> {
             yielder_handle: yielder.get_handle(),
             inflight: HashMap::<(u16, u16), AsyncValue<Result<(), Fail>>>::new(),
         }));
-        runtime.insert_background_coroutine("Inetstack::ICMP::background", Box::pin(peer.clone().poll(yielder)))?;
+        runtime.insert_background_coroutine(
+            "Inetstack::ICMP::background",
+            Box::pin(peer.clone().poll(yielder).fuse()),
+        )?;
         Ok(peer)
     }
 

--- a/src/rust/inetstack/protocols/tcp/established/mod.rs
+++ b/src/rust/inetstack/protocols/tcp/established/mod.rs
@@ -35,7 +35,10 @@ use crate::{
     },
     QToken,
 };
-use ::futures::channel::mpsc;
+use ::futures::{
+    channel::mpsc,
+    FutureExt,
+};
 use ::std::{
     net::SocketAddrV4,
     time::Duration,
@@ -101,7 +104,7 @@ impl<N: NetworkRuntime> EstablishedSocket<N> {
         );
         let qt: QToken = runtime.insert_background_coroutine(
             "Inetstack::TCP::established::background",
-            Box::pin(background::background(cb.clone(), dead_socket_tx)),
+            Box::pin(background::background(cb.clone(), dead_socket_tx).fuse()),
         )?;
         Ok(Self {
             cb,

--- a/src/rust/inetstack/protocols/tcp/passive_open.rs
+++ b/src/rust/inetstack/protocols/tcp/passive_open.rs
@@ -131,8 +131,8 @@ impl<N: NetworkRuntime> SharedPassiveSocket<N> {
             yielder_handle: yielder.get_handle(),
             background_task_qt: None,
         }));
-        let qt: QToken =
-            runtime.insert_background_coroutine("passive_listening::poll", Box::pin(me.clone().poll(yielder)))?;
+        let qt: QToken = runtime
+            .insert_background_coroutine("passive_listening::poll", Box::pin(me.clone().poll(yielder).fuse()))?;
         me.background_task_qt = Some(qt);
         Ok(me)
     }
@@ -211,15 +211,18 @@ impl<N: NetworkRuntime> SharedPassiveSocket<N> {
         let recv_queue: SharedAsyncQueue<(Ipv4Header, TcpHeader, DemiBuffer)> =
             SharedAsyncQueue::<(Ipv4Header, TcpHeader, DemiBuffer)>::default();
         let ack_queue: SharedAsyncQueue<usize> = SharedAsyncQueue::<usize>::default();
-        let future = self.clone().send_syn_ack_and_wait_for_ack(
-            remote,
-            remote_isn,
-            local_isn,
-            tcp_hdr,
-            recv_queue.clone(),
-            ack_queue,
-            yielder,
-        );
+        let future = self
+            .clone()
+            .send_syn_ack_and_wait_for_ack(
+                remote,
+                remote_isn,
+                local_isn,
+                tcp_hdr,
+                recv_queue.clone(),
+                ack_queue,
+                yielder,
+            )
+            .fuse();
         match self
             .runtime
             .insert_background_coroutine("Inetstack::TCP::passiveopen::background", Box::pin(future))

--- a/src/rust/runtime/queue/mod.rs
+++ b/src/rust/runtime/queue/mod.rs
@@ -14,13 +14,13 @@ use crate::runtime::{
     fail::Fail,
     scheduler::TaskWithResult,
 };
+use ::futures::future::FusedFuture;
 use ::slab::{
     Iter,
     Slab,
 };
 use ::std::{
     any::Any,
-    future::Future,
     net::SocketAddrV4,
 };
 
@@ -36,7 +36,7 @@ pub use self::{
 };
 
 // Coroutine for running an operation on an I/O Queue.
-pub type Operation = dyn Future<Output = (QDesc, OperationResult)>;
+pub type Operation = dyn FusedFuture<Output = (QDesc, OperationResult)>;
 // Task for running I/O operations
 pub type OperationTask = TaskWithResult<(QDesc, OperationResult)>;
 /// Background coroutines never return so they do not need a [ResultType].


### PR DESCRIPTION
This PR moves the scheduler and tasks to using FusedFutures instead of the basic Futures. Our scheduler notes the first time that a Task returns Ready and marks it as completed and never schedules it again. So if the future is not fused, it'll still never get polled again. [See this line of code](https://github.com/microsoft/demikernel/blob/647d0200e3266196d6adbedac703e7b79e198723/src/rust/runtime/scheduler/page/page.rs#L60).

Furthermore, our TaskWithResult type will have stored the output of the coroutine and will never invoke it again.[See here](https://github.com/microsoft/demikernel/blob/647d0200e3266196d6adbedac703e7b79e198723/src/rust/runtime/scheduler/task.rs#L101).

Thus, we should use FusedFutures to enforce that none of the futures that our scheduler operate on are able to run again after the first time the future returns Ready. 