### PR TITLE
[test] Redirect STDERR to File

### DIFF
--- a/tools/demikernel_ci.py
+++ b/tools/demikernel_ci.py
@@ -195,7 +195,7 @@ def remote_compile_windows(host: str, repository: str, target: str, is_debug: bo
 def remote_run(host: str, repository: str, is_debug: bool, target: str, is_sudo: bool, config_path: str):
     debug_flag: str = "DEBUG=yes" if is_debug else "DEBUG=no"
     sudo_cmd: str = "sudo -E" if is_sudo else ""
-    cmd = "cd {} && {} make CONFIG_PATH={} {} {}".format(
+    cmd = "cd {} && {} make CONFIG_PATH={} {} {} 2> out.stderr && cat out.stderr".format(
         repository, sudo_cmd, config_path, debug_flag, target)
     ssh_cmd = "ssh {} \"bash -l -c \'{}\'\"".format(host, cmd)
     return subprocess.Popen(ssh_cmd, shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
## Description

This PR changes the `demikernel_ci.py` utility so as to redirect `stderr` to a file.

The `stderr` output can be very large for debug runs, and this was causing the pipe communication between the SSH client and the python tool to timeout.