### PR TITLE
[demikernel] Enhacement: remove unstable features 

### DIFF
--- a/src/rust/collections/ring.rs
+++ b/src/rust/collections/ring.rs
@@ -395,12 +395,16 @@ macro_rules! int_size_trait_impl {
     ($int_type:ident, $atomic_type:ident) => {
         impl IntSize for $int_type {
             fn atomic_load_acquire(src: &mut $int_type) -> $int_type {
-                let a: &mut $atomic_type = $atomic_type::from_mut(src);
+                // Safety: the single mutable reference guarantees unique ownership. Memory layouts are identical for
+                // support atomic types.
+                let a: &$atomic_type = unsafe { &*(src as *mut $int_type).cast() };
                 a.load(atomic::Ordering::Acquire)
             }
 
             fn atomic_store_release(dest: &mut $int_type, val: $int_type) {
-                let a: &mut $atomic_type = $atomic_type::from_mut(dest);
+                // Safety: the single mutable reference guarantees unique ownership. Memory layouts are identical for
+                // support atomic types.
+                let a: &$atomic_type = unsafe { &*(dest as *mut $int_type).cast() };
                 a.store(val, atomic::Ordering::Release);
             }
 

--- a/src/rust/inetstack/protocols/tcp/established/background/acknowledger.rs
+++ b/src/rust/inetstack/protocols/tcp/established/background/acknowledger.rs
@@ -9,14 +9,17 @@ use crate::runtime::{
     timer::SharedTimer,
     watched::SharedWatchedValue,
 };
-use ::futures::future::{
-    self,
-    Either,
-    FutureExt,
+use ::futures::{
+    future::{
+        self,
+        Either,
+        FutureExt,
+    },
+    never::Never,
 };
 use ::std::time::Instant;
 
-pub async fn acknowledger<N: NetworkRuntime>(mut cb: SharedControlBlock<N>, yielder: Yielder) -> Result<!, Fail> {
+pub async fn acknowledger<N: NetworkRuntime>(mut cb: SharedControlBlock<N>, yielder: Yielder) -> Result<Never, Fail> {
     loop {
         // TODO: Implement TCP delayed ACKs, subject to restrictions from RFC 1122
         // - TCP should implement a delayed ACK

--- a/src/rust/inetstack/protocols/tcp/established/background/retransmitter.rs
+++ b/src/rust/inetstack/protocols/tcp/established/background/retransmitter.rs
@@ -11,17 +11,20 @@ use crate::{
         watched::SharedWatchedValue,
     },
 };
-use ::futures::future::{
-    self,
-    Either,
-    FutureExt,
+use ::futures::{
+    future::{
+        self,
+        Either,
+        FutureExt,
+    },
+    never::Never,
 };
 use ::std::time::{
     Duration,
     Instant,
 };
 
-pub async fn retransmitter<N: NetworkRuntime>(mut cb: SharedControlBlock<N>, yielder: Yielder) -> Result<!, Fail> {
+pub async fn retransmitter<N: NetworkRuntime>(mut cb: SharedControlBlock<N>, yielder: Yielder) -> Result<Never, Fail> {
     loop {
         // Pin future for timeout retransmission.
         let mut rtx_deadline_watched: SharedWatchedValue<Option<Instant>> = cb.watch_retransmit_deadline();

--- a/src/rust/inetstack/protocols/tcp/established/background/sender.rs
+++ b/src/rust/inetstack/protocols/tcp/established/background/sender.rs
@@ -19,13 +19,16 @@ use crate::{
         watched::SharedWatchedValue,
     },
 };
-use ::futures::FutureExt;
+use ::futures::{
+    never::Never,
+    FutureExt,
+};
 use ::std::{
     cmp,
     time::Duration,
 };
 
-pub async fn sender<N: NetworkRuntime>(mut cb: SharedControlBlock<N>, yielder: Yielder) -> Result<!, Fail> {
+pub async fn sender<N: NetworkRuntime>(mut cb: SharedControlBlock<N>, yielder: Yielder) -> Result<Never, Fail> {
     'top: loop {
         // First, check to see if there's any unsent data.
         // TODO: Change this to just look at the unsent queue to see if it is empty or not.

--- a/src/rust/inetstack/protocols/tcp/established/ctrlblk.rs
+++ b/src/rust/inetstack/protocols/tcp/established/ctrlblk.rs
@@ -48,6 +48,7 @@ use crate::{
         SharedObject,
     },
 };
+use ::futures::never::Never;
 use ::std::{
     collections::VecDeque,
     convert::TryInto,
@@ -394,7 +395,7 @@ impl<N: NetworkRuntime> SharedControlBlock<N> {
     }
 
     // This is the main TCP processing routine.
-    pub async fn poll(&mut self, yielder: Yielder) -> Result<!, Fail> {
+    pub async fn poll(&mut self, yielder: Yielder) -> Result<Never, Fail> {
         // Normal data processing in the Established state.
         loop {
             let (header, data): (TcpHeader, DemiBuffer) = match self.recv_queue.pop(&yielder).await {

--- a/src/rust/lib.rs
+++ b/src/rust/lib.rs
@@ -4,9 +4,7 @@
 #![cfg_attr(feature = "strict", deny(clippy:all))]
 #![recursion_limit = "512"]
 #![feature(test)]
-#![feature(type_alias_impl_trait)]
 #![feature(allocator_api)]
-#![feature(slice_ptr_get)]
 #![feature(strict_provenance)]
 #![cfg_attr(target_os = "windows", feature(maybe_uninit_uninit_array))]
 

--- a/src/rust/lib.rs
+++ b/src/rust/lib.rs
@@ -3,7 +3,6 @@
 
 #![cfg_attr(feature = "strict", deny(clippy:all))]
 #![recursion_limit = "512"]
-#![feature(atomic_from_mut)]
 #![feature(test)]
 #![feature(type_alias_impl_trait)]
 #![feature(allocator_api)]

--- a/src/rust/lib.rs
+++ b/src/rust/lib.rs
@@ -4,7 +4,6 @@
 #![cfg_attr(feature = "strict", deny(clippy:all))]
 #![recursion_limit = "512"]
 #![feature(atomic_from_mut)]
-#![feature(never_type)]
 #![feature(test)]
 #![feature(type_alias_impl_trait)]
 #![feature(allocator_api)]


### PR DESCRIPTION
This PR moves Demikernel closer to stable Rust, removing never_type, type_alias_impl_trait, and slice_ptr_get.