### PR TITLE
[demikernel] Drop `timedwait()`

### DIFF
--- a/include/demi/wait.h
+++ b/include/demi/wait.h
@@ -24,17 +24,6 @@ extern "C"
     extern int demi_wait(demi_qresult_t *qr_out, demi_qtoken_t qt, const struct timespec *timeout);
 
     /**
-     * @brief Waits for an asynchronous I/O operation to complete or a timeout to expire.
-     *
-     * @param qr_out  Store location for the result of the completed I/O operation.
-     * @param qt      I/O queue token of the target operation to wait for completion.
-     * @param abstime Absolute timeout in seconds and nanoseconds since Epoch.
-     *
-     * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
-     */
-    extern int demi_timedwait(demi_qresult_t *qr_out, demi_qtoken_t qt, const struct timespec *abstime);
-
-    /**
      * @brief Waits for the first asynchronous I/O operation in a list to complete.
      *
      * @param qr_out       Store location for the result of the completed I/O operation.
@@ -45,7 +34,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_wait_any(demi_qresult_t *qr_out, int *ready_offset, const demi_qtoken_t qts[], int num_qts, const struct timespec *timeout);
+    extern int demi_wait_any(demi_qresult_t *qr_out, int *ready_offset, const demi_qtoken_t qts[], int num_qts,
+                             const struct timespec *timeout);
 
 #ifdef __cplusplus
 }

--- a/man/demi_wait.md
+++ b/man/demi_wait.md
@@ -4,8 +4,6 @@
 
 `demi_wait` - Waits for an asynchronous I/O operation to complete or a timeout to expire.
 
-`demi_timedwait` - Waits for an asynchronous I/O operation to complete or a timeout to expire.
-
 `demi_wait_any` - Waits for the first asynchronous I/O operation in a list to complete or a timeout to expire.
 
 ## Synopsis
@@ -15,22 +13,17 @@
 #include <demi/types.h> /* For demi_qresult_t and demi_qtoken_t. */
 
 int demi_wait(demi_qresult_t *qr_out, demi_qtoken_t qt, struct timespec *timeout);
-int demi_timedwait(demi_qresult_t *qr_out, demi_qtoken_t qt, const struct timespec *abstime);
 int demi_wait_any(demi_qresult_t *qr_out, int *ready_offset, demi_qtoken_t qts[], int num_qts, struct timespec *timeout);
 ```
 
 ## Description
 
-`demi_wait()` waits for the completion of the asynchronous I/O operation associated with the queue token `qt` or for
-the expiration of a timeout, whichever happens first.  The `timeout` parameter specifies an interval timeout in seconds
-and nanoseconds.  If the `timeout` parameter is NULL, then the timeout will be treated as infinite.  If the I/O
-operation has already completed when `demi_wait()` is called, then this system call never fails with a timeout error, regardless of the value of `timeout`. This system call may cause the calling thread to block (spin) until the timeout `timeout` expires, or indefinitely if the `timeout` is not specified (i.e. is NULL).
-
-`demi_timedwait()` waits for the completion of the asynchronous I/O operation associated with the queue token `qt` or
-for the expiration of a timeout, whichever happens first. The `abstime` parameter specifies an absolute timeout in
-seconds and nanoseconds since the Epoch.  If the I/O operation has already completed when `demi_timedwait()` is called,
-then this system call never fails with a timeout error, regardless of the value of `abstime`. This system call may cause
-the calling thread to block (spin) until the timeout `abstime` expires.
+`demi_wait()` waits for the completion of the asynchronous I/O operation associated with the queue token `qt` or for the
+expiration of a timeout, whichever happens first.  The `timeout` parameter specifies an interval timeout in seconds and
+nanoseconds.  If the `timeout` parameter is NULL, then the timeout will be treated as infinite.  If the I/O operation
+has already completed when `demi_wait()` is called, then this system call never fails with a timeout error, regardless
+of the value of `timeout`. This system call may cause the calling thread to block (spin) until the timeout `timeout`
+expires, or indefinitely if the `timeout` is not specified (i.e. is NULL).
 
 `demi_wait_any()` waits for the first asynchronous I/O operation in a set to complete. The set of I/O operations is
 specified by the list of queue tokens `qts` and it has a length of `num_qts`.  The `timeout` parameter specifies an
@@ -39,10 +32,9 @@ infinite.  If the I/O operation has already completed when `demi_wait()` is call
 with a timeout error, regardless of the value of `timeout`. This system call may cause the calling thread to block
 (spin) until the timeout `timeout` expires, or indefinitely if the `timeout` is not specified (i.e. is NULL).
 
-When `demi_wait()` and `demi_timedwait()` successfully completes, the structure pointed to by `qr_out` is filled in with
-the result value of the I/O operation that has completed. The `demi_wait_any()` system call behaves similarly, but it
-additionally sets `ready_offset` to indicate the index of that I/O operation in the list of queue tokens `qts` that has
-completed.
+When `demi_wait()` successfully completes, the structure pointed to by `qr_out` is filled in with the result value of
+the I/O operation that has completed. The `demi_wait_any()` system call behaves similarly, but it additionally sets
+`ready_offset` to indicate the index of that I/O operation in the list of queue tokens `qts` that has completed.
 
 The `demi_qresult_t` is defined as follows:
 

--- a/src/rust/demikernel/libos/memory.rs
+++ b/src/rust/demikernel/libos/memory.rs
@@ -17,7 +17,6 @@ use crate::runtime::{
 use ::std::time::{
     Duration,
     Instant,
-    SystemTime,
 };
 
 #[cfg(feature = "catmem-libos")]
@@ -108,25 +107,6 @@ impl MemoryLibOS {
         let (offset, qr): (usize, demi_qresult_t) = self.wait_any(&qt_array, timeout)?;
         debug_assert_eq!(offset, 0);
         Ok(qr)
-    }
-
-    /// Waits for an I/O operation to complete or a timeout to expire.
-    pub fn timedwait(&mut self, qt: QToken, abstime: Option<SystemTime>) -> Result<demi_qresult_t, Fail> {
-        trace!("timedwait() qt={:?}, timeout={:?}", qt, abstime);
-
-        loop {
-            // Poll first, so as to give pending operations a chance to complete.
-            self.poll();
-
-            // The operation has completed, so extract the result and return.
-            if self.has_completed(qt)? {
-                return Ok(self.get_result(qt)?);
-            }
-
-            if abstime.is_none() || SystemTime::now() >= abstime.unwrap() {
-                return Err(Fail::new(libc::ETIMEDOUT, "timer expired"));
-            }
-        }
     }
 
     /// Waits for any of the given pending I/O operations to complete or a timeout to expire.

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -44,10 +44,7 @@ use crate::{
 use ::std::{
     env,
     net::SocketAddr,
-    time::{
-        Duration,
-        SystemTime,
-    },
+    time::Duration,
 };
 
 #[cfg(feature = "catloop-libos")]
@@ -379,16 +376,6 @@ impl LibOS {
         match self {
             LibOS::NetworkLibOS(libos) => libos.wait(qt, timeout),
             LibOS::MemoryLibOS(libos) => libos.wait(qt, timeout),
-        }
-    }
-
-    /// Waits for an I/O operation to complete or a timeout to expire.
-    pub fn timedwait(&mut self, qt: QToken, abstime: Option<SystemTime>) -> Result<demi_qresult_t, Fail> {
-        #[cfg(feature = "profiler")]
-        timer!("demikernel::timedwait");
-        match self {
-            LibOS::NetworkLibOS(libos) => libos.timedwait(qt, abstime),
-            LibOS::MemoryLibOS(libos) => libos.timedwait(qt, abstime),
         }
     }
 

--- a/src/rust/demikernel/libos/network/mod.rs
+++ b/src/rust/demikernel/libos/network/mod.rs
@@ -33,7 +33,6 @@ use ::std::{
     time::{
         Duration,
         Instant,
-        SystemTime,
     },
 };
 
@@ -248,25 +247,6 @@ impl NetworkLibOSWrapper {
         let (offset, qr): (usize, demi_qresult_t) = self.wait_any(&qt_array, timeout)?;
         debug_assert_eq!(offset, 0);
         Ok(qr)
-    }
-
-    /// Waits for an I/O operation to complete or a timeout to expire.
-    pub fn timedwait(&mut self, qt: QToken, abstime: Option<SystemTime>) -> Result<demi_qresult_t, Fail> {
-        trace!("timedwait() qt={:?}, timeout={:?}", qt, abstime);
-
-        loop {
-            // Poll first, so as to give pending operations a chance to complete.
-            self.poll();
-
-            // The operation has completed, so extract the result and return.
-            if self.has_completed(qt)? {
-                return Ok(self.get_result(qt)?);
-            }
-
-            if abstime.is_none() || SystemTime::now() >= abstime.unwrap() {
-                return Err(Fail::new(libc::ETIMEDOUT, "timer expired"));
-            }
-        }
     }
 
     /// Waits for any of the given pending I/O operations to complete or a timeout to expire.

--- a/tests/c/syscalls.c
+++ b/tests/c/syscalls.c
@@ -153,18 +153,6 @@ static bool inval_sgafree(void)
  *===================================================================================================================*/
 
 /**
- * @brief Issues an invalid system call to demi_timedwait().
- */
-static bool inval_timedwait(void)
-{
-    struct timespec *abstime = NULL;
-    demi_qresult_t *qr = NULL;
-    demi_qtoken_t qt = -1;
-
-    return (demi_timedwait(qr, qt, abstime) != 0);
-}
-
-/**
  * @brief Issues an invalid system call to demi_wait().
  */
 static bool inval_wait(void)
@@ -221,9 +209,7 @@ static struct test tests_sga[] = {{inval_sgaalloc, "invalid demi_sgaalloc()"},
 /**
  * @brief Tests for system calls in demi/wait.h
  */
-static struct test tests_wait[] = {{inval_timedwait, "invalid demi_timedwait()"},
-                                   {inval_wait, "invalid demi_wait()"},
-                                   {inval_wait_any, "invalid demi_wait_any()"}};
+static struct test tests_wait[] = {{inval_wait, "invalid demi_wait()"}, {inval_wait_any, "invalid demi_wait_any()"}};
 
 /**
  * @brief Drives the application.


### PR DESCRIPTION
## Description

This PR drops support for `timedwait()` system call.