### PR TITLE
[runtime] `remove_coroutine()` Doesn't Remove Completed QTokens from Pending Ops

### DIFF
--- a/src/rust/inetstack/test_helpers/engine.rs
+++ b/src/rust/inetstack/test_helpers/engine.rs
@@ -163,7 +163,8 @@ impl SharedEngine {
         while !self.get_runtime().has_completed(qt)? {
             self.poll()
         }
-        Ok(self.get_runtime().remove_coroutine(qt).get_result().unwrap())
+        let (qd, result): (QDesc, OperationResult) = self.get_runtime().remove_coroutine(qt);
+        Ok((qd, result))
     }
 }
 

--- a/tests/rust/tcp.rs
+++ b/tests/rust/tcp.rs
@@ -682,7 +682,7 @@ fn tcp_bad_connect() -> Result<()> {
         let bad_remote: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port);
         let sockqd: QDesc = safe_socket(&mut libos)?;
         let qt: QToken = safe_connect(&mut libos, sockqd, bad_remote)?;
-        match libos.wait(qt, Duration::from_millis(10)) {
+        match libos.wait(qt, Some(Duration::from_millis(10))) {
             Err(e) if e.errno == libc::ETIMEDOUT => (),
             Ok((_, OperationResult::Connect)) => {
                 // Close socket if not error because this test cannot continue.
@@ -1152,7 +1152,7 @@ fn safe_push(libos: &mut DummyLibOS, sockqd: QDesc, bytes: demi_sgarray_t) -> Re
 
 /// Safe call to `wait2()`.
 fn safe_wait(libos: &mut DummyLibOS, qt: QToken) -> Result<(QDesc, OperationResult)> {
-    match libos.wait(qt, Duration::from_secs(1)) {
+    match libos.wait(qt, None) {
         Ok(result) => Ok(result),
         Err(e) => anyhow::bail!("wait failed: {:?}", e),
     }

--- a/tests/rust/udp.rs
+++ b/tests/rust/udp.rs
@@ -510,8 +510,6 @@ fn safe_wait(libos: &mut DummyLibOS, qt: QToken) -> Result<(QDesc, OperationResu
         libos.get_runtime().poll();
     }
 
-    match libos.get_runtime().remove_coroutine(qt).get_result() {
-        Some((qd, qr)) => Ok((qd, qr)),
-        None => unreachable!("coroutine should have a result if completed"),
-    }
+    let (qd, result): (QDesc, OperationResult) = libos.get_runtime().remove_coroutine(qt);
+    Ok((qd, result))
 }


### PR DESCRIPTION
## Description

This PR closes https://github.com/microsoft/demikernel/issues/1120

## Summary of Changes

- Fixed `remove_coroutine()`
- Fixed `wait()` to behave as it should and tests accordingly.
- Cleaned up "debug" traces on network stack.
- Added more useful trace statements on network stack.