### PR TITLE
[runtime] Remove poll and check completed in scheduler

### DIFF
--- a/src/rust/catnap/win/overlapped.rs
+++ b/src/rust/catnap/win/overlapped.rs
@@ -405,6 +405,7 @@ mod tests {
         ensure_eq,
         runtime::scheduler::{
             Scheduler,
+            Task,
             TaskId,
             TaskWithResult,
         },
@@ -677,8 +678,9 @@ mod tests {
             .insert_task(TaskWithResult::<Result<(), Fail>>::new("server".into(), server))
             .unwrap();
 
-        let get_server_result = |scheduler: &mut Scheduler| {
-            TaskWithResult::<Result<(), Fail>>::from(scheduler.remove_task(server_handle).unwrap().as_any())
+        let get_server_result = |task: Box<dyn Task>| {
+            TaskWithResult::<Result<(), Fail>>::try_from(task.as_any())
+                .expect("should be correct task type")
                 .get_result()
                 .unwrap()
         };
@@ -686,11 +688,14 @@ mod tests {
         let mut wait_for_state = |scheduler: &mut Scheduler, state| -> Result<(), Fail> {
             while server_state_view.load(Ordering::Relaxed) < state {
                 iocp.get_mut().process_events()?;
-                scheduler.poll_all();
-                if let Some(true) = scheduler.has_completed(server_handle) {
-                    return Err(get_server_result(scheduler).unwrap_err());
+                // Loop for an arbitrary number of quanta.
+                if let Some(task) = scheduler.get_next_completed_task(64) {
+                    if task.get_id() == server_handle {
+                        return Err(get_server_result(task).unwrap_err());
+                    }
                 }
             }
+
             Ok(())
         };
 
@@ -722,15 +727,16 @@ mod tests {
 
         std::mem::drop(client_handle);
 
-        loop {
-            if let Some(true) = scheduler.has_completed(server_handle) {
-                break;
-            }
+        let task = loop {
             iocp.get_mut().process_events()?;
-            scheduler.poll_all();
-        }
+            if let Some(task) = scheduler.get_next_completed_task(64) {
+                if task.get_id() == server_handle {
+                    break task;
+                }
+            }
+        };
 
-        get_server_result(&mut scheduler)?;
+        get_server_result(task)?;
 
         Ok(())
     }
@@ -789,8 +795,9 @@ mod tests {
             .insert_task(TaskWithResult::<Result<(), Fail>>::new("server".into(), server))
             .unwrap();
 
-        let get_server_result = |scheduler: &mut Scheduler| {
-            TaskWithResult::<Result<(), Fail>>::from(scheduler.remove_task(server_handle).unwrap().as_any())
+        let get_server_result = |task: Box<dyn Task>| {
+            TaskWithResult::<Result<(), Fail>>::try_from(task.as_any())
+                .expect("should be correct task type")
                 .get_result()
                 .unwrap()
         };
@@ -798,9 +805,11 @@ mod tests {
         let mut wait_for_state = |scheduler: &mut Scheduler, state| -> Result<(), Fail> {
             while server_state_view.load(Ordering::Relaxed) < state {
                 iocp.get_mut().process_events()?;
-                scheduler.poll_all();
-                if let Some(true) = scheduler.has_completed(server_handle) {
-                    return Err(get_server_result(scheduler).unwrap_err());
+                // Loop for an arbitrary number of quanta.
+                if let Some(task) = scheduler.get_next_completed_task(64) {
+                    if task.get_id() == server_handle {
+                        return Err(get_server_result(task).unwrap_err());
+                    }
                 }
             }
             Ok(())
@@ -810,15 +819,16 @@ mod tests {
 
         yielder_handle.wake_with(Err(Fail::new(libc::ECANCELED, "I/O cancelled")));
 
-        loop {
-            if let Some(true) = scheduler.has_completed(server_handle) {
-                break;
-            }
+        let task = loop {
             iocp.get_mut().process_events()?;
-            scheduler.poll_all();
-        }
+            if let Some(task) = scheduler.get_next_completed_task(64) {
+                if task.get_id() == server_handle {
+                    break task;
+                }
+            }
+        };
 
-        let result: Result<(), Fail> = get_server_result(&mut scheduler);
+        let result: Result<(), Fail> = get_server_result(task);
         if let Err(err) = result {
             if err.errno == libc::ECANCELED {
                 Ok(())

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -63,6 +63,9 @@ use crate::catnap::transport::SharedCatnapTransport;
 // Structures
 //======================================================================================================================
 
+// By default, we have a timeout of 100ms, which is extremely long for our libOSes.
+const DEFAULT_TIMEOUT: Duration = Duration::from_millis(100);
+
 /// LibOS
 pub enum LibOS {
     /// Network LibOS
@@ -384,8 +387,8 @@ impl LibOS {
         #[cfg(feature = "profiler")]
         timer!("demikernel::wait");
         match self {
-            LibOS::NetworkLibOS(libos) => libos.wait(qt, timeout),
-            LibOS::MemoryLibOS(libos) => libos.wait(qt, timeout),
+            LibOS::NetworkLibOS(libos) => libos.wait(qt, timeout.unwrap_or(DEFAULT_TIMEOUT)),
+            LibOS::MemoryLibOS(libos) => libos.wait(qt, timeout.unwrap_or(DEFAULT_TIMEOUT)),
         }
     }
 
@@ -404,8 +407,8 @@ impl LibOS {
         #[cfg(feature = "profiler")]
         timer!("demikernel::wait_any");
         match self {
-            LibOS::NetworkLibOS(libos) => libos.wait_any(qts, timeout),
-            LibOS::MemoryLibOS(libos) => libos.wait_any(qts, timeout),
+            LibOS::NetworkLibOS(libos) => libos.wait_any(qts, timeout.unwrap_or(DEFAULT_TIMEOUT)),
+            LibOS::MemoryLibOS(libos) => libos.wait_any(qts, timeout.unwrap_or(DEFAULT_TIMEOUT)),
         }
     }
 

--- a/src/rust/inetstack/protocols/tcp/tests/simulator.rs
+++ b/src/rust/inetstack/protocols/tcp/tests/simulator.rs
@@ -810,10 +810,6 @@ impl Simulation {
         self.engine.receive(buf)?;
 
         self.engine.poll();
-        // Poll the scheduler again.
-        // TODO: Remove this once we have a way to poll the scheduler until there is no more work to be done.
-        self.engine.poll();
-
         Ok(())
     }
 
@@ -907,7 +903,6 @@ impl Simulation {
     /// Runs an outgoing packet.
     fn run_outgoing_packet(&mut self, tcp_packet: &TcpPacket) -> Result<()> {
         self.engine.poll();
-
         let frames: VecDeque<DemiBuffer> = self.engine.pop_all_frames();
 
         // FIXME: We currently do not support multi-frame segments.

--- a/src/rust/inetstack/protocols/udp/tests.rs
+++ b/src/rust/inetstack/protocols/udp/tests.rs
@@ -103,7 +103,7 @@ fn udp_push_pop() -> Result<()> {
     // Receive data from Alice.
     bob.receive(alice.pop_frame()).unwrap();
     let bob_qt: QToken = bob.udp_pop(bob_fd)?;
-    bob.poll();
+
     let (remote_addr, received_buf): (Option<SocketAddrV4>, DemiBuffer) = match bob.wait(bob_qt)? {
         (_, OperationResult::Pop(addr, buf)) => (addr, buf),
         _ => anyhow::bail!("Pop failed"),
@@ -147,7 +147,6 @@ fn udp_push_pop_wildcard_address() -> Result<()> {
         (_, OperationResult::Push) => {},
         _ => anyhow::bail!("Push failed"),
     };
-    alice.poll();
 
     now += Duration::from_micros(1);
 
@@ -196,13 +195,13 @@ fn udp_ping_pong() -> Result<()> {
         (_, OperationResult::Push) => {},
         _ => anyhow::bail!("Push failed"),
     };
-    alice.poll();
     now += Duration::from_micros(1);
 
     // Receive data from Alice.
     bob.receive(alice.pop_frame()).unwrap();
     let bob_qt: QToken = bob.udp_pop(bob_fd)?;
     bob.poll();
+
     let (remote_addr, received_buf_a): (Option<SocketAddrV4>, DemiBuffer) = match bob.wait(bob_qt)? {
         (_, OperationResult::Pop(addr, buf)) => (addr, buf),
         _ => anyhow::bail!("Pop failed"),
@@ -215,19 +214,16 @@ fn udp_ping_pong() -> Result<()> {
     // Send data to Alice.
     let buf_b: DemiBuffer = DemiBuffer::from_slice(&vec![0x5a; 32][..]).expect("slice should fit in DemiBuffer");
     let bob_qt2: QToken = bob.udp_pushto(bob_fd, buf_b.clone(), alice_addr)?;
-    bob.poll();
     match bob.wait(bob_qt2)? {
         (_, OperationResult::Push) => {},
         _ => anyhow::bail!("Push failed"),
     };
     bob.poll();
-
     now += Duration::from_micros(1);
 
     // Receive data from Bob.
     alice.receive(bob.pop_frame()).unwrap();
     let alice_qt: QToken = alice.udp_pop(alice_fd)?;
-    alice.poll();
     let (remote_addr, received_buf_b): (Option<SocketAddrV4>, DemiBuffer) = match alice.wait(alice_qt)? {
         (_, OperationResult::Pop(addr, buf)) => (addr, buf),
         _ => anyhow::bail!("Pop failed"),

--- a/src/rust/inetstack/test_helpers/engine.rs
+++ b/src/rust/inetstack/test_helpers/engine.rs
@@ -45,6 +45,9 @@ use ::std::{
     },
 };
 
+/// A default amount of time to wait on an operation to complete. This was chosen arbitrarily.
+const DEFAULT_TIMEOUT: Duration = Duration::from_millis(10);
+
 pub struct SharedEngine(SharedNetworkLibOS<SharedInetStack<SharedTestRuntime>>);
 
 impl SharedEngine {
@@ -160,11 +163,26 @@ impl SharedEngine {
     }
 
     pub fn wait(&self, qt: QToken) -> Result<(QDesc, OperationResult), Fail> {
-        while !self.get_runtime().has_completed(qt)? {
-            self.poll()
+        // First check if the task has already completed.
+        if let Some(result) = self.get_runtime().get_completed_task(&qt) {
+            return Ok(result);
         }
-        let (qd, result): (QDesc, OperationResult) = self.get_runtime().remove_coroutine(qt);
-        Ok((qd, result))
+
+        // Otherwise, run the scheduler.
+        // Put the QToken into a single element array.
+        let qt_array: [QToken; 1] = [qt];
+        let start: Instant = Instant::now();
+
+        // Call run_any() until the task finishes.
+        while Instant::now() <= start + DEFAULT_TIMEOUT {
+            // Run for one quanta and if one of our queue tokens completed, then return.
+            if let Some((offset, qd, qr)) = self.get_runtime().run_any(&qt_array) {
+                debug_assert_eq!(offset, 0);
+                return Ok((qd, qr));
+            }
+        }
+
+        Err(Fail::new(libc::ETIMEDOUT, "wait timed out"))
     }
 }
 

--- a/src/rust/inetstack/test_helpers/engine.rs
+++ b/src/rust/inetstack/test_helpers/engine.rs
@@ -84,6 +84,7 @@ impl SharedEngine {
         self.get_transport().receive(bytes)?;
         // So poll the scheduler to do the processing.
         self.get_runtime().poll();
+        self.get_runtime().poll();
 
         Ok(())
     }

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -411,7 +411,7 @@ impl SharedDemiRuntime {
     /// Performs a single pool on the underlying scheduler.
     pub fn poll(&mut self) {
         // For all ready tasks that were removed from the scheduler, add to our completed task list.
-        for boxed_task in self.scheduler.poll_all() {
+        for boxed_task in self.scheduler.poll_all(TIMER_RESOLUTION) {
             trace!("Completed while polling coroutine: {:?}", boxed_task.get_name());
             let qt: QToken = boxed_task.get_id().into();
 

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -51,7 +51,7 @@ use crate::{
         },
         scheduler::{
             Scheduler,
-            Task,
+            TaskId,
         },
         timer::SharedTimer,
         types::demi_opcode_t,
@@ -73,7 +73,11 @@ use ::std::{
     },
     pin::Pin,
     rc::Rc,
-    time::Instant,
+    time::{
+        Duration,
+        Instant,
+        SystemTime,
+    },
 };
 
 #[cfg(target_os = "windows")]
@@ -119,7 +123,10 @@ pub struct DemiRuntime {
     network_table: NetworkQueueTable,
     /// Currently running coroutines.
     pending_ops: HashMap<QDesc, HashMap<QToken, YielderHandle>>,
+    /// Number of iterations that we have polled since advancing the clock.
     ts_iters: usize,
+    /// Tasks that have been completed and removed from the
+    completed_tasks: HashMap<QToken, (QDesc, OperationResult)>,
 }
 
 #[derive(Clone)]
@@ -155,6 +162,7 @@ impl SharedDemiRuntime {
             network_table: NetworkQueueTable::default(),
             pending_ops: HashMap::<QDesc, HashMap<QToken, YielderHandle>>::new(),
             ts_iters: 0,
+            completed_tasks: HashMap::<QToken, (QDesc, OperationResult)>::new(),
         }))
     }
 
@@ -199,26 +207,133 @@ impl SharedDemiRuntime {
         }
     }
 
-    /// Removes a coroutine from the underlying scheduler given its associated QToken.
-    pub fn remove_coroutine(&mut self, qt: QToken) -> (QDesc, OperationResult) {
-        // 1. Remove Task from scheduler.
-        let boxed_task: Box<dyn Task> = self
-            .scheduler
-            .remove_task(qt.into())
-            .expect("Removing task that does not exist (either was previously removed or never inserted");
-        // 2. Cast to void and then downcast to operation task.
-        trace!("Removing coroutine: {:?}", boxed_task.get_name());
-        let operation_task: OperationTask = OperationTask::from(boxed_task.as_any());
-        let (qd, result): (QDesc, OperationResult) = operation_task.get_result().expect("coroutine not finished");
-        self.cancel_or_remove_pending_ops_as_needed(&result, qd, qt);
-        (qd, result)
+    /// This is just a single-token convenience wrapper for wait_any().
+    pub fn wait(&mut self, qt: QToken, timeout: Duration) -> Result<demi_qresult_t, Fail> {
+        trace!("wait(): qt={:?}, timeout={:?}", qt, timeout);
+
+        // Put the QToken into a single element array.
+        let qt_array: [QToken; 1] = [qt];
+
+        // Call wait_any() to do the real work.
+        let (offset, qr): (usize, demi_qresult_t) = self.wait_any(&qt_array, timeout)?;
+        debug_assert_eq!(offset, 0);
+        Ok(qr)
     }
 
-    /// Removes a coroutine from the underlying scheduler given its associated QToken and gets the result immediately.
-    pub fn remove_coroutine_and_get_result(&mut self, qt: QToken) -> Result<demi_qresult_t, Fail> {
-        let (qd, result): (QDesc, OperationResult) = self.remove_coroutine(qt);
-        let result: demi_qresult_t = self.create_result(result, qd, qt);
-        Ok(result)
+    pub fn timedwait(&mut self, qt: QToken, abstime: Option<SystemTime>) -> Result<demi_qresult_t, Fail> {
+        if let Some((qd, result)) = self.completed_tasks.remove(&qt) {
+            let result: demi_qresult_t = self.create_result(result, qd, qt);
+            return Ok(result);
+        }
+        if !self.scheduler.is_valid_task(&TaskId::from(qt)) {
+            let cause: String = format!("{:?} is not a valid queue token", qt);
+            warn!("wait_any: {}", cause);
+            return Err(Fail::new(libc::EINVAL, &cause));
+        }
+
+        // 2. None of the tasks have already completed, so start a timer and move the clock.
+        let start: Instant = self.get_now();
+        self.advance_clock(start);
+
+        loop {
+            if let Some(boxed_task) = self.scheduler.get_next_completed_task(TIMER_RESOLUTION) {
+                // Perform bookkeeping for the completed and removed task.
+                trace!("Removing coroutine: {:?}", boxed_task.get_name());
+                let completed_qt: QToken = boxed_task.get_id().into();
+                // If an operation task (and not a background task), then check the task to see if it is one of ours.
+                if let Ok(operation_task) = OperationTask::try_from(boxed_task.as_any()) {
+                    let (qd, result): (QDesc, OperationResult) =
+                        operation_task.get_result().expect("coroutine not finished");
+                    self.cancel_or_remove_pending_ops_as_needed(&result, qd, completed_qt);
+
+                    // Check whether it matches any of the queue tokens that we are waiting on.
+                    if completed_qt == qt {
+                        let result: demi_qresult_t = self.create_result(result, qd, qt);
+                        return Ok(result);
+                    }
+
+                    // If not a queue token that we are waiting on, then insert into our list of completed tasks.
+                    self.completed_tasks.insert(qt, (qd, result));
+                }
+            }
+            // Check the timeout.
+            if let Some(abstime) = abstime {
+                if SystemTime::now() >= abstime {
+                    return Err(Fail::new(libc::ETIMEDOUT, "wait timed out"));
+                }
+            }
+
+            // Advance the clock and continue running tasks.
+            let now: Instant = self.get_now();
+            self.advance_clock(now);
+        }
+    }
+
+    /// Waits until one of the tasks in qts has completed and returns the result.
+    pub fn wait_any(&mut self, qts: &[QToken], timeout: Duration) -> Result<(usize, demi_qresult_t), Fail> {
+        for (i, qt) in qts.iter().enumerate() {
+            // 1. Check if any of these queue tokens point to already completed tasks.
+            if let Some((qd, result)) = self.get_completed_task(&qt) {
+                return Ok((i, self.create_result(result, qd, *qt)));
+            }
+
+            // 2. Make sure these queue tokens all point to valid tasks.
+            if !self.scheduler.is_valid_task(&TaskId::from(*qt)) {
+                let cause: String = format!("{:?} is not a valid queue token", qt);
+                warn!("wait_any: {}", cause);
+                return Err(Fail::new(libc::EINVAL, &cause));
+            }
+        }
+
+        // 3. None of the tasks have already completed, so start a timer and move the clock.
+        let start: Instant = self.get_now();
+        self.advance_clock(start);
+
+        // 4. Invoke the scheduler and run some tasks.
+        loop {
+            // Run for one quanta and if one of our queue tokens completed, then return.
+            if let Some((i, qd, result)) = self.run_any(qts) {
+                return Ok((i, self.create_result(result, qd, qts[i])));
+            }
+            // Otherwise, move time forward.
+            let now: Instant = self.get_now();
+            if now >= start + timeout {
+                return Err(Fail::new(libc::ETIMEDOUT, "wait timed out"));
+            } else {
+                self.advance_clock(now);
+            }
+        }
+    }
+
+    pub fn get_completed_task(&mut self, qt: &QToken) -> Option<(QDesc, OperationResult)> {
+        self.completed_tasks.remove(qt)
+    }
+
+    /// Runs the scheduler for one [TIMER_RESOLUTION] quanta. Importantly does not modify the clock.
+    pub fn run_any(&mut self, qts: &[QToken]) -> Option<(usize, QDesc, OperationResult)> {
+        if let Some(boxed_task) = self.scheduler.get_next_completed_task(TIMER_RESOLUTION) {
+            // Perform bookkeeping for the completed and removed task.
+            trace!("Removing coroutine: {:?}", boxed_task.get_name());
+            let qt: QToken = boxed_task.get_id().into();
+
+            // If an operation task, then take a look at the result.
+            if let Ok(operation_task) = OperationTask::try_from(boxed_task.as_any()) {
+                let (qd, result): (QDesc, OperationResult) =
+                    operation_task.get_result().expect("coroutine not finished");
+                self.cancel_or_remove_pending_ops_as_needed(&result, qd, qt);
+
+                // Check whether it matches any of the queue tokens that we are waiting on.
+                for i in 0..qts.len() {
+                    if qts[i] == qt {
+                        return Some((i, qd, result));
+                    }
+                }
+
+                // If not a queue token that we are waiting on, then insert into our list of completed tasks.
+                self.completed_tasks.insert(qt, (qd, result));
+            }
+        }
+        None
     }
 
     /// When the queue is closed, we need to cancel all pending ops. When the coroutine is removed, we only need to
@@ -245,10 +360,8 @@ impl SharedDemiRuntime {
     fn cancel_all_pending_ops_for_queue(&mut self, qd: &QDesc) {
         if let Some(inner_hash_map) = &mut self.pending_ops.remove(&qd) {
             let drain = inner_hash_map.drain();
-            for (qt, mut yielder_handle) in drain {
-                if let Ok(false) = self.has_completed(qt) {
-                    yielder_handle.wake_with(Err(Fail::new(libc::ECANCELED, "This queue was closed")));
-                }
+            for (_, mut yielder_handle) in drain {
+                yielder_handle.wake_with(Err(Fail::new(libc::ECANCELED, "This queue was closed")));
             }
         }
     }
@@ -297,12 +410,18 @@ impl SharedDemiRuntime {
 
     /// Performs a single pool on the underlying scheduler.
     pub fn poll(&mut self) {
-        // Grab the number of polled tasks because this might be useful in the future.
-        // TODO: Do something with this number when scheduling.
-        // Eventually this will return actual ready tasks.
-        // FIXME: https://github.com/microsoft/demikernel/issues/1128
-        #[allow(unused)]
-        let num_ready: usize = self.scheduler.poll_all();
+        // For all ready tasks that were removed from the scheduler, add to our completed task list.
+        for boxed_task in self.scheduler.poll_all() {
+            trace!("Completed while polling coroutine: {:?}", boxed_task.get_name());
+            let qt: QToken = boxed_task.get_id().into();
+
+            if let Ok(operation_task) = OperationTask::try_from(boxed_task.as_any()) {
+                let (qd, result): (QDesc, OperationResult) =
+                    operation_task.get_result().expect("coroutine not finished");
+                self.cancel_or_remove_pending_ops_as_needed(&result, qd, qt);
+                self.completed_tasks.insert(qt, (qd, result));
+            }
+        }
     }
 
     /// Allocates a queue of type `T` and returns the associated queue descriptor.
@@ -518,17 +637,6 @@ impl SharedDemiRuntime {
                     qr_ret: e.errno as i64,
                     qr_value: unsafe { mem::zeroed() },
                 }
-            },
-        }
-    }
-
-    pub fn has_completed(&self, qt: QToken) -> Result<bool, Fail> {
-        match self.scheduler.has_completed(qt.into()) {
-            Some(has_completed) => Ok(has_completed),
-            None => {
-                let cause: String = format!("invalid scheduler task id (qt={:?})", &qt);
-                error!("has_completed(): {}", cause);
-                Err(Fail::new(libc::EINVAL, &cause))
             },
         }
     }

--- a/src/rust/runtime/scheduler/group.rs
+++ b/src/rust/runtime/scheduler/group.rs
@@ -154,25 +154,14 @@ impl TaskGroup {
         (waker_page_index << WAKER_BIT_LENGTH_SHIFT) + waker_page_offset
     }
 
-    pub fn has_completed(&self, task_id: TaskId) -> Option<bool> {
-        let pin_slab_index: usize = self.ids.get(&task_id)?.into();
-
-        let (waker_page_ref, waker_page_offset) = {
-            let (waker_page_index, waker_page_offset) = self.get_waker_page_index_and_offset(pin_slab_index)?;
-            (&self.waker_page_refs[waker_page_index], waker_page_offset)
-        };
-
-        Some(waker_page_ref.has_completed(waker_page_offset))
-    }
-
-    pub fn get_offsets_for_ready_tasks(&mut self) -> Vec<usize> {
-        let mut result: Vec<usize> = vec![];
+    pub fn get_offsets_for_ready_tasks(&mut self) -> Vec<InternalId> {
+        let mut result: Vec<InternalId> = vec![];
         for i in 0..self.get_num_waker_pages() {
             // Grab notified bits.
             let notified: u64 = self.waker_page_refs[i].take_notified();
             // Turn into bit iter.
-            let mut offset: Vec<usize> = BitIter::from(notified)
-                .map(|x| Self::get_pin_slab_index(i, x))
+            let mut offset: Vec<InternalId> = BitIter::from(notified)
+                .map(|x| Self::get_pin_slab_index(i, x).into())
                 .collect();
             result.append(&mut offset);
         }
@@ -198,26 +187,29 @@ impl TaskGroup {
         unsafe { Waker::from_raw(WakerRef::new(raw_waker).into()) }
     }
 
-    pub fn poll_notified_task(&mut self, pin_slab_index: usize) -> Option<bool> {
-        // Get the waker context.
-        let (waker_page_index, waker_page_offset) = self.get_waker_page_index_and_offset(pin_slab_index)?;
-        let waker: Waker = self.get_waker(waker_page_index, waker_page_offset);
-        let mut waker_context: Context = Context::from_waker(&waker);
+    pub fn poll_notified_task_and_remove_if_ready(&mut self, internal_task_id: InternalId) -> Option<Box<dyn Task>> {
+        // Perform the actual work of running the task.
+        let poll_result: Poll<()> = {
+            // Get the waker context.
+            let (waker_page_index, waker_page_offset) =
+                self.get_waker_page_index_and_offset(internal_task_id.into())?;
+            let waker: Waker = self.get_waker(waker_page_index, waker_page_offset);
+            let mut waker_context: Context = Context::from_waker(&waker);
 
-        let mut pinned_ptr = self.get_pinned_task_ptr(pin_slab_index);
-        let pinned_ref = unsafe { Pin::new_unchecked(&mut *pinned_ptr) };
+            let mut pinned_ptr = self.get_pinned_task_ptr(internal_task_id.into());
+            let pinned_ref = unsafe { Pin::new_unchecked(&mut *pinned_ptr) };
 
-        // Poll future.
-        let poll_result: Poll<()> = Future::poll(pinned_ref, &mut waker_context);
+            // Poll future.
+            Future::poll(pinned_ref, &mut waker_context)
+        };
+
         if let Poll::Ready(()) = poll_result {
-            self.waker_page_refs[waker_page_index].mark_completed(waker_page_offset);
-            Some(true)
-        } else {
-            Some(false)
+            let task_id: TaskId = self.get_id(internal_task_id.into());
+            return self.remove(task_id);
         }
+        None
     }
 
-    #[cfg(test)]
     pub fn is_valid_task(&self, task_id: &TaskId) -> bool {
         if let Some(internal_id) = self.ids.get(task_id) {
             self.tasks.contains(internal_id.into())

--- a/src/rust/runtime/scheduler/scheduler.rs
+++ b/src/rust/runtime/scheduler/scheduler.rs
@@ -26,14 +26,21 @@ use ::slab::Slab;
 //======================================================================================================================
 
 /// Internal offset into the slab that holds the task state.
-#[derive(Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Copy, Debug)]
 pub struct InternalId(usize);
 
 /// Task Scheduler
 pub struct Scheduler {
     ids: IdMap<TaskId, InternalId>,
     groups: Slab<TaskGroup>,
-    current_task: TaskId,
+
+    // These global variables are for our scheduling policy. For now, we simply use round robin.
+    // The index of the current or last task that we ran.
+    current_task_id: InternalId,
+    // The group index of the current or last task that we ran.
+    current_group_id: InternalId,
+    // The current set of ready tasks in the group.
+    current_ready_tasks: Vec<InternalId>,
 }
 
 //======================================================================================================================
@@ -47,17 +54,18 @@ impl Scheduler {
         self.ids.insert_with_new_id(internal_id)
     }
 
-    pub fn switch_group(&mut self, group_id: TaskId) -> Option<TaskId> {
+    /// Switch to a different task group. Returns true if the group has been switched.
+    pub fn switch_group(&mut self, group_id: TaskId) -> bool {
         if let Some(internal_id) = self.ids.get(&group_id) {
             if self.groups.contains(internal_id.into()) {
-                let old_task: TaskId = self.current_task;
-                self.current_task = group_id;
-                return Some(old_task);
+                self.current_group_id = internal_id;
+                return true;
             }
         }
-        None
+        false
     }
 
+    /// Get a reference to the task group using the id.
     fn get_group(&self, task_id: &TaskId) -> Option<&TaskGroup> {
         // Get the internal id of the parent task or group.
         let group_id: InternalId = self.ids.get(task_id)?;
@@ -65,6 +73,7 @@ impl Scheduler {
         self.groups.get(group_id.into())
     }
 
+    /// Get a mutable reference to the task group using the id.
     fn get_mut_group(&mut self, task_id: &TaskId) -> Option<&mut TaskGroup> {
         // Get the internal id of the parent task or group.
         let group_id: InternalId = self.ids.get(task_id)?;
@@ -86,14 +95,12 @@ impl Scheduler {
     /// Insert a task into a task group. The parent id can either be the id of the group or another task in the same
     /// group.
     pub fn insert_task<T: Task>(&mut self, task: T) -> Option<TaskId> {
-        // Get the internal id of the parent task or group.
-        let group_id: InternalId = self.ids.get(&self.current_task)?;
-        // Use that to find the task group for this task.
-        let group: &mut TaskGroup = self.groups.get_mut(group_id.into())?;
+        // Use the currently running task id to find the task group for this task.
+        let group: &mut TaskGroup = self.groups.get_mut(self.current_group_id.into())?;
         // Insert the task into the task group.
         let new_task_id: TaskId = group.insert(Box::new(task))?;
         // Add a mapping so we can use this new task id to find the task in the future.
-        if let Some(existing) = self.ids.insert(new_task_id, group_id) {
+        if let Some(existing) = self.ids.insert(new_task_id, self.current_group_id) {
             panic!("should not exist an id: {:?}", existing);
         }
         Some(new_task_id)
@@ -123,48 +130,86 @@ impl Scheduler {
         Some(task)
     }
 
-    fn poll(&mut self, group_index: usize) -> usize {
-        debug_assert!(group_index < self.groups.len());
+    /// This function polls a task and if it has completed, removes it from the scheduler and returns it.
+    fn poll(&mut self) -> Vec<Box<dyn Task>> {
+        let mut completed_tasks: Vec<Box<dyn Task>> = vec![];
 
-        let mut polled_tasks: usize = 0;
-
-        let ready_indices: Vec<usize> = self.groups[group_index].get_offsets_for_ready_tasks();
-        for pin_slab_index in ready_indices {
+        // Performance note: We could set this for self.current_ready_tasks but is not necessary. On the other hand,
+        // it's not impactful for performance (around 1ns difference in the poll benchmark).
+        let ready_tasks: Vec<InternalId> = self.groups[self.current_group_id.into()].get_offsets_for_ready_tasks();
+        for internal_task_id in ready_tasks {
             // Set the current running task for polling this task. This ensures that all tasks spawned by this task
             // will share the same task group.
-            let old_task: TaskId = self.current_task;
-            self.current_task = self.groups[group_index].get_id(pin_slab_index);
-            self.groups[group_index].poll_notified_task(pin_slab_index);
-            // Unset the current running task.
-            self.current_task = old_task;
-            polled_tasks += 1;
+            self.current_task_id = internal_task_id;
+            if let Some(completed_task) =
+                self.groups[self.current_group_id.into()].poll_notified_task_and_remove_if_ready(internal_task_id)
+            {
+                completed_tasks.push(completed_task)
+            }
         }
-        polled_tasks
+        completed_tasks
     }
 
     /// Poll all tasks which are ready to run once. Tasks in our scheduler are notified when
     /// relevant data or events happen. The relevant event have callback function (the waker) which
     /// they can invoke to notify the scheduler that future should be polled again.
-    pub fn poll_all(&mut self) -> usize {
-        let mut polled_tasks: usize = 0;
+    pub fn poll_all(&mut self) -> Vec<Box<dyn Task>> {
+        let mut completed_tasks: Vec<Box<dyn Task>> = vec![];
         for i in 0..self.groups.len() {
-            polled_tasks += self.poll(i);
+            self.current_group_id = InternalId::from(i);
+            completed_tasks.append(&mut self.poll());
         }
-        polled_tasks
+        completed_tasks
     }
 
     /// Poll all tasks in this group that are ready to run.
-    pub fn poll_group(&mut self, group_id: TaskId) -> Option<usize> {
-        Some(self.poll(self.ids.get(&group_id)?.into()))
+    pub fn poll_group(&mut self, group_id: TaskId) -> Option<Vec<Box<dyn Task>>> {
+        self.current_group_id = self.ids.get(&group_id)?;
+        Some(self.poll())
     }
 
-    pub fn has_completed(&self, task_id: TaskId) -> Option<bool> {
-        // Use that to find the task group for this task.
-        let group: &TaskGroup = self.get_group(&task_id)?;
-        group.has_completed(task_id)
+    /// Poll all tasks until one completes. Remove that task and return it or fail after polling [max_iteration] number
+    /// of tasks.
+    pub fn get_next_completed_task(&mut self, max_iterations: usize) -> Option<Box<dyn Task>> {
+        for _ in 0..max_iterations {
+            self.current_task_id = {
+                let starting_group_index: InternalId = self.current_group_id;
+                if self.current_ready_tasks.is_empty() {
+                    self.current_ready_tasks = self.groups[self.current_group_id.into()].get_offsets_for_ready_tasks();
+                }
+
+                loop {
+                    match self.current_ready_tasks.pop() {
+                        Some(index) => break index,
+                        None => {
+                            self.current_group_id = self.get_next_group_index();
+                            self.current_ready_tasks =
+                                self.groups[self.current_group_id.into()].get_offsets_for_ready_tasks();
+                        },
+                    }
+                    // If we reach this point, then we have looped all the way around without finding any runnable tasks.
+                    if self.current_group_id == starting_group_index {
+                        return None;
+                    }
+                }
+            };
+
+            // Now that we have a runnable task, actually poll it.
+            if let Some(task) = self.groups[self.current_group_id.into()]
+                .poll_notified_task_and_remove_if_ready(self.current_task_id.into())
+            {
+                return Some(task);
+            }
+        }
+        None
     }
 
-    #[cfg(test)]
+    /// Choose the index of the next group to run.
+    fn get_next_group_index(&self) -> InternalId {
+        // For now, we just choose the next group in the list.
+        InternalId::from((usize::from(self.current_group_id) + 1) % self.groups.len())
+    }
+
     pub fn is_valid_task(&self, task_id: &TaskId) -> bool {
         if let Some(group) = self.get_group(task_id) {
             group.is_valid_task(&task_id)
@@ -199,7 +244,9 @@ impl Default for Scheduler {
         Self {
             ids,
             groups,
-            current_task,
+            current_group_id: internal_id,
+            current_task_id: InternalId(0),
+            current_ready_tasks: vec![],
         }
     }
 }
@@ -256,6 +303,9 @@ mod tests {
         black_box,
         Bencher,
     };
+
+    /// This should never be used but ensures that the tests do not run forever.
+    const MAX_ITERATIONS: usize = 100;
 
     #[derive(Default)]
     struct DummyCoroutine {
@@ -320,16 +370,32 @@ mod tests {
 
         // All futures are inserted in the scheduler with notification flag set.
         // By polling once, our future should complete.
-        scheduler.poll_all();
-
-        crate::ensure_eq!(
-            scheduler
-                .has_completed(task_id)
-                .expect("should find task completion status"),
-            true
-        );
-
+        if let Some(task) = scheduler.get_next_completed_task(1) {
+            crate::ensure_eq!(task.get_id(), task_id);
+        } else {
+            anyhow::bail!("task should have completed");
+        }
         Ok(())
+    }
+
+    #[test]
+    fn poll_next_with_one_small_task_completes_it() -> Result<()> {
+        let mut scheduler: Scheduler = Scheduler::default();
+
+        // Insert a single future in the scheduler. This future shall complete with a single poll operation.
+        let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(0).fuse()));
+        let Some(task_id) = scheduler.insert_task(task) else {
+            anyhow::bail!("insert() failed")
+        };
+
+        // All futures are inserted in the scheduler with notification flag set.
+        // By polling once, our future should complete.
+        if let Some(task) = scheduler.get_next_completed_task(MAX_ITERATIONS) {
+            crate::ensure_eq!(task_id, task.get_id());
+            Ok(())
+        } else {
+            anyhow::bail!("task should have completed")
+        }
     }
 
     #[test]
@@ -345,26 +411,38 @@ mod tests {
 
         // All futures are inserted in the scheduler with notification flag set.
         // By polling once, this future should make a transition.
-        scheduler.poll_all();
-
-        crate::ensure_eq!(
-            scheduler
-                .has_completed(task_id)
-                .expect("should find task completion status"),
-            false
-        );
+        // All futures are inserted in the scheduler with notification flag set.
+        // By polling once, our future should complete.
+        let result = scheduler.get_next_completed_task(1);
+        crate::ensure_eq!(result.is_some(), false);
 
         // This shall make the future ready.
-        scheduler.poll_all();
-
-        crate::ensure_eq!(
-            scheduler
-                .has_completed(task_id)
-                .expect("should find task completion status"),
-            true
-        );
-
+        if let Some(task) = scheduler.get_next_completed_task(1) {
+            crate::ensure_eq!(task.get_id(), task_id);
+        } else {
+            anyhow::bail!("task should have completed");
+        }
         Ok(())
+    }
+
+    #[test]
+    fn poll_next_with_one_long_task_completes_it() -> Result<()> {
+        let mut scheduler: Scheduler = Scheduler::default();
+
+        // Insert a single future in the scheduler. This future shall complete with a single poll operation.
+        let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(0).fuse()));
+        let Some(task_id) = scheduler.insert_task(task) else {
+            anyhow::bail!("insert() failed")
+        };
+
+        // All futures are inserted in the scheduler with notification flag set.
+        // By polling until the task completes, our future should complete.
+        if let Some(task) = scheduler.get_next_completed_task(MAX_ITERATIONS) {
+            crate::ensure_eq!(task_id, task.get_id());
+            Ok(())
+        } else {
+            anyhow::bail!("task should have completed")
+        }
     }
 
     /// Tests if consecutive tasks are not assigned the same task id.
@@ -377,15 +455,12 @@ mod tests {
         let Some(task_id) = scheduler.insert_task(task) else {
             anyhow::bail!("insert() failed")
         };
-        scheduler.poll_all();
 
-        // Ensure that the first task has completed.
-        crate::ensure_eq!(
-            scheduler
-                .has_completed(task_id)
-                .expect("should find task completion status"),
-            true
-        );
+        if let Some(task) = scheduler.get_next_completed_task(1) {
+            crate::ensure_eq!(task.get_id(), task_id);
+        } else {
+            anyhow::bail!("task should have completed");
+        }
 
         // Create another task.
         let task2: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(0).fuse()));
@@ -416,9 +491,6 @@ mod tests {
             };
             task_ids.push(task_id);
         }
-
-        // This poll is required to give the opportunity for all the tasks to complete.
-        scheduler.poll_all();
 
         // Remove tasks one by one and check if remove is only removing the task requested to be removed.
         let mut curr_num_tasks: usize = NUM_TASKS;
@@ -470,6 +542,25 @@ mod tests {
 
         b.iter(|| {
             black_box(scheduler.poll_all());
+        });
+    }
+
+    #[bench]
+    fn benchmark_next(b: &mut Bencher) {
+        let mut scheduler: Scheduler = Scheduler::default();
+        const NUM_TASKS: usize = 1024;
+        let mut task_ids: Vec<TaskId> = Vec::<TaskId>::with_capacity(NUM_TASKS);
+
+        for val in 0..NUM_TASKS {
+            let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(val).fuse()));
+            let Some(task_id) = scheduler.insert_task(task) else {
+                panic!("insert() failed");
+            };
+            task_ids.push(task_id);
+        }
+
+        b.iter(|| {
+            black_box(scheduler.get_next_completed_task(MAX_ITERATIONS));
         });
     }
 }

--- a/src/rust/runtime/scheduler/waker64.rs
+++ b/src/rust/runtime/scheduler/waker64.rs
@@ -76,6 +76,7 @@ impl Waker64 {
         Some(old)
     }
 
+    #[allow(unused)]
     /// Returns the value stored in the the target [Waker64].
     pub fn load(&self) -> u64 {
         let s = unsafe { &mut *self.0.get() };

--- a/tests/rust/tcp-test/accept/mod.rs
+++ b/tests/rust/tcp-test/accept/mod.rs
@@ -151,6 +151,9 @@ fn accept_connecting_socket(libos: &mut LibOS, remote: &SocketAddr) -> Result<()
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && qr.qr_ret == libc::ECONNREFUSED as i64 => {
             connect_finished = true
         },
+        Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && qr.qr_ret == libc::ECONNABORTED as i64 => {
+            connect_finished = true
+        },
         Ok(_) => anyhow::bail!("wait() should not succeed"),
         Err(_) => anyhow::bail!("wait() should be cancelled"),
     }

--- a/tests/rust/tcp-test/wait/mod.rs
+++ b/tests/rust/tcp-test/wait/mod.rs
@@ -111,14 +111,23 @@ fn wait_after_close_connecting_socket(libos: &mut LibOS, remote: &SocketAddr) ->
     match libos.wait(qt, Some(Duration::from_micros(0))) {
         Err(e) if e.errno == libc::ETIMEDOUT => {},
         // Can only complete with ECONNREFUSED because remote does not exist.
-        Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && qr.qr_ret == libc::ECONNREFUSED as i64 => {
+        Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && (qr.qr_ret == libc::ECONNREFUSED as i64) => {
+            connect_finished = true
+        },
+        Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && qr.qr_ret == libc::ECONNABORTED as i64 => {
             connect_finished = true
         },
         // If completes successfully, something has gone wrong.
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CONNECT && qr.qr_ret == 0 => {
             anyhow::bail!("connect() should not succeed because remote does not exist")
         },
-        Ok(_) => anyhow::bail!("wait() should not succeed on connect()"),
+        Ok(qr) => {
+            anyhow::bail!(
+                "wait() should not succeed on connect(): opcode {:?} ret {:?}",
+                qr.qr_opcode,
+                qr.qr_ret
+            )
+        },
         Err(_) => anyhow::bail!("wait() should timeout"),
     }
 
@@ -201,11 +210,19 @@ fn wait_after_async_close_connecting_socket(libos: &mut LibOS, remote: &SocketAd
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && qr.qr_ret == libc::ECONNREFUSED as i64 => {
             connect_finished = true
         },
+        Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && qr.qr_ret == libc::ECONNABORTED as i64 => {
+            connect_finished = true
+        },
+
         // If connect() completes successfully, something has gone wrong.
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CONNECT && qr.qr_ret == 0 => {
             anyhow::bail!("connect() should not succeed because remote does not exist")
         },
-        Ok(_) => anyhow::bail!("wait() should not succeed with connect()"),
+        Ok(qr) => anyhow::bail!(
+            "wait() should not succeed with connect(): opcode {:?} error {:?}",
+            qr.qr_opcode,
+            qr.qr_ret
+        ),
         Err(_) => anyhow::bail!("wait() should timeout with connect()"),
     }
 
@@ -334,6 +351,9 @@ fn wait_for_connect_after_issuing_async_close(libos: &mut LibOS, remote: &Socket
         Err(e) if e.errno == libc::ETIMEDOUT => {},
         // Can only complete with ECONNREFUSED because remote does not exist.
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && qr.qr_ret == libc::ECONNREFUSED as i64 => {
+            connect_finished = true
+        },
+        Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && qr.qr_ret == libc::ECONNABORTED as i64 => {
             connect_finished = true
         },
         // If connect() completes successfully, something has gone wrong.

--- a/tests/rust/tcp.rs
+++ b/tests/rust/tcp.rs
@@ -54,6 +54,10 @@ pub const AF_INET: i32 = libc::AF_INET;
 #[cfg(target_os = "linux")]
 pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
 
+/// A default amount of time to wait on an operation to complete. This was chosen arbitrarily to be high enough to
+/// ensure most OS operations will complete.
+const DEFAULT_TIMEOUT: Duration = Duration::from_millis(100);
+
 use std::{
     net::{
         IpAddr,
@@ -1152,7 +1156,8 @@ fn safe_push(libos: &mut DummyLibOS, sockqd: QDesc, bytes: demi_sgarray_t) -> Re
 
 /// Safe call to `wait2()`.
 fn safe_wait(libos: &mut DummyLibOS, qt: QToken) -> Result<(QDesc, OperationResult)> {
-    match libos.wait(qt, None) {
+    // Set this to something reasonably high because it should eventually complete.
+    match libos.wait(qt, Some(DEFAULT_TIMEOUT)) {
         Ok(result) => Ok(result),
         Err(e) => anyhow::bail!("wait failed: {:?}", e),
     }


### PR DESCRIPTION
This PR closes #1128 . We move away from a polling model to directly return completed tasks after running the scheduler. We also immediately remove completed tasks (since they will never run again) and it is the responsibility of the higher-level runtime to stash them somewhere. Thus, now the runtime contains a wait function that runs the scheduler until the requested queue token has completed. This also moves us towards a model where we can unify timeouts for wait calls and background coroutines.

Note that this PR introduces mandatory time outs for everything in the libOS, ensuring that we are never wedged in Demikernel. However, it does require us to set these defaults, which might need to be adjusted and should probably eventually be moved to a single place.