### PR TITLE
[build] Enhancement: Bump socket2 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ log = "0.4.20"
 mimalloc = { version = "0.1.39", default-features = false }
 rand = { version = "0.8.5", features = ["small_rng"] }
 slab = "0.4.9"
-socket2 = "0.5.5"
+socket2 = "0.5.6"
 yaml-rust = "0.4.5"
 x86 = "0.52.0"
 
@@ -61,7 +61,7 @@ windows = { version = "0.52.0", features = [
     "Win32_System_Threading",
 ] }
 # for interacting with socket2.
-windows-sys = { version = "0.48.0", features = ["Win32_Networking_WinSock"] }
+windows-sys = { version = "0.52.0", features = ["Win32_Networking_WinSock"] }
 
 #=======================================================================================================================
 # Targets


### PR DESCRIPTION
The windows build seems to be taking the newest version of socket2 available, so we need to bump the windows-sys crate to match.