### PR TITLE
[collections] Enhancement: External to internal ID map

### DIFF
--- a/src/rust/catnap/win/overlapped.rs
+++ b/src/rust/catnap/win/overlapped.rs
@@ -404,6 +404,7 @@ mod tests {
     use crate::{
         ensure_eq,
         runtime::scheduler::{
+            scheduler::TaskId,
             Scheduler,
             TaskWithResult,
         },
@@ -672,7 +673,7 @@ mod tests {
         );
 
         let mut scheduler: Scheduler = Scheduler::default();
-        let server_handle: u64 = scheduler
+        let server_handle: TaskId = scheduler
             .insert(TaskWithResult::<Result<(), Fail>>::new("server".into(), server))
             .unwrap();
 
@@ -784,7 +785,7 @@ mod tests {
         );
 
         let mut scheduler: Scheduler = Scheduler::default();
-        let server_handle: u64 = scheduler
+        let server_handle: TaskId = scheduler
             .insert(TaskWithResult::<Result<(), Fail>>::new("server".into(), server))
             .unwrap();
 

--- a/src/rust/collections/id_map.rs
+++ b/src/rust/collections/id_map.rs
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+//======================================================================================================================
+// Imports
+//======================================================================================================================
+
+use ::rand::{
+    rngs::SmallRng,
+    RngCore,
+    SeedableRng,
+};
+use ::std::{
+    collections::HashMap,
+    convert::From,
+    hash::Hash,
+};
+
+//======================================================================================================================
+// Constants
+//======================================================================================================================
+
+/// Performance note: These two flags were benchmarked with the scheduler insert benchmark on a
+/// release build and have the following impact on performance. The number is the average of 5 runs of the test and
+/// performed on an Azure Standard D16ds v4 (16 vcpus, 64 GiB memory) VM running Linux (ubuntu 22.04).
+/// Direct vs indirect mapping: 152 for direct, indirect is below.
+/// Randomize vs non random: 332ns vs 154ns
+
+/// This flag controls whether we actually use a mapping or just directly expose internal IDs.
+/// We should eventually set this using an environment variable.
+const DIRECT_MAPPING: bool = false;
+/// This flag controls how the ids are allocated, either randomly or in a Fibonacci sequence.
+#[cfg(debug_assertions)]
+const RANDOMIZE: bool = true;
+#[cfg(not(debug_assertions))]
+const RANDOMIZE: bool = false;
+
+/// Arbitrary size chosen to pre-allocate the hashmap. This improves performance by 6ns on average on our scheduler
+/// insert benchmark.
+const DEFAULT_SIZE: usize = 1024;
+
+/// Seed for the random number generator used to generate tokens.
+/// This value was chosen arbitrarily.
+const SCHEDULER_SEED: u64 = 42;
+const MAX_RETRIES_ID_ALLOC: usize = 500;
+
+//======================================================================================================================
+// Structures
+//======================================================================================================================
+
+/// This data structure is a general-purpose map for obfuscating ids from external modules. It takes an external id type
+/// and an internal id type and translates between the two. The ID types must be basic types that can be converted back
+/// and forth between u64 and therefore each other.
+pub struct IdMap<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Copy> {
+    /// Map between external and internal ids.
+    ids: HashMap<E, I>,
+    /// Small random number generator for external ids.
+    rng: SmallRng,
+    last_id: u64,
+    current_id: u64,
+}
+
+//======================================================================================================================
+// Associate Functions
+//======================================================================================================================
+
+impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Copy> IdMap<E, I> {
+    /// Retrieve a mapping for this external id if it exists. If we are using a direct mapping, this operation always
+    /// succeeds, so DO NOT use this function to check for the existance of a particular key. We expect the user to use
+    /// nother data structure for validity.
+    pub fn get(&self, external_id: &E) -> Option<I> {
+        // If we are not obfuscating ids, just return the external id.
+        if DIRECT_MAPPING {
+            Some(<E as Into<u64>>::into(*external_id).into())
+        } else {
+            self.ids.get(external_id).copied()
+        }
+    }
+
+    #[allow(dead_code)]
+    /// Insert a mapping between a specified external and internal id. If we are using a direct mapping,
+    /// then this is a no op.
+    pub fn insert(&mut self, external_id: E, internal_id: I) -> Option<I> {
+        if DIRECT_MAPPING {
+            None
+        } else {
+            self.ids.insert(external_id, internal_id)
+        }
+    }
+
+    /// Remove a mapping between a specificed external and internal id. If the mapping exists, then return the internal
+    /// id mapped to the external id. If we are using a direct mapping, then this is a no op.
+    pub fn remove(&mut self, external_id: &E) -> Option<I> {
+        if DIRECT_MAPPING {
+            Some(<E as Into<u64>>::into(*external_id).into())
+        } else {
+            self.ids.remove(external_id)
+        }
+    }
+
+    /// Generate a new id and insert the mapping to the internal id. If the id is currently in use, keep generating
+    /// until we find an unused id (up to a maximum number of tries). If we are using a direct mapping, then just
+    /// return the internal id without generating a new id or inserting a mapping.
+    pub fn insert_with_new_id(&mut self, internal_id: I) -> E {
+        // If we are not obfuscating ids, just return the external id.
+        if DIRECT_MAPPING {
+            return E::from(internal_id.into());
+        }
+
+        if RANDOMIZE {
+            // Otherwise, allocate a new external id.
+            for _ in 0..MAX_RETRIES_ID_ALLOC {
+                let external_id: E = E::from(self.rng.next_u64());
+                if !self.ids.contains_key(&external_id) {
+                    self.ids.insert(external_id, internal_id);
+                    return external_id;
+                }
+            }
+            panic!("Could not find a valid task id");
+        } else {
+            // Use a Fibonacci sequence.
+            let id: u64 = self.current_id;
+            // Roll around.
+            self.current_id = if self.current_id < u64::MAX - self.last_id {
+                self.current_id + self.last_id
+            } else {
+                self.last_id - (u64::MAX - self.current_id)
+            };
+            self.last_id = id;
+            let external_id: E = E::from(id);
+            if self.ids.insert(external_id, internal_id).is_some() {
+                panic!("Should not have a previous task with this id");
+            }
+            external_id
+        }
+    }
+}
+
+//======================================================================================================================
+// Trait Implementations
+//======================================================================================================================
+
+/// A default implementation for the external to internal id map.
+impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Copy> Default for IdMap<E, I> {
+    fn default() -> Self {
+        Self {
+            // Don't need to pre-allocate, the overhead is a 6ns on the scheduler insert benchmark.
+            ids: HashMap::<E, I>::with_capacity(DEFAULT_SIZE),
+            rng: SmallRng::seed_from_u64(SCHEDULER_SEED),
+            last_id: 1,
+            current_id: 2,
+        }
+    }
+}

--- a/src/rust/collections/id_map.rs
+++ b/src/rust/collections/id_map.rs
@@ -59,6 +59,7 @@ pub struct IdMap<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Int
     /// For non-random id generation, we keep the last 2 id numbers for a Fibonacci calculation.
     last_id: u64,
     current_id: u64,
+    #[cfg(test)]
     /// For direct mapping, we keep track of the total number of mappings with a counter.
     num_mappings: usize,
 }
@@ -85,7 +86,10 @@ impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Cop
     /// then this is a no op.
     pub fn insert(&mut self, external_id: E, internal_id: I) -> Option<I> {
         if DIRECT_MAPPING {
-            self.num_mappings = self.num_mappings + 1;
+            #[cfg(test)]
+            {
+                self.num_mappings = self.num_mappings + 1;
+            }
             None
         } else {
             self.ids.insert(external_id, internal_id)
@@ -96,7 +100,10 @@ impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Cop
     /// id mapped to the external id. If we are using a direct mapping, then this is a no op.
     pub fn remove(&mut self, external_id: &E) -> Option<I> {
         if DIRECT_MAPPING {
-            self.num_mappings = self.num_mappings - 1;
+            #[cfg(test)]
+            {
+                self.num_mappings = self.num_mappings - 1;
+            }
             Some(<E as Into<u64>>::into(*external_id).into())
         } else {
             self.ids.remove(external_id)
@@ -163,6 +170,7 @@ impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Cop
             rng: SmallRng::seed_from_u64(SCHEDULER_SEED),
             last_id: 1,
             current_id: 2,
+            #[cfg(test)]
             num_mappings: 0,
         }
     }

--- a/src/rust/collections/id_map.rs
+++ b/src/rust/collections/id_map.rs
@@ -56,8 +56,11 @@ pub struct IdMap<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Int
     ids: HashMap<E, I>,
     /// Small random number generator for external ids.
     rng: SmallRng,
+    /// For non-random id generation, we keep the last 2 id numbers for a Fibonacci calculation.
     last_id: u64,
     current_id: u64,
+    /// For direct mapping, we keep track of the total number of mappings with a counter.
+    num_mappings: usize,
 }
 
 //======================================================================================================================
@@ -82,6 +85,7 @@ impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Cop
     /// then this is a no op.
     pub fn insert(&mut self, external_id: E, internal_id: I) -> Option<I> {
         if DIRECT_MAPPING {
+            self.num_mappings = self.num_mappings + 1;
             None
         } else {
             self.ids.insert(external_id, internal_id)
@@ -92,6 +96,7 @@ impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Cop
     /// id mapped to the external id. If we are using a direct mapping, then this is a no op.
     pub fn remove(&mut self, external_id: &E) -> Option<I> {
         if DIRECT_MAPPING {
+            self.num_mappings = self.num_mappings - 1;
             Some(<E as Into<u64>>::into(*external_id).into())
         } else {
             self.ids.remove(external_id)
@@ -134,6 +139,15 @@ impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Cop
             external_id
         }
     }
+
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        if DIRECT_MAPPING {
+            self.num_mappings
+        } else {
+            self.ids.len()
+        }
+    }
 }
 
 //======================================================================================================================
@@ -149,6 +163,7 @@ impl<E: Eq + Hash + From<u64> + Into<u64> + Copy, I: From<u64> + Into<u64> + Cop
             rng: SmallRng::seed_from_u64(SCHEDULER_SEED),
             last_id: 1,
             current_id: 2,
+            num_mappings: 0,
         }
     }
 }

--- a/src/rust/collections/mod.rs
+++ b/src/rust/collections/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod async_queue;
 pub mod async_value;
+pub mod id_map;
 pub mod intrusive;
 pub mod pin_slab;
 

--- a/src/rust/collections/pin_slab.rs
+++ b/src/rust/collections/pin_slab.rs
@@ -99,7 +99,7 @@ impl<T> PinSlab<T> {
     /// Checks whether the given slot is occupied.
     pub fn contains(&self, key: usize) -> bool {
         // We are just using this to check the existance of an entry in this slot or not.
-        unsafe { self.internal_get(key).is_some() }
+        self.internal_get(key).is_some()
     }
 
     /// Insert a value into the pin slab.
@@ -122,7 +122,7 @@ impl<T> PinSlab<T> {
 
     /// Get a reference to the value at the given slot.
     #[inline(always)]
-    unsafe fn internal_get(&self, key: usize) -> Option<&T> {
+    fn internal_get(&self, key: usize) -> Option<&T> {
         let (slot, offset, len): (usize, usize, usize) = calculate_key(key)?;
         let slot: NonNull<Entry<T>> = *self.slots.get(slot)?;
 
@@ -131,7 +131,7 @@ impl<T> PinSlab<T> {
         // initialized entries assuming offset < len.
         debug_assert!(offset < len);
 
-        let entry: &T = match &*slot.as_ptr().add(offset) {
+        let entry: &T = match unsafe { &*slot.as_ptr().add(offset) } {
             Entry::Occupied(entry) => entry,
             _ => return None,
         };
@@ -141,7 +141,7 @@ impl<T> PinSlab<T> {
 
     /// Get a mutable reference to the value at the given slot.
     #[inline(always)]
-    unsafe fn internal_get_mut(&mut self, key: usize) -> Option<&mut T> {
+    fn internal_get_mut(&mut self, key: usize) -> Option<&mut T> {
         let (slot, offset, len): (usize, usize, usize) = calculate_key(key)?;
         let slot: NonNull<Entry<T>> = *self.slots.get_mut(slot)?;
 
@@ -150,7 +150,7 @@ impl<T> PinSlab<T> {
         // initialized entries assuming offset < len.
         debug_assert!(offset < len);
 
-        let entry: &mut T = match &mut *slot.as_ptr().add(offset) {
+        let entry: &mut T = match unsafe { &mut *slot.as_ptr().add(offset) } {
             Entry::Occupied(entry) => entry,
             _ => return None,
         };

--- a/src/rust/runtime/queue/qtoken.rs
+++ b/src/rust/runtime/queue/qtoken.rs
@@ -2,6 +2,12 @@
 // Licensed under the MIT license.
 
 //==============================================================================
+// Imports
+//==============================================================================
+
+use crate::runtime::scheduler::scheduler::TaskId;
+
+//==============================================================================
 // Structures
 //==============================================================================
 
@@ -26,5 +32,18 @@ impl From<QToken> for u64 {
     /// Converts a [QToken] to a [u64].
     fn from(value: QToken) -> Self {
         value.0
+    }
+}
+
+/// This converts a QToken to an external identifier specifically for our scheduler.
+impl From<TaskId> for QToken {
+    fn from(value: TaskId) -> Self {
+        QToken(value.into())
+    }
+}
+
+impl From<QToken> for TaskId {
+    fn from(value: QToken) -> Self {
+        TaskId(value.into())
     }
 }

--- a/src/rust/runtime/scheduler/scheduler.rs
+++ b/src/rust/runtime/scheduler/scheduler.rs
@@ -12,7 +12,10 @@
 //======================================================================================================================
 
 use crate::{
-    collections::pin_slab::PinSlab,
+    collections::{
+        id_map::IdMap,
+        pin_slab::PinSlab,
+    },
     runtime::scheduler::{
         page::{
             WakerPageRef,
@@ -26,13 +29,7 @@ use crate::{
     },
 };
 use ::bit_iter::BitIter;
-use ::rand::{
-    rngs::SmallRng,
-    RngCore,
-    SeedableRng,
-};
 use ::std::{
-    collections::HashMap,
     future::Future,
     pin::Pin,
     ptr::NonNull,
@@ -44,30 +41,23 @@ use ::std::{
 };
 
 //======================================================================================================================
-// Constants
-//======================================================================================================================
-
-/// Seed for the random number generator used to generate tokens.
-/// This value was chosen arbitrarily.
-#[cfg(debug_assertions)]
-const SCHEDULER_SEED: u64 = 42;
-const MAX_NUM_TASKS: usize = 16000;
-const MAX_RETRIES_TASK_ID_ALLOC: usize = 500;
-
-//======================================================================================================================
 // Structures
 //======================================================================================================================
 
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug)]
+pub struct TaskId(pub u64);
+#[derive(Clone, Copy, Debug)]
+struct InternalId(usize);
+
 /// Task Scheduler
 pub struct Scheduler {
+    task_ids: IdMap<TaskId, InternalId>,
     /// Stores all the tasks that are held by the scheduler.
     tasks: PinSlab<Box<dyn Task>>,
-    /// Maps between externally meaningful ids and the index of the task in the slab.
-    task_ids: HashMap<u64, usize>,
     /// Holds the waker bits for controlling task scheduling.
     waker_page_refs: Vec<WakerPageRef>,
-    /// Small random number generator for tokens.
-    rng: SmallRng,
+    /// Holds the total number of running tasks.
+    total_num_tasks: usize,
 }
 
 //======================================================================================================================
@@ -77,24 +67,25 @@ pub struct Scheduler {
 /// Associate Functions for Scheduler
 impl Scheduler {
     /// Given a handle to a task, remove it from the scheduler
-    pub fn remove(&mut self, task_id: u64) -> Option<Box<dyn Task>> {
+    pub fn remove(&mut self, task_id: TaskId) -> Option<Box<dyn Task>> {
         // We should not have a scheduler handle that refers to an invalid id, so unwrap and expect are safe here.
-        let pin_slab_index: usize = self
+        let pin_slab_index: InternalId = self
             .task_ids
             .remove(&task_id)
             .expect("Token should be in the token table");
         let (waker_page_ref, waker_page_offset): (&WakerPageRef, usize) = {
-            let (waker_page_index, waker_page_offset) = self.get_waker_page_index_and_offset(pin_slab_index);
+            let (waker_page_index, waker_page_offset) = self.get_waker_page_index_and_offset(pin_slab_index.into())?;
             (&self.waker_page_refs[waker_page_index], waker_page_offset)
         };
         waker_page_ref.clear(waker_page_offset);
-        if let Some(task) = self.tasks.remove_unpin(pin_slab_index) {
+        if let Some(task) = self.tasks.remove_unpin(pin_slab_index.into()) {
             trace!(
                 "remove(): name={:?}, id={:?}, pin_slab_index={:?}",
                 task.get_name(),
                 task_id,
                 pin_slab_index
             );
+            self.total_num_tasks = self.total_num_tasks - 1;
             Some(task)
         } else {
             warn!(
@@ -106,19 +97,17 @@ impl Scheduler {
     }
 
     /// Insert a new task into our scheduler returning a handle corresponding to it.
-    pub fn insert<F: Task>(&mut self, future: F) -> Option<u64> {
-        self.panic_if_too_many_tasks();
-
+    pub fn insert<F: Task>(&mut self, future: F) -> Option<TaskId> {
         let task_name: String = future.get_name();
         // The pin slab index can be reverse-computed in a page index and an offset within the page.
-        let pin_slab_index: usize = self.tasks.insert(Box::new(future))?;
-        let task_id: u64 = self.get_new_task_id(pin_slab_index);
+        let pin_slab_index: InternalId = self.tasks.insert(Box::new(future))?.into();
+        let task_id: TaskId = self.task_ids.insert_with_new_id(pin_slab_index);
 
-        self.add_new_pages_up_to_pin_slab_index(pin_slab_index);
+        self.add_new_pages_up_to_pin_slab_index(pin_slab_index.into());
 
         // Initialize the appropriate page offset.
         let (waker_page_ref, waker_page_offset): (&WakerPageRef, usize) = {
-            let (waker_page_index, waker_page_offset) = self.get_waker_page_index_and_offset(pin_slab_index);
+            let (waker_page_index, waker_page_offset) = self.get_waker_page_index_and_offset(pin_slab_index.into())?;
             (&self.waker_page_refs[waker_page_index], waker_page_offset)
         };
         waker_page_ref.initialize(waker_page_offset);
@@ -130,37 +119,18 @@ impl Scheduler {
             pin_slab_index
         );
 
+        self.total_num_tasks += 1;
         Some(task_id)
     }
 
-    /// Generate a new id. If the id is currently in use, keep generating until we find an unused id.
-    fn get_new_task_id(&mut self, pin_slab_index: usize) -> u64 {
-        let new_task_id: u64 = 'get_id: {
-            for _ in 0..MAX_RETRIES_TASK_ID_ALLOC {
-                let new_task_id: u64 = self.rng.next_u64() as u16 as u64;
-                if !self.task_ids.contains_key(&new_task_id) {
-                    self.task_ids.insert(new_task_id, pin_slab_index);
-                    break 'get_id new_task_id;
-                }
-            }
-            panic!("Could not find a valid task id");
-        };
-        new_task_id
-    }
-
-    /// If the address space for task ids is close to half full, it will become increasingly difficult to avoid
-    /// collisions, so we cap the number of tasks.
-    fn panic_if_too_many_tasks(&self) {
-        if self.task_ids.len() > MAX_NUM_TASKS {
-            panic!("Too many concurrent tasks");
-        }
-    }
-
     /// Computes the page and page offset of a given task based on its total offset.
-    fn get_waker_page_index_and_offset(&self, pin_slab_index: usize) -> (usize, usize) {
+    fn get_waker_page_index_and_offset(&self, pin_slab_index: usize) -> Option<(usize, usize)> {
+        if !self.tasks.contains(pin_slab_index) {
+            return None;
+        }
         let waker_page_index: usize = pin_slab_index >> WAKER_BIT_LENGTH_SHIFT;
         let waker_page_offset: usize = Scheduler::get_waker_page_offset(pin_slab_index);
-        (waker_page_index, waker_page_offset)
+        Some((waker_page_index, waker_page_offset))
     }
 
     /// Add new page(s) to hold this future's status if the current page is filled. This may result in addition of
@@ -229,13 +199,15 @@ impl Scheduler {
         (waker_page_index << WAKER_BIT_LENGTH_SHIFT) + waker_page_offset
     }
 
-    pub fn has_completed(&self, task_id: u64) -> Option<bool> {
-        let pin_slab_index: usize = match self.task_ids.get(&task_id) {
-            Some(pin_slab_index) => *pin_slab_index,
+    pub fn has_completed(&self, task_id: TaskId) -> Option<bool> {
+        let pin_slab_index: InternalId = match self.task_ids.get(&task_id) {
+            Some(pin_slab_index) => pin_slab_index,
             None => return None,
         };
+
+        // Add a check here for whether the index is valid.
         let (waker_page_ref, waker_page_offset) = {
-            let (waker_page_index, waker_page_offset) = self.get_waker_page_index_and_offset(pin_slab_index);
+            let (waker_page_index, waker_page_offset) = self.get_waker_page_index_and_offset(pin_slab_index.into())?;
             (&self.waker_page_refs[waker_page_index], waker_page_offset)
         };
 
@@ -252,14 +224,47 @@ impl Default for Scheduler {
     /// Creates a scheduler with default values.
     fn default() -> Self {
         Self {
+            task_ids: IdMap::<TaskId, InternalId>::default(),
             tasks: PinSlab::new(),
-            task_ids: HashMap::<u64, usize>::new(),
             waker_page_refs: vec![],
-            #[cfg(debug_assertions)]
-            rng: SmallRng::seed_from_u64(SCHEDULER_SEED),
-            #[cfg(not(debug_assertions))]
-            rng: SmallRng::from_entropy(),
+            total_num_tasks: 0,
         }
+    }
+}
+
+impl From<u64> for TaskId {
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl From<TaskId> for u64 {
+    fn from(value: TaskId) -> Self {
+        value.0
+    }
+}
+
+impl From<usize> for InternalId {
+    fn from(value: usize) -> Self {
+        Self(value)
+    }
+}
+
+impl From<InternalId> for usize {
+    fn from(value: InternalId) -> Self {
+        value.0
+    }
+}
+
+impl From<u64> for InternalId {
+    fn from(value: u64) -> Self {
+        Self(value as usize)
+    }
+}
+
+impl From<InternalId> for u64 {
+    fn from(value: InternalId) -> Self {
+        value.0 as u64
     }
 }
 
@@ -270,7 +275,10 @@ impl Default for Scheduler {
 #[cfg(test)]
 mod tests {
     use crate::runtime::scheduler::{
-        scheduler::Scheduler,
+        scheduler::{
+            Scheduler,
+            TaskId,
+        },
         task::TaskWithResult,
     };
     use ::anyhow::Result;
@@ -436,9 +444,9 @@ mod tests {
         let mut scheduler: Scheduler = Scheduler::default();
         // Arbitrarily large number.
         const NUM_TASKS: usize = 8192;
-        let mut task_ids: Vec<u64> = Vec::<u64>::with_capacity(NUM_TASKS);
+        let mut task_ids: Vec<TaskId> = Vec::<TaskId>::with_capacity(NUM_TASKS);
 
-        crate::ensure_eq!(true, scheduler.task_ids.is_empty());
+        crate::ensure_eq!(scheduler.total_num_tasks, 0);
 
         for val in 0..NUM_TASKS {
             let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(val).fuse()));
@@ -454,15 +462,23 @@ mod tests {
         // Remove tasks one by one and check if remove is only removing the task requested to be removed.
         let mut curr_num_tasks: usize = NUM_TASKS;
         for i in 0..NUM_TASKS {
-            let task_id: u64 = task_ids[i];
-            crate::ensure_eq!(true, scheduler.task_ids.contains_key(&task_id));
+            let task_id: TaskId = task_ids[i];
+            // The id map does not dictate whether the id is valid, so we need to check the task slab as well.
+            if let Some(internal_id) = scheduler.task_ids.get(&task_id) {
+                crate::ensure_eq!(true, scheduler.tasks.get_pin_mut(internal_id.into()).is_some());
+            } else {
+                anyhow::bail!("Could not find task");
+            }
             scheduler.remove(task_id);
             curr_num_tasks = curr_num_tasks - 1;
-            crate::ensure_eq!(scheduler.task_ids.len(), curr_num_tasks);
-            crate::ensure_eq!(false, scheduler.task_ids.contains_key(&task_id));
+            crate::ensure_eq!(scheduler.total_num_tasks, curr_num_tasks);
+            // The id map does not dictate whether the id is valid, so we need to check the task slab as well.
+            if let Some(internal_id) = scheduler.task_ids.get(&task_id) {
+                crate::ensure_eq!(false, scheduler.tasks.get_pin_mut(internal_id.into()).is_some());
+            }
         }
 
-        crate::ensure_eq!(scheduler.task_ids.is_empty(), true);
+        crate::ensure_eq!(scheduler.total_num_tasks, 0);
 
         Ok(())
     }
@@ -476,7 +492,7 @@ mod tests {
                 String::from("testing"),
                 Box::pin(black_box(DummyCoroutine::default().fuse())),
             );
-            let task_id: u64 = scheduler.insert(task).expect("couldn't insert future in scheduler");
+            let task_id: TaskId = scheduler.insert(task).expect("couldn't insert future in scheduler");
             black_box(task_id);
         });
     }
@@ -485,7 +501,7 @@ mod tests {
     fn benchmark_poll(b: &mut Bencher) {
         let mut scheduler: Scheduler = Scheduler::default();
         const NUM_TASKS: usize = 1024;
-        let mut task_ids: Vec<u64> = Vec::<u64>::with_capacity(NUM_TASKS);
+        let mut task_ids: Vec<TaskId> = Vec::<TaskId>::with_capacity(NUM_TASKS);
 
         for val in 0..NUM_TASKS {
             let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(val).fuse()));


### PR DESCRIPTION
This PR adds a new data structure that is explicitly for us to enforce ID translations between internal data structures and external ones. Generally this takes the form of translating from something that we may hand to the application (e.g., a queue token) to an internal representation (e.g., an offset into a slab). Since slab offsets are often allocated sequentially, we do not want external applications or even the libOSes to depends on their specific characteristics. 

To deal with this, we introduce an IdMap data structure. It is explicitly used for translating between external and internal identifiers. On debug builds, this data structure randomly generates IDs and uses a hash map to map external to internal identifiers to enforce that there are no weird dependencies on IDs. On release builds, we discard the map and directly use the internal identifier.

Currently, I'm using a simple flag to perform this switch because it seemed easier to read and the compiler will remove the unused code but we could use more explicit compiler blocks later.

These results are from running the benchmark_insert() test from scheduler.rs
| | Debug | Release|
|----|-----|----|
|Indirection|1228 ns|311 ns|
|Direct Mapping|408 ns|141 ns|

This PR also removes the limitation on the number of coroutines that we can schedule since we have completely moved to 64-bit identifiers, there should be no issues with collisions.