### PR TITLE
[collections] Enhancement: External to internal ID map

### DIFF
--- a/src/rust/collections/id_map.rs
+++ b/src/rust/collections/id_map.rs
@@ -21,7 +21,13 @@ use ::std::{
 //======================================================================================================================
 
 /// This flag controls whether we actually use a mapping or just directly expose internal IDs.
+/// We use a mapping for debug builds to ensure there is no reliance on internal identifiers, then remove that for
+/// release builds
+#[cfg(debug_assertions)]
 const DIRECT_MAPPING: bool = false;
+#[cfg(not(debug_assertions))]
+const DIRECT_MAPPING: bool = true;
+
 /// Seed for the random number generator used to generate tokens.
 /// This value was chosen arbitrarily.
 #[cfg(debug_assertions)]

--- a/src/rust/collections/id_map.rs
+++ b/src/rust/collections/id_map.rs
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use ::rand::{
+    rngs::SmallRng,
+    RngCore,
+    SeedableRng,
+};
+use ::std::{
+    collections::HashMap,
+    convert::From,
+    hash::Hash,
+};
+
+//======================================================================================================================
+// Constants
+//======================================================================================================================
+
+/// This flag controls whether we actually use a mapping or just directly expose internal IDs.
+const DIRECT_MAPPING: bool = false;
+/// Seed for the random number generator used to generate tokens.
+/// This value was chosen arbitrarily.
+#[cfg(debug_assertions)]
+const SCHEDULER_SEED: u64 = 42;
+const MAX_RETRIES_ID_ALLOC: usize = 500;
+
+//======================================================================================================================
+// Structures
+//======================================================================================================================
+
+/// This data structure is a general-purpose map for obfuscating ids from external modules. It takes an external id type
+/// and an internal id type and translates between the two. The ID types must be basic types that can be converted back
+/// and forth between u64 and therefore each other.
+pub struct IdMap<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Copy> {
+    /// Map between external and internal ids.
+    ids: HashMap<E, I>,
+    /// Small random number generator for external ids.
+    rng: SmallRng,
+}
+
+//======================================================================================================================
+// Associate Functions
+//======================================================================================================================
+
+impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Copy> IdMap<E, I> {
+    /// Retrieve a mapping for this external id if it exists. If we are using a direct mapping, this operation always
+    /// succeeds, so DO NOT use this function to check for the existance of a particular key. We expect the user to use
+    /// nother data structure for validity.
+    pub fn get(&self, external_id: &E) -> Option<I> {
+        // If we are not obfuscating ids, just return the external id.
+        if DIRECT_MAPPING {
+            Some(<E as Into<u64>>::into(*external_id).into())
+        } else {
+            self.ids.get(external_id).copied()
+        }
+    }
+
+    #[allow(dead_code)]
+    /// Insert a mapping between a specified external and internal id. If we are using a direct mapping,
+    /// then this is a no op.
+    pub fn insert(&mut self, external_id: E, internal_id: I) -> Option<I> {
+        if !DIRECT_MAPPING {
+            self.ids.insert(external_id, internal_id)
+        } else {
+            None
+        }
+    }
+
+    /// Remove a mapping between a specificed external and internal id. If the mapping exists, then return the internal
+    /// id mapped to the external id. If we are using a direct mapping, then this is a no op.
+    pub fn remove(&mut self, external_id: &E) -> Option<I> {
+        if !DIRECT_MAPPING {
+            self.ids.remove(external_id)
+        } else {
+            None
+        }
+    }
+
+    /// Generate a new id and insert the mapping to the internal id. If the id is currently in use, keep generating
+    /// until we find an unused id (up to a maximum number of tries). If we are using a direct mapping, then just
+    /// return the internal id without generating a new id or inserting a mapping.
+    pub fn insert_with_new_id(&mut self, internal_id: I) -> E {
+        // If we are not obfuscating ids, just return the external id.
+        if DIRECT_MAPPING {
+            return E::from(internal_id.into());
+        }
+
+        // Otherwise, allocate a new external id.
+        for _ in 0..MAX_RETRIES_ID_ALLOC {
+            let external_id: E = E::from(self.rng.next_u64());
+            if !self.ids.contains_key(&external_id) {
+                self.ids.insert(external_id, internal_id);
+                return external_id;
+            }
+        }
+        panic!("Could not find a valid task id");
+    }
+}
+
+//======================================================================================================================
+// Trait Implementations
+//======================================================================================================================
+
+/// A default implementation for the external to internal id map.
+impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Copy> Default for IdMap<E, I> {
+    fn default() -> Self {
+        Self {
+            ids: HashMap::<E, I>::default(),
+            #[cfg(debug_assertions)]
+            rng: SmallRng::seed_from_u64(SCHEDULER_SEED),
+            #[cfg(not(debug_assertions))]
+            rng: SmallRng::from_entropy(),
+        }
+    }
+}

--- a/src/rust/collections/mod.rs
+++ b/src/rust/collections/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod async_queue;
 pub mod async_value;
+pub mod id_map;
 pub mod intrusive;
 pub mod pin_slab;
 

--- a/src/rust/runtime/queue/qtoken.rs
+++ b/src/rust/runtime/queue/qtoken.rs
@@ -2,6 +2,12 @@
 // Licensed under the MIT license.
 
 //==============================================================================
+// Imports
+//==============================================================================
+
+use crate::runtime::scheduler::scheduler::ExternalId;
+
+//==============================================================================
 // Structures
 //==============================================================================
 
@@ -26,5 +32,18 @@ impl From<QToken> for u64 {
     /// Converts a [QToken] to a [u64].
     fn from(value: QToken) -> Self {
         value.0
+    }
+}
+
+/// This converts a QToken to an external identifier specifically for our scheduler.
+impl From<ExternalId> for QToken {
+    fn from(value: ExternalId) -> Self {
+        QToken(value.into())
+    }
+}
+
+impl From<QToken> for ExternalId {
+    fn from(value: QToken) -> Self {
+        ExternalId(value.into())
     }
 }

--- a/src/rust/runtime/scheduler/scheduler.rs
+++ b/src/rust/runtime/scheduler/scheduler.rs
@@ -41,12 +41,6 @@ use ::std::{
 };
 
 //======================================================================================================================
-// Constants
-//======================================================================================================================
-
-const MAX_NUM_TASKS: usize = 16000;
-
-//======================================================================================================================
 // Structures
 //======================================================================================================================
 
@@ -104,8 +98,6 @@ impl Scheduler {
 
     /// Insert a new task into our scheduler returning a handle corresponding to it.
     pub fn insert<F: Task>(&mut self, future: F) -> Option<ExternalId> {
-        self.panic_if_too_many_tasks();
-
         let task_name: String = future.get_name();
         // The pin slab index can be reverse-computed in a page index and an offset within the page.
         let pin_slab_index: InternalId = self.tasks.insert(Box::new(future))?.into();
@@ -129,14 +121,6 @@ impl Scheduler {
 
         self.total_num_tasks += 1;
         Some(task_id)
-    }
-
-    /// If the address space for task ids is close to half full, it will become increasingly difficult to avoid
-    /// collisions, so we cap the number of tasks.
-    fn panic_if_too_many_tasks(&self) {
-        if self.total_num_tasks > MAX_NUM_TASKS {
-            panic!("Too many concurrent tasks");
-        }
     }
 
     /// Computes the page and page offset of a given task based on its total offset.


### PR DESCRIPTION
This PR adds a new data structure that is explicitly for us to enforce ID translations between internal data structures and external ones. Generally this takes the form of translating from something that we may hand to the application (e.g., a queue token) to an internal representation (e.g., an offset into a slab). Since slab offsets are often allocated sequentially, we do not want external applications or even the libOSes to depends on their specific characteristics. 

To deal with this, we introduce an IdMap data structure. It is explicitly used for translating between external and internal identifiers. On debug builds, this data structure randomly generates IDs and uses a hash map to map external to internal identifiers to enforce that there are no weird dependencies on IDs. On release builds, we discard the map and directly use the internal identifier.

Currently, I'm using a simple flag to perform this switch because it seemed easier to read and the compiler will remove the unused code but we could use more explicit compiler blocks later.

These results are from running the benchmark_insert() test from scheduler.rs
| | Debug | Release|
|----|-----|----|
|Indirection|1228 ns|311 ns|
|Direct Mapping|408 ns|141 ns|

This PR also removes the limitation on the number of coroutines that we can schedule since we have completely moved to 64-bit identifiers, there should be no issues with collisions.