### PR TITLE
[catnap] Enhancement: allow configuring Nagle's algorithm for TCP on Windows

### DIFF
--- a/src/rust/catnap/win/transport.rs
+++ b/src/rust/catnap/win/transport.rs
@@ -65,6 +65,9 @@ pub(super) struct WinConfig {
 
     /// Linger socket options.
     linger_time: Option<Duration>,
+
+    /// Whether Nagle's algorithm is enabled or disabled.
+    nagle: Option<bool>,
 }
 
 /// Underlying network transport.
@@ -96,6 +99,7 @@ impl SharedCatnapTransport {
         let config: WinConfig = WinConfig {
             keepalive_params: config.tcp_keepalive().expect("failed to load TCP settings"),
             linger_time: config.linger_time().expect("failed to load linger settings"),
+            nagle: config.nagle().expect("failed to load nagle's algorithm settings"),
         };
 
         let me: Self = Self(SharedObject::new(CatnapTransport {


### PR DESCRIPTION
This PR allows configuring Nagle's algorithm (i.e. TCP_NODELAY socket option) via a "use_nagle" config in config.yaml. I also refactored some of the Catnap/win/config.rs because the `require_option...` contradiction was bothering me.