### PR TITLE
[catnap] Fix use-after-free related to I/O cancellation in catnap for Windows

### DIFF
--- a/src/rust/catnap/win/overlapped.rs
+++ b/src/rust/catnap/win/overlapped.rs
@@ -236,11 +236,12 @@ impl IoCompletionPort {
                         if err.errno == libc::ECANCELED {
                             if let Err(cancel_err) = cancel(completion.get_state_ref(), overlapped) {
                                 warn!("cancellation failed: {}", cancel_err);
-                            } else {
-                                return Err(err);
                             }
                         }
 
+                        // NOTE: the semantics of completion ports with cancellation is unclear: CancelIoEx
+                        // documentation implies that some operations may not post a completion packet after this
+                        // operation. If completions are found to leak, this may be why.
                         completion.abandon();
                         return Err(err);
                     },


### PR DESCRIPTION
This PR fixes a use-after-free when cancelling I/O operations on Windows. As noted in the added comment, the exact semantics of CancelIoEx on Windows are unclear w.r.t. the completion port. This could result in memory leaks. Tracking the OVERLAPPED objects in a table may allow us to more accurately own/free these.