### PR TITLE
[testing] Add multicore support to tcp echo

### DIFF
--- a/examples/tcp-echo/main.rs
+++ b/examples/tcp-echo/main.rs
@@ -25,6 +25,8 @@ use server::TcpEchoServer;
 use std::{
     net::SocketAddr,
     str::FromStr,
+    thread,
+    thread::JoinHandle,
     time::Duration,
 };
 
@@ -66,6 +68,8 @@ pub struct ProgramArguments {
     nrequests: Option<usize>,
     /// Number of clients.
     nclients: Option<usize>,
+    /// Number of threads.
+    nthreads: Option<usize>,
     /// Log interval.
     log_interval: Option<u64>,
     /// Peer type.
@@ -110,7 +114,15 @@ impl ProgramArguments {
                     .value_parser(clap::value_parser!(usize))
                     .required(false)
                     .value_name("NUMBER")
-                    .help("Sets number of clients"),
+                    .help("Sets number of clients (per thread)"),
+            )
+            .arg(
+                Arg::new("nthreads")
+                    .long("nthreads")
+                    .value_parser(clap::value_parser!(usize))
+                    .required(false)
+                    .value_name("NUMBER")
+                    .help("Sets number of threads"),
             )
             .arg(
                 Arg::new("nrequests")
@@ -151,6 +163,7 @@ impl ProgramArguments {
             bufsize: None,
             nrequests: None,
             nclients: None,
+            nthreads: None,
             log_interval: None,
             peer_type: "server".to_string(),
         };
@@ -181,6 +194,13 @@ impl ProgramArguments {
             }
         }
 
+        // Number of clients.
+        if let Some(nthreads) = matches.get_one::<usize>("nthreads") {
+            if *nthreads > 0 {
+                args.nthreads = Some(*nthreads);
+            }
+        }
+
         // Log interval.
         if let Some(log_interval) = matches.get_one::<u64>("log") {
             if *log_interval > 0 {
@@ -203,6 +223,50 @@ impl ProgramArguments {
     }
 }
 
+fn start_server_thread(
+    libos_name: LibOSName,
+    addr: SocketAddr,
+    log_interval: Option<u64>,
+) -> Result<JoinHandle<Result<()>>> {
+    Ok(thread::spawn(move || -> Result<()> {
+        let libos: LibOS = match LibOS::new(libos_name) {
+            Ok(libos) => libos,
+            Err(e) => anyhow::bail!("failed to initialize libos: {:?}", e.cause),
+        };
+        let mut server: TcpEchoServer = TcpEchoServer::new(libos, addr)?;
+        server.run(log_interval)
+    }))
+}
+
+fn start_client_thread(
+    libos_name: LibOSName,
+    nclients: usize,
+    nrequests: Option<usize>,
+    bufsize: usize,
+    run_mode: &String,
+    addr: SocketAddr,
+    log_interval: Option<u64>,
+) -> Result<JoinHandle<Result<()>>> {
+    match run_mode.as_str() {
+        "sequential" => Ok(thread::spawn(move || -> Result<()> {
+            let libos: LibOS = match LibOS::new(libos_name) {
+                Ok(libos) => libos,
+                Err(e) => anyhow::bail!("failed to initialize libos: {:?}", e.cause),
+            };
+            let mut client: TcpEchoClient = TcpEchoClient::new(libos, bufsize, addr)?;
+            client.run_sequential(log_interval, nclients, nrequests)
+        })),
+        "concurrent" => Ok(thread::spawn(move || -> Result<()> {
+            let libos: LibOS = match LibOS::new(libos_name) {
+                Ok(libos) => libos,
+                Err(e) => anyhow::bail!("failed to initialize libos: {:?}", e.cause),
+            };
+            let mut client: TcpEchoClient = TcpEchoClient::new(libos, bufsize, addr)?;
+            client.run_concurrent(log_interval, nclients, nrequests)
+        })),
+        _ => anyhow::bail!("invalid run mode"),
+    }
+}
 //======================================================================================================================
 
 fn main() -> Result<()> {
@@ -216,31 +280,37 @@ fn main() -> Result<()> {
         Ok(libos_name) => libos_name.into(),
         Err(e) => anyhow::bail!("{:?}", e),
     };
-    let libos: LibOS = match LibOS::new(libos_name) {
-        Ok(libos) => libos,
-        Err(e) => anyhow::bail!("failed to initialize libos: {:?}", e.cause),
-    };
 
+    let run_mode: String = args.run_mode.ok_or(anyhow::anyhow!("missing run mode"))?;
+    let mut threads = vec![];
     match args.peer_type.as_str() {
         "server" => {
-            let mut server: TcpEchoServer = TcpEchoServer::new(libos, args.addr)?;
-            server.run(args.log_interval)?;
+            for _ in 0..args.nthreads.unwrap_or(1) {
+                if let Ok(handle) = start_server_thread(libos_name, args.addr, args.log_interval) {
+                    threads.push(handle)
+                }
+            }
         },
         "client" => {
-            let mut client: TcpEchoClient = TcpEchoClient::new(
-                libos,
-                args.bufsize.ok_or(anyhow::anyhow!("missing buffer size"))?,
-                args.addr,
-            )?;
-            let nclients: usize = args.nclients.ok_or(anyhow::anyhow!("missing number of clients"))?;
-            match args.run_mode.ok_or(anyhow::anyhow!("missing run mode"))?.as_str() {
-                "sequential" => client.run_sequential(args.log_interval, nclients, args.nrequests)?,
-                "concurrent" => client.run_concurrent(args.log_interval, nclients, args.nrequests)?,
-                _ => anyhow::bail!("invalid run mode"),
+            for _ in 0..args.nthreads.unwrap_or(1) {
+                if let Ok(handle) = start_client_thread(
+                    libos_name,
+                    args.nclients.ok_or(anyhow::anyhow!("missing number of clients"))?,
+                    args.nrequests,
+                    args.bufsize.ok_or(anyhow::anyhow!("missing buffer size"))?,
+                    &run_mode,
+                    args.addr,
+                    args.log_interval,
+                ) {
+                    threads.push(handle);
+                }
             }
         },
         _ => todo!(),
     }
 
+    for handle in threads {
+        handle.join().unwrap()?;
+    }
     Ok(())
 }

--- a/examples/tcp-echo/main.rs
+++ b/examples/tcp-echo/main.rs
@@ -281,7 +281,6 @@ fn main() -> Result<()> {
         Err(e) => anyhow::bail!("{:?}", e),
     };
 
-    let run_mode: String = args.run_mode.ok_or(anyhow::anyhow!("missing run mode"))?;
     let mut threads = vec![];
     match args.peer_type.as_str() {
         "server" => {
@@ -292,6 +291,7 @@ fn main() -> Result<()> {
             }
         },
         "client" => {
+            let run_mode: String = args.run_mode.ok_or(anyhow::anyhow!("missing run mode"))?;
             for _ in 0..args.nthreads.unwrap_or(1) {
                 if let Ok(handle) = start_client_thread(
                     libos_name,

--- a/src/rust/catnap/linux/transport.rs
+++ b/src/rust/catnap/linux/transport.rs
@@ -287,6 +287,7 @@ impl NetworkTransport for SharedCatnapTransport {
                     error!("new(): {}", cause);
                     return Err(Fail::new(get_libc_err(e), &cause));
                 }
+
                 if let Err(e) = socket.set_nonblocking(true) {
                     let cause: String = format!("cannot set NONBLOCKING option: {:?}", e);
                     socket.shutdown(Shutdown::Both)?;
@@ -328,6 +329,20 @@ impl NetworkTransport for SharedCatnapTransport {
     fn bind(&mut self, sd: &mut Self::SocketDescriptor, local: SocketAddr) -> Result<(), Fail> {
         trace!("Bind to {:?}", local);
         let socket: &mut Socket = self.socket_from_sd(sd);
+
+        // Set SO_REUSE_PORT.
+        let optval: libc::c_int = 1;
+        let optval_len: libc::socklen_t = std::mem::size_of_val(&optval) as libc::socklen_t;
+        if unsafe {
+            libc::setsockopt(
+                socket.as_raw_fd(),
+                libc::SOL_SOCKET,
+                libc::SO_REUSEPORT,
+                &optval as *const _ as *const libc::c_void,
+                optval_len,
+            )
+        } < 0
+        {}
         if let Err(e) = socket.bind(&local.into()) {
             let cause: String = format!("failed to bind socket: {:?}", e);
             error!("bind(): {}", cause);

--- a/src/rust/catnap/win/overlapped.rs
+++ b/src/rust/catnap/win/overlapped.rs
@@ -6,14 +6,8 @@
 //==============================================================================
 
 use std::{
-    cell::{
-        Cell,
-        UnsafeCell,
-    },
-    marker::{
-        PhantomData,
-        PhantomPinned,
-    },
+    cell::Cell,
+    marker::PhantomData,
     pin::Pin,
 };
 
@@ -38,12 +32,10 @@ use windows::Win32::{
 
 use crate::{
     catnap::transport::error::translate_ntstatus,
+    collections::pin_slab::PinSlab,
     runtime::{
         fail::Fail,
-        scheduler::{
-            Yielder,
-            YielderHandle,
-        },
+        SharedConditionVariable,
     },
 };
 
@@ -64,37 +56,31 @@ pub struct OverlappedResult {
 
 /// Data required by the I/O completion port processor to process I/O completions.
 #[repr(C)]
-struct OverlappedCompletion {
+struct OverlappedCompletion<S: Unpin> {
     /// OVERLAPPED must be first; the implementation casts between the outer structure and this type.
     overlapped: OVERLAPPED,
     /// If set, indicates a coroutine in waiting. Cleared by the I/O processor to signal completion. If unset when an
     /// overlapped is dequeued from the completion port, the completion is abandoned.
-    yielder_handle: Option<YielderHandle>,
+    condition_variable: Option<SharedConditionVariable>,
+    /// If set, indicates that this completion is pinned in the pin slab.
+    pinslab_index: Option<usize>,
     /// Set by the I/O processor to indicate overlapped result.
     completion_key: usize,
-    /// A callback to free all resources associated with the completion for abandoned waits.
-    free: unsafe fn(*mut OVERLAPPED) -> (),
-    /// Ensure the data stays pinned since the OVERLAPPED must be pinned.
-    _marker: PhantomPinned,
-}
-
-/// The set of data which must live as long as the I/O operation, including any optional state from the caller.
-#[repr(C)]
-struct StatefulOverlappedCompletion<S> {
-    /// Inner data required by the completion processor; must be first to "downcast" to OVERLAPPED.
-    inner: OverlappedCompletion,
-    /// Caller state, encased in a cell for interior mutability.
-    state: UnsafeCell<S>,
+    /// Operation type and state associated with that type.
+    state: S,
 }
 
 /// This struct encapsulates the behavior of Windows I/O completion ports. This implementation exposes a single
 /// threaded interface for invoking and processing the results of overlapped I/O via idiomatic start-cancel-finish
 /// operations. While this type implements `Send`, multiple threads should avoid calling `process_events`, as there may
 /// be overhead or OS limitations on the number of such threads. This type cannot be shared among threads.
-pub struct IoCompletionPort {
+/// 'S' represents the operation state that needs to be pinned per overlapped operation. It is stored in the pin slab
+/// for the entirety of the operation and then unpinned and freed.
+pub struct IoCompletionPort<S: Unpin> {
     /// The OS handle to the completion port.
     iocp: HANDLE,
-
+    /// Ongoing overlapped I/O operations. This is purely for reference counting
+    ops: PinSlab<OverlappedCompletion<S>>,
     /// Marker to prevent this type from implementing `Sync`.
     _marker: PhantomData<Cell<()>>,
 }
@@ -106,7 +92,7 @@ pub struct IoCompletionPort {
 impl OverlappedResult {
     /// Create an OverlappedResult from the completed OVERLAPPED structure and the completion key returned from the
     /// I/O completion port.
-    pub fn new(overlapped: &OVERLAPPED, completion_key: usize) -> OverlappedResult {
+    pub fn new(overlapped: OVERLAPPED, completion_key: usize) -> OverlappedResult {
         Self {
             completion_key,
             result: NTSTATUS(overlapped.Internal as i32),
@@ -125,9 +111,9 @@ impl OverlappedResult {
     }
 }
 
-impl IoCompletionPort {
+impl<S: Unpin> IoCompletionPort<S> {
     /// Create a new I/O completion port.
-    pub fn new() -> Result<IoCompletionPort, Fail> {
+    pub fn new() -> Result<IoCompletionPort<S>, Fail> {
         let iocp: HANDLE = match unsafe { CreateIoCompletionPort(INVALID_HANDLE_VALUE, None, 0, 1) } {
             Ok(handle) => handle,
             Err(err) => return Err(err.into()),
@@ -141,6 +127,7 @@ impl IoCompletionPort {
 
         Ok(IoCompletionPort {
             iocp,
+            ops: PinSlab::<OverlappedCompletion<S>>::default(),
             _marker: PhantomData,
         })
     }
@@ -172,108 +159,57 @@ impl IoCompletionPort {
     /// completion port, `finish` is invoked with the OverlappedResult type and the state (the same reference passed to
     /// `start`). The return of `finish` is returned from the method.
     ///
-    /// Note that the state type S is bound to the `'static` lifetime. The state object is dynamically allocated and may
-    /// outlive this function. An example here may be a failed cancellation: a call to `ReadFile` or `WSARecv` may be in
-    /// the process of filling the receive buffer when a cancellation occurs (presumably kept alive by S). In this case,
-    /// `CancelIo` will fail. Assuming the caller returns before the OVERLAPPED is dequeued, S may live longer than the
-    /// calling method.
-    ///
     /// Safety: `start` should return Ok(...) iff the I/O is started and the OVERLAPPED parameter will
     /// eventually be dequeued from the completion port; if this requirement is not met, resources will leak. Likewise,
     /// `cancel` should return Ok(...) iff the operation is cancelled and the OVERLAPPED parameter will never be
     /// dequeued from the completion port.  Waking the Yielder for errors which are no ECANCELLED will abandon the wait.
     /// While OVERLAPPED resources will be freed in a non-exceptional scenario, this may cause unsound behavior I/O on
     /// the same file/socket.
-    pub async unsafe fn do_io_with<F1, F2, F3, R, S>(
-        &mut self,
-        state: S,
-        yielder: &Yielder,
-        start: F1,
-        cancel: F2,
-        finish: F3,
-    ) -> Result<R, Fail>
+    pub async unsafe fn do_io<F1, F2, R>(&mut self, state: S, start: F1, finish: F2) -> Result<R, Fail>
     where
-        S: 'static,
         for<'a> F1: FnOnce(Pin<&'a mut S>, *mut OVERLAPPED) -> Result<(), Fail>,
-        for<'a> F2: FnOnce(Pin<&'a mut S>, *mut OVERLAPPED) -> Result<(), Fail>,
-        for<'a> F3: FnOnce(Pin<&'a mut S>, OverlappedResult) -> Result<R, Fail>,
+        for<'a> F2: FnOnce(Pin<&'a mut S>, OverlappedResult) -> Result<R, Fail>,
     {
-        let mut completion: Pin<Box<StatefulOverlappedCompletion<S>>> = Box::pin(StatefulOverlappedCompletion {
-            inner: OverlappedCompletion {
-                overlapped: OVERLAPPED::default(),
-                yielder_handle: Some(yielder.get_handle()),
-                completion_key: 0,
-                free: StatefulOverlappedCompletion::<S>::drop_overlapped,
-                _marker: PhantomPinned,
+        // Allocate a new Overlapped completion in the pin slab.
+        let pinslab_index: usize = match self.ops.insert(OverlappedCompletion::new(state)) {
+            Some(index) => index,
+            None => {
+                return Err(Fail::new(
+                    libc::EINVAL,
+                    "Could not allocate space for overlapped completion",
+                ))
             },
-            state: UnsafeCell::new(state),
-        });
+        };
+        // Grab a reference to the new completion in the pin slab.
+        let mut pinned_completion: Pin<&mut OverlappedCompletion<S>> =
+            self.ops.get_pin_mut(pinslab_index).expect("Just inserted this");
 
-        let overlapped: *mut OVERLAPPED = completion.as_mut().marshal();
-        match start(completion.get_state_ref(), overlapped) {
+        // Set the pinslab index so the I/O processor can remove it later if necessary.
+        pinned_completion.as_mut().set_pinslab_index(pinslab_index);
+
+        let overlapped: *mut OVERLAPPED = pinned_completion.as_mut().marshal();
+        let result: Result<R, Fail> = match start(pinned_completion.as_mut().get_state(), overlapped) {
             // Operation in progress, pending overlapped completion.
-            Ok(()) => loop {
-                let status: Result<(), Fail> = yielder.yield_until_wake().await;
-
-                // NB If the yielder handle is cleared, the event was dequeued from the completion port and
-                // processed. If the coroutine was also cancelled, depending on the order of scheduling the result
-                // may still indicate failure. YielderHandler absence takes higher precedence here -- no need to
-                // signal failure if it's not semantically useful.
-                if completion.inner.yielder_handle.is_none() {
-                    return finish(
-                        completion.get_state_ref(),
-                        OverlappedResult::new(&completion.inner.overlapped, completion.inner.completion_key),
-                    );
+            Ok(()) => {
+                while let Some(cv) = pinned_completion.as_ref().get_cv() {
+                    cv.wait().await;
                 }
 
-                match status {
-                    Ok(()) => {
-                        // Spurious wake-up.
-                        continue;
-                    },
-
-                    Err(err) => {
-                        if err.errno == libc::ECANCELED {
-                            if let Err(cancel_err) = cancel(completion.get_state_ref(), overlapped) {
-                                warn!("cancellation failed: {}", cancel_err);
-                            }
-                        }
-
-                        // NOTE: the semantics of completion ports with cancellation is unclear: CancelIoEx
-                        // documentation implies that some operations may not post a completion packet after this
-                        // operation. If completions are found to leak, this may be why.
-                        completion.abandon();
-                        return Err(err);
-                    },
-                }
+                let overlapped_result: OverlappedResult = OverlappedResult::new(
+                    pinned_completion.as_mut().overlapped,
+                    pinned_completion.as_mut().completion_key,
+                );
+                // This operation should not have moved but we can remove it now because we know that the overlapped
+                // I/O completed.
+                finish(pinned_completion.as_mut().get_state(), overlapped_result)
             },
 
             // Operation failed to start.
             Err(err) => Err(err),
-        }
-    }
-
-    /// Same as `do_io_with`, but does not use an intermediate state value.
-    pub async unsafe fn do_io<F1, F2, F3, R>(
-        &mut self,
-        yielder: &Yielder,
-        start: F1,
-        cancel: F2,
-        finish: F3,
-    ) -> Result<R, Fail>
-    where
-        F1: FnOnce(*mut OVERLAPPED) -> Result<(), Fail>,
-        F2: FnOnce(*mut OVERLAPPED) -> Result<(), Fail>,
-        F3: FnOnce(OverlappedResult) -> Result<R, Fail>,
-    {
-        self.do_io_with(
-            (),
-            yielder,
-            |_, overlapped: *mut OVERLAPPED| -> Result<(), Fail> { start(overlapped) },
-            |_, overlapped: *mut OVERLAPPED| -> Result<(), Fail> { cancel(overlapped) },
-            |_, result: OverlappedResult| -> Result<R, Fail> { finish(result) },
-        )
-        .await
+        };
+        // Finally safe to unpin this completion.
+        self.ops.remove_unpin(pinslab_index);
+        result
     }
 
     /// Process a single overlapped entry.
@@ -282,19 +218,19 @@ impl IoCompletionPort {
         if let Some(overlapped) = std::ptr::NonNull::new(entry.lpOverlapped) {
             // Safety: this is valid as long as the caller follows the contract: all queued OVERLAPPED instances are
             // generated by `IoCompletionPort` API.
-            let overlapped: Pin<&mut OverlappedCompletion> = OverlappedCompletion::unmarshal(overlapped);
+            let mut overlapped: Pin<&mut OverlappedCompletion<S>> = OverlappedCompletion::unmarshal(overlapped);
 
             // Safety: the OVERLAPPED does not need to be pinned after being dequeued from the completion port.
-            let overlapped: &mut OverlappedCompletion = unsafe { overlapped.get_unchecked_mut() };
-            if let Some(mut yielder_handle) = overlapped.yielder_handle.take() {
-                debug_assert!(entry.dwNumberOfBytesTransferred as usize == overlapped.overlapped.InternalHigh);
-                overlapped.completion_key = entry.lpCompletionKey;
-                yielder_handle.wake_with(Ok(()));
+            if let Some(mut cv) = overlapped.as_mut().take_cv() {
+                debug_assert!(entry.dwNumberOfBytesTransferred as usize == overlapped.as_ref().overlapped.InternalHigh);
+                unsafe { overlapped.get_unchecked_mut() }.completion_key = entry.lpCompletionKey;
+                cv.signal();
             } else {
                 // This can happen due to a failed cancellation or any other error on the do_overlapped path.
                 trace!("I/O dropped for completion key {}", entry.lpCompletionKey);
-                let free_fn: unsafe fn(*mut OVERLAPPED) = overlapped.free;
-                unsafe { (free_fn)(entry.lpOverlapped) };
+                if let Some(pinslab_index) = overlapped.as_mut().get_pinslab_index() {
+                    self.ops.remove_unpin(pinslab_index);
+                }
             }
         }
     }
@@ -330,50 +266,54 @@ impl IoCompletionPort {
     }
 }
 
-impl OverlappedCompletion {
-    /// Marshal an OVERLAPPED pointer back into an OverlappedCompletion.
-    fn unmarshal<'a>(overlapped: std::ptr::NonNull<OVERLAPPED>) -> Pin<&'a mut Self> {
-        unsafe { Pin::new_unchecked(&mut *(overlapped.as_ptr() as *mut Self)) }
-    }
-}
+impl<S: Unpin> OverlappedCompletion<S> {
+    pub fn new(state: S) -> Self {
+        let cv: SharedConditionVariable = SharedConditionVariable::default();
 
-impl<S> StatefulOverlappedCompletion<S> {
-    /// Marshal a StatefulOverlappedCompletion into an OVERLAPPED pointer. This type must be pinned for marshaling.
-    fn marshal(mut self: Pin<&mut Self>) -> *mut OVERLAPPED {
-        unsafe { self.as_mut().get_unchecked_mut() as *mut Self }.cast()
-    }
-
-    /// Called by the I/O event processor to free this instance if the completion is abandoned by the waiter.
-    unsafe fn drop_overlapped(overlapped: *mut OVERLAPPED) {
-        if overlapped != std::ptr::null_mut() {
-            let overlapped: *mut Self = overlapped.cast();
-            let overlapped: Box<Self> = unsafe { Box::from_raw(overlapped) };
-            std::mem::drop(overlapped);
+        Self {
+            overlapped: OVERLAPPED::default(),
+            condition_variable: Some(cv),
+            pinslab_index: None,
+            completion_key: 0,
+            state,
         }
     }
 
-    /// Structural pinning (required) for `inner`.
-    fn get_inner<'a>(self: &'a mut Pin<Box<Self>>) -> Pin<&'a mut OverlappedCompletion> {
-        unsafe { Pin::new_unchecked(&mut self.as_mut().get_unchecked_mut().inner) }
+    /// Take the condition variable from this struct. The condition variable is not structurally pinned.
+    pub fn take_cv(self: Pin<&mut Self>) -> Option<SharedConditionVariable> {
+        // Safety: updating the condition variable does not violate pinning invariants.
+        self.get_mut().condition_variable.take()
     }
 
-    /// Structure pinning (probably required) for `state`.
-    fn get_state_ref<'a>(self: &Pin<Box<Self>>) -> Pin<&'a mut S> {
-        unsafe { Pin::new_unchecked(&mut *self.state.get()) }
+    /// Check whether the condition variable is still set.
+    pub fn get_cv(self: Pin<&Self>) -> Option<SharedConditionVariable> {
+        self.condition_variable.clone()
     }
 
-    /// Set the yielder handle for the waiter. The yielder handle is not structurally pinned.
-    fn set_yielder(self: &mut Pin<Box<Self>>, yielder_handle: Option<YielderHandle>) {
-        // Safety: updating the yielder does not violate pinning invariants.
-        unsafe { self.get_inner().get_unchecked_mut() }.yielder_handle = yielder_handle;
+    /// Sets the index into the ops table for this completion.
+    pub fn set_pinslab_index(self: Pin<&mut Self>, index: usize) {
+        self.get_mut().pinslab_index = Some(index);
     }
 
-    /// Abandon this overlapped instance. This will consume and forget `self` so that the waiter may return without
-    /// invalidating memory needed by the I/O event processor. This method should only be called when the OVERLAPPED
-    /// has not yet been dequeued from the completion port.
-    unsafe fn abandon(mut self: Pin<Box<Self>>) {
-        self.set_yielder(None);
-        std::mem::forget(self)
+    /// Gets the index into the ops table for this completion.
+    pub fn get_pinslab_index(self: Pin<&mut Self>) -> Option<usize> {
+        self.pinslab_index
+    }
+
+    /// Marshal a OverlappedCompletion into an OVERLAPPED pointer. This type must be pinned for marshaling.
+    pub fn marshal(mut self: Pin<&mut Self>) -> *mut OVERLAPPED {
+        unsafe { self.as_mut().get_unchecked_mut() as *mut Self }.cast()
+    }
+
+    /// Marshal an OVERLAPPED pointer back into an OverlappedCompletion.
+    pub fn unmarshal<'a>(overlapped: std::ptr::NonNull<OVERLAPPED>) -> Pin<&'a mut Self> {
+        unsafe { Pin::new_unchecked(&mut *(overlapped.as_ptr() as *mut Self)) }
+    }
+
+    /// Grab the state from its offset inside the OverlappedCompletion.
+    /// Safety: This field cannot move as long as it is inside the pinslab.
+    pub fn get_state(self: Pin<&mut Self>) -> Pin<&mut S> {
+        unsafe { Pin::new_unchecked(&mut self.get_unchecked_mut().state) }
     }
 }
 
@@ -381,7 +321,7 @@ impl<S> StatefulOverlappedCompletion<S> {
 // Traits
 //======================================================================================================================
 
-impl Drop for IoCompletionPort {
+impl<S: Unpin> Drop for IoCompletionPort<S> {
     /// Close the underlying handle when the completion port is dropped. The underlying primitive will not be freed
     /// until until all `associate`d handles are closed.
     fn drop(&mut self) {
@@ -391,38 +331,46 @@ impl Drop for IoCompletionPort {
 
 #[cfg(test)]
 mod tests {
+    use crate::{
+        ensure_eq,
+        runtime::{
+            conditional_yield_with_timeout,
+            Operation,
+            SharedDemiRuntime,
+        },
+        OperationResult,
+        QDesc,
+        QToken,
+    };
+    use futures::pin_mut;
     use std::{
+        cell::UnsafeCell,
         iter,
-        pin::pin,
         ptr::NonNull,
         rc::Rc,
         sync::atomic::{
             AtomicU32,
             Ordering,
         },
-    };
-
-    use crate::{
-        ensure_eq,
-        runtime::scheduler::{
-            Scheduler,
-            Task,
-            TaskId,
-            TaskWithResult,
+        task::{
+            Context,
+            Poll,
+        },
+        time::{
+            Duration,
+            Instant,
         },
     };
 
     use super::*;
-    use ::futures::{
-        future::FusedFuture,
-        FutureExt,
-    };
+    use ::futures::FutureExt;
     use anyhow::{
         anyhow,
         bail,
         ensure,
         Result,
     };
+    use futures::Future;
     use windows::{
         core::{
             s,
@@ -453,15 +401,37 @@ mod tests {
                     PIPE_REJECT_REMOTE_CLIENTS,
                     PIPE_TYPE_MESSAGE,
                 },
-                IO::{
-                    CancelIoEx,
-                    PostQueuedCompletionStatus,
-                },
+                IO::PostQueuedCompletionStatus,
             },
         },
     };
 
     struct SafeHandle(HANDLE);
+
+    // A future wrapper which will poll the wrapped future exactly once.
+    struct PollOnceFuture<F: Future<Output = (QDesc, OperationResult)>> {
+        future: F,
+        count: usize,
+    }
+
+    impl<F: Future<Output = (QDesc, OperationResult)>> Future for PollOnceFuture<F> {
+        type Output = (QDesc, OperationResult);
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<(QDesc, OperationResult)> {
+            if self.count == 0 {
+                // Safety: count is not structurally pinned.
+                unsafe { self.as_mut().get_unchecked_mut() }.count += 1;
+
+                // Safety: the following does not move any members of self.
+                unsafe { self.map_unchecked_mut(|s| &mut s.future) }.poll(cx)
+            } else {
+                Poll::Ready((
+                    QDesc::from(0),
+                    OperationResult::Failed(Fail::new(libc::EALREADY, "called more than once")),
+                ))
+            }
+        }
+    }
 
     impl Drop for SafeHandle {
         fn drop(&mut self) {
@@ -470,12 +440,16 @@ mod tests {
     }
 
     /// Create an I/O completion port, mapping the error return to
-    fn make_iocp() -> Result<IoCompletionPort> {
+    fn make_iocp<S: Unpin>() -> Result<IoCompletionPort<S>> {
         IoCompletionPort::new().map_err(|err: Fail| anyhow!("Failed to create I/O completion port: {}", err))
     }
 
     /// Post an overlapped instance to the I/O completion port.
-    fn post_completion(iocp: &IoCompletionPort, overlapped: *const OVERLAPPED, completion_key: usize) -> Result<()> {
+    fn post_completion<S: Unpin>(
+        iocp: &IoCompletionPort<S>,
+        overlapped: *const OVERLAPPED,
+        completion_key: usize,
+    ) -> Result<()> {
         unsafe { PostQueuedCompletionStatus(iocp.iocp, 0, completion_key, Some(overlapped)) }
             .map_err(|err| anyhow!("PostQueuedCompletionStatus failed: {}", err))
     }
@@ -498,45 +472,45 @@ mod tests {
         }
     }
 
+    // An async function which can be marshaled into an Operation and which wraps some other async function which
+    // returns Result<...>.
+    async fn run_as_io_op<F: Future<Output = Result<OperationResult, Fail>>>(future: F) -> (QDesc, OperationResult) {
+        match future.await {
+            Ok(result) => (QDesc::from(0), result),
+            Err(err) => (QDesc::from(0), OperationResult::Failed(err)),
+        }
+    }
+
     #[test]
     fn test_marshal_unmarshal() -> Result<()> {
-        let mut completion: Pin<&mut StatefulOverlappedCompletion<()>> = pin!(StatefulOverlappedCompletion {
-            inner: OverlappedCompletion {
-                overlapped: OVERLAPPED::default(),
-                yielder_handle: None,
-                completion_key: 0,
-                free: StatefulOverlappedCompletion::<()>::drop_overlapped,
-                _marker: PhantomPinned,
-            },
-            state: UnsafeCell::new(()),
-        });
+        let mut completion: Pin<Box<OverlappedCompletion<()>>> = Box::pin(OverlappedCompletion::new(()));
 
         // Ensure that the marshal returns the address of the overlapped member.
         ensure_eq!(
             completion.as_mut().marshal() as *const OVERLAPPED as usize,
-            &completion.inner.overlapped as *const OVERLAPPED as usize
+            &completion.overlapped as *const OVERLAPPED as usize
         );
 
         // Ensure that marshal returns the address of the completion.
         ensure_eq!(
             completion.as_mut().marshal() as usize,
-            completion.as_ref().get_ref() as *const StatefulOverlappedCompletion<()> as usize
+            completion.as_ref().get_ref() as *const OverlappedCompletion<()> as usize
         );
 
         // This can be inferred transitively from above. The overlapped member must be at offset 0.
         ensure_eq!(
-            (&completion.inner.overlapped as *const OVERLAPPED) as usize,
-            (completion.as_ref().get_ref() as *const StatefulOverlappedCompletion<()>) as usize
+            (&completion.overlapped as *const OVERLAPPED) as usize,
+            (completion.as_ref().get_ref() as *const OverlappedCompletion<()>) as usize
         );
 
         let overlapped_ptr: NonNull<OVERLAPPED> = NonNull::new(completion.as_mut().marshal()).unwrap();
-        let unmarshalled: Pin<&mut OverlappedCompletion> = OverlappedCompletion::unmarshal(overlapped_ptr);
+        let unmarshalled: Pin<&mut OverlappedCompletion<()>> = OverlappedCompletion::unmarshal(overlapped_ptr);
 
         // Test that unmarshal returns an address which is the same as the OVERLAPPED, which is the same as the original
-        // StatefulOverlappedCompletion. This implies that OVERLAPPED is at member offset 0 in all structs.
+        // OverlappedCompletionWithState. This implies that OVERLAPPED is at member offset 0 in all structs.
         ensure_eq!(
-            unmarshalled.as_ref().get_ref() as *const OverlappedCompletion as usize,
-            completion.as_ref().get_ref() as *const StatefulOverlappedCompletion<()> as usize
+            unmarshalled.as_ref().get_ref() as *const OverlappedCompletion<()> as usize,
+            completion.as_ref().get_ref() as *const OverlappedCompletion<()> as usize
         );
 
         Ok(())
@@ -546,38 +520,36 @@ mod tests {
     #[test]
     fn test_event_processor() -> Result<()> {
         const COMPLETION_KEY: usize = 123;
-        let mut iocp: IoCompletionPort = make_iocp()?;
-        let mut yielder_handle: YielderHandle = YielderHandle::new();
-        let mut overlapped: Pin<&mut StatefulOverlappedCompletion<()>> = pin!(StatefulOverlappedCompletion {
-            inner: OverlappedCompletion {
-                overlapped: OVERLAPPED::default(),
-                yielder_handle: Some(yielder_handle.clone()),
-                completion_key: 0,
-                free: StatefulOverlappedCompletion::<()>::drop_overlapped,
-                _marker: PhantomPinned,
-            },
-            state: UnsafeCell::new(()),
-        });
+        let mut iocp: IoCompletionPort<()> = make_iocp()?;
+        let overlapped: OverlappedCompletion<()> = OverlappedCompletion::new(());
+        let cv: SharedConditionVariable = overlapped.condition_variable.clone().unwrap();
+        pin_mut!(overlapped);
 
+        // Insert coroutine
+        let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
+        let server = run_as_io_op(async move {
+            cv.wait().await;
+            Ok(OperationResult::Close)
+        })
+        .fuse();
+
+        let server_task: QToken = runtime.insert_io_coroutine("server", Box::pin(server)).unwrap();
+        ensure!(runtime.run_any(&[server_task]).is_none());
         post_completion(&iocp, overlapped.as_mut().marshal(), COMPLETION_KEY)?;
 
         iocp.process_events()?;
 
-        let unpinned_overlapped: &mut StatefulOverlappedCompletion<()> = unsafe { overlapped.get_unchecked_mut() };
-
         ensure!(
-            unpinned_overlapped.inner.yielder_handle.is_none(),
+            overlapped.condition_variable.is_none(),
             "yielder should be cleared by iocp"
         );
         ensure_eq!(
-            unpinned_overlapped.inner.completion_key,
+            overlapped.as_ref().completion_key,
             COMPLETION_KEY,
             "completion key not updated"
         );
 
-        let result: Option<Result<(), Fail>> = yielder_handle.get_result();
-        ensure!(result.is_some(), "yielder handle not woken");
-        ensure!(result.unwrap().is_ok(), "yielder handle result not success");
+        ensure!(runtime.run_any(&[server_task]).is_some());
 
         Ok(())
     }
@@ -602,23 +574,20 @@ mod tests {
         }?);
         let server_state: Rc<AtomicU32> = Rc::new(AtomicU32::new(0));
         let server_state_view: Rc<AtomicU32> = server_state.clone();
-        let mut iocp: UnsafeCell<IoCompletionPort> = UnsafeCell::new(make_iocp().map_err(anyhow_fail)?);
+        let mut iocp: UnsafeCell<IoCompletionPort<Rc<Vec<u8>>>> = UnsafeCell::new(make_iocp().map_err(anyhow_fail)?);
         iocp.get_mut().associate_handle(server_pipe.0, COMPLETION_KEY)?;
-        let iocp_ref: &mut IoCompletionPort = unsafe { &mut *iocp.get() };
+        let iocp_ref: &mut IoCompletionPort<Rc<Vec<u8>>> = unsafe { &mut *iocp.get() };
 
-        let server: Pin<Box<dyn FusedFuture<Output = Result<(), Fail>>>> = Box::pin(
-            async move {
-                let yielder: Yielder = Yielder::new();
-
+        let server: Pin<Box<Operation>> = Box::pin(
+            run_as_io_op(async move {
                 unsafe {
                     iocp_ref.do_io(
-                        &yielder,
-                        |overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
+                        Rc::new(Vec::<u8>::new()),
+                        |_: Pin<&mut Rc<Vec<u8>>>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
                             server_state.fetch_add(1, Ordering::Relaxed);
                             is_overlapped_ok(ConnectNamedPipe(server_pipe.0, Some(overlapped)))
                         },
-                        |_| -> Result<(), Fail> { Err(Fail::new(libc::ENOTSUP, "cannot cancel")) },
-                        |result: OverlappedResult| -> Result<(), Fail> { result.ok() },
+                        |_: Pin<&mut Rc<Vec<u8>>>, result: OverlappedResult| -> Result<(), Fail> { result.ok() },
                     )
                 }
                 .await?;
@@ -628,9 +597,8 @@ mod tests {
                 let mut buffer: Rc<Vec<u8>> =
                     Rc::new(iter::repeat(0u8).take(BUFFER_SIZE as usize).collect::<Vec<u8>>());
                 buffer = unsafe {
-                    iocp_ref.do_io_with(
+                    iocp_ref.do_io(
                         buffer,
-                        &yielder,
                         |state: Pin<&mut Rc<Vec<u8>>>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
                             let vec: &mut Vec<u8> = Rc::get_mut(state.get_mut()).unwrap();
                             vec.resize(BUFFER_SIZE as usize, 0u8);
@@ -641,7 +609,6 @@ mod tests {
                                 Some(overlapped),
                             ))
                         },
-                        |_, _| -> Result<(), Fail> { Err(Fail::new(libc::ENOTSUP, "cannot cancel")) },
                         |mut state: Pin<&mut Rc<Vec<u8>>>, result: OverlappedResult| -> Result<Rc<Vec<u8>>, Fail> {
                             match result.ok() {
                                 Ok(()) => {
@@ -668,39 +635,31 @@ mod tests {
                     let err_msg: String = format!("expected \"{}\", got \"{}\"", MESSAGE, message);
                     Err(Fail::new(libc::EINVAL, err_msg.as_str()))
                 } else {
-                    Ok(())
+                    // Dummy result
+                    Ok(OperationResult::Close)
                 }
-            }
+            })
             .fuse(),
         );
 
-        let mut scheduler: Scheduler = Scheduler::default();
-        let server_handle: TaskId = scheduler
-            .insert_task(TaskWithResult::<Result<(), Fail>>::new("server".into(), server))
-            .unwrap();
+        let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
+        let server_task: QToken = runtime.insert_io_coroutine("server", server).unwrap();
 
-        let get_server_result = |task: Box<dyn Task>| {
-            TaskWithResult::<Result<(), Fail>>::try_from(task.as_any())
-                .expect("should be correct task type")
-                .get_result()
-                .unwrap()
-        };
-
-        let mut wait_for_state = |scheduler: &mut Scheduler, state| -> Result<(), Fail> {
+        let mut wait_for_state = |state| -> Result<(), Fail> {
             while server_state_view.load(Ordering::Relaxed) < state {
                 iocp.get_mut().process_events()?;
-                // Loop for an arbitrary number of quanta.
-                if let Some(task) = scheduler.get_next_completed_task(64) {
-                    if task.get_id() == server_handle {
-                        return Err(get_server_result(task).unwrap_err());
-                    }
+                if let Some(result) = runtime.run_any(&[server_task]) {
+                    return match result {
+                        (_, _, OperationResult::Failed(e)) => Err(e),
+                        _ => Err(Fail::new(libc::EFAULT, "server completed early unexpectedly")),
+                    };
                 }
             }
 
             Ok(())
         };
 
-        wait_for_state(&mut scheduler, 1)?;
+        wait_for_state(1)?;
 
         let client_handle: SafeHandle = SafeHandle(unsafe {
             CreateFileA(
@@ -714,7 +673,7 @@ mod tests {
             )
         }?);
 
-        wait_for_state(&mut scheduler, 2)?;
+        wait_for_state(2)?;
 
         let mut bytes_written: u32 = 0;
         unsafe {
@@ -728,18 +687,18 @@ mod tests {
 
         std::mem::drop(client_handle);
 
-        let task = loop {
+        let result: OperationResult = loop {
             iocp.get_mut().process_events()?;
-            if let Some(task) = scheduler.get_next_completed_task(64) {
-                if task.get_id() == server_handle {
-                    break task;
-                }
+            runtime.poll();
+            if let Some((_, result)) = runtime.get_completed_task(&server_task) {
+                break result;
             }
         };
 
-        get_server_result(task)?;
-
-        Ok(())
+        match result {
+            OperationResult::Close => Ok(()),
+            _ => bail!("server did not complete successfully"),
+        }
     }
 
     /// Test I/O cancellation.
@@ -763,81 +722,59 @@ mod tests {
         }?);
         let server_state: Rc<AtomicU32> = Rc::new(AtomicU32::new(0));
         let server_state_view: Rc<AtomicU32> = server_state.clone();
-        let mut iocp: UnsafeCell<IoCompletionPort> = UnsafeCell::new(make_iocp().map_err(anyhow_fail)?);
+        let mut iocp: UnsafeCell<IoCompletionPort<()>> = UnsafeCell::new(make_iocp().map_err(anyhow_fail)?);
         iocp.get_mut().associate_handle(server_pipe.0, COMPLETION_KEY)?;
-        let iocp_ref: &mut IoCompletionPort = unsafe { &mut *iocp.get() };
-        let yielder: Yielder = Yielder::new();
-        let mut yielder_handle: YielderHandle = yielder.get_handle();
+        let iocp_ref: &mut IoCompletionPort<()> = unsafe { &mut *iocp.get() };
 
-        let server: Pin<Box<dyn FusedFuture<Output = Result<(), Fail>>>> = Box::pin(
-            async move {
-                let result: Result<(), Fail> = unsafe {
+        let server = run_as_io_op(async move {
+            match conditional_yield_with_timeout(
+                unsafe {
                     iocp_ref.do_io(
-                        &yielder,
-                        |overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
+                        (),
+                        |_: Pin<&mut ()>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
                             server_state.fetch_add(1, Ordering::Relaxed);
                             is_overlapped_ok(ConnectNamedPipe(server_pipe.0, Some(overlapped)))
                         },
-                        |overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
-                            CancelIoEx(server_pipe.0, Some(overlapped)).map_err(Fail::from)
-                        },
-                        |result: OverlappedResult| -> Result<(), Fail> { result.ok() },
+                        |_: Pin<&mut ()>, result: OverlappedResult| -> Result<(), Fail> { result.ok() },
                     )
-                }
-                .await;
-
-                result
+                },
+                Duration::from_micros(100),
+            )
+            .await
+            {
+                Ok(_) => Ok(OperationResult::Close),
+                Err(e) => Ok(OperationResult::Failed(e)),
             }
-            .fuse(),
+        })
+        .fuse();
+
+        let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
+        let server_task: QToken = runtime.insert_io_coroutine("server", Box::pin(server)).unwrap();
+
+        ensure!(
+            server_state_view.load(Ordering::Relaxed) < 1,
+            "server execution should not start yet"
         );
 
-        let mut scheduler: Scheduler = Scheduler::default();
-        let server_handle: TaskId = scheduler
-            .insert_task(TaskWithResult::<Result<(), Fail>>::new("server".into(), server))
-            .unwrap();
+        let iocp_ref: &mut IoCompletionPort<()> = unsafe { &mut *iocp.get() };
+        iocp_ref.process_events()?;
+        ensure!(runtime.run_any(&[server_task]).is_none(), "server should not be done");
 
-        let get_server_result = |task: Box<dyn Task>| {
-            TaskWithResult::<Result<(), Fail>>::try_from(task.as_any())
-                .expect("should be correct task type")
-                .get_result()
-                .unwrap()
-        };
-
-        let mut wait_for_state = |scheduler: &mut Scheduler, state| -> Result<(), Fail> {
-            while server_state_view.load(Ordering::Relaxed) < state {
-                iocp.get_mut().process_events()?;
-                // Loop for an arbitrary number of quanta.
-                if let Some(task) = scheduler.get_next_completed_task(64) {
-                    if task.get_id() == server_handle {
-                        return Err(get_server_result(task).unwrap_err());
-                    }
-                }
-            }
-            Ok(())
-        };
-
-        wait_for_state(&mut scheduler, 1)?;
-
-        yielder_handle.wake_with(Err(Fail::new(libc::ECANCELED, "I/O cancelled")));
-
-        let task = loop {
+        // Poll the runtime again, which
+        let result: OperationResult = loop {
+            // Move time forward, which should time out the operation.
+            runtime.advance_clock(Instant::now());
             iocp.get_mut().process_events()?;
-            if let Some(task) = scheduler.get_next_completed_task(64) {
-                if task.get_id() == server_handle {
-                    break task;
-                }
+            if let Some((i, _, result)) = runtime.run_any(&[server_task]) {
+                ensure_eq!(i, 0);
+                break result;
             }
         };
 
-        let result: Result<(), Fail> = get_server_result(task);
-        if let Err(err) = result {
-            if err.errno == libc::ECANCELED {
-                Ok(())
-            } else {
-                bail!("coroutine failed with unexpected code: {:?}", err)
-            }
-        } else {
-            bail!("expected coroutine to fail")
+        match result {
+            OperationResult::Failed(Fail { errno, cause: _ }) if errno == libc::ETIMEDOUT => Ok(()),
+            OperationResult::Failed(e) => bail!("coroutine failed with unexpected code: {:?}", e),
+            _ => bail!("expected coroutine to fail"),
         }
     }
 }

--- a/src/rust/catnap/win/socket.rs
+++ b/src/rust/catnap/win/socket.rs
@@ -7,7 +7,6 @@
 
 use std::{
     fmt::Debug,
-    marker::PhantomPinned,
     mem::MaybeUninit,
     net::{
         Ipv4Addr,
@@ -115,10 +114,10 @@ pub struct Socket {
 }
 
 /// State type used by `Socket::start_accept` and `Socket::finish_accept`.
+/// This data structure will be pinned along with the completion during the entirety of the overlapped operation.
 pub struct AcceptState {
     new_socket: Option<Socket>,
     buffer: [u8; ACCEPT_BUFFER_LEN],
-    _marker: PhantomPinned,
 }
 
 /// State type used by `Socket::start_pop` and `Socket::finish_pop`.
@@ -126,7 +125,15 @@ pub struct PopState {
     buffer: DemiBuffer,
     address: MaybeUninit<SOCKADDR_STORAGE>,
     addr_len: i32,
-    _marker: PhantomPinned,
+}
+
+pub enum SocketOpState {
+    Accept(AcceptState),
+    // No state for connect.
+    Connect,
+    Pop(PopState),
+    Push(DemiBuffer),
+    Close,
 }
 
 //======================================================================================================================
@@ -139,7 +146,6 @@ impl AcceptState {
         Self {
             new_socket: None,
             buffer: [0u8; ACCEPT_BUFFER_LEN],
-            _marker: PhantomPinned,
         }
     }
 }
@@ -151,7 +157,6 @@ impl PopState {
             buffer,
             address: MaybeUninit::zeroed(),
             addr_len: 0,
-            _marker: PhantomPinned,
         }
     }
 }
@@ -163,7 +168,7 @@ impl Socket {
         protocol: libc::c_int,
         config: &WinConfig,
         extensions: Rc<SocketExtensions>,
-        iocp: &IoCompletionPort,
+        iocp: &IoCompletionPort<SocketOpState>,
     ) -> Result<Socket, Fail> {
         let s: Socket = Socket { s, extensions };
         s.setup_socket(protocol, config)?;
@@ -310,17 +315,15 @@ impl Socket {
 
     /// Start an overlapped accept operation; this must be called from inside IoCompletionPort::do_io/do_socket_io.
     /// Once the operation completes, the AcceptState can be given to `finish_accept` to finish the operation.
-    pub fn start_accept(
-        &self,
-        mut accept_result: Pin<&mut AcceptState>,
-        overlapped: *mut OVERLAPPED,
-    ) -> Result<(), Fail> {
+    pub fn start_accept(&self, state: Pin<&mut SocketOpState>, overlapped: *mut OVERLAPPED) -> Result<(), Fail> {
+        let accept_result: &mut AcceptState = match state.get_mut() {
+            SocketOpState::Accept(ref mut accept_result) => accept_result,
+            _ => unreachable!("must be an accept operation"),
+        };
         let new_socket: Socket = Socket::new_like(self)?;
 
         // Safety: getting the buffer pointer does not violate pinning invariants.
-        let buf_ptr: *mut u8 = unsafe { accept_result.as_mut().get_unchecked_mut() }
-            .buffer
-            .as_mut_ptr();
+        let buf_ptr: *mut u8 = accept_result.buffer.as_mut_ptr();
         let mut bytes_out: u32 = 0;
 
         // Safety: buffer pointers refer to valid, live locations for the duration of the call iff accept_result stays
@@ -341,7 +344,7 @@ impl Socket {
 
         get_overlapped_api_result(success).and_then(|_| {
             // Safety: the socket does not require structural pinning.
-            unsafe { accept_result.as_mut().get_unchecked_mut() }.new_socket = Some(new_socket);
+            accept_result.new_socket = Some(new_socket);
             Ok(())
         })
     }
@@ -351,19 +354,24 @@ impl Socket {
     /// with the (local, remote) address pair.
     pub fn finish_accept(
         &self,
-        mut accept_result: Pin<&mut AcceptState>,
-        iocp: &IoCompletionPort,
+        state: Pin<&mut SocketOpState>,
+        iocp: &IoCompletionPort<SocketOpState>,
         result: OverlappedResult,
     ) -> Result<(Socket, SocketAddr, SocketAddr), Fail> {
         if let Err(err) = result.ok() {
             return Err(err);
         }
 
+        let accept_result: &mut AcceptState = match state.get_mut() {
+            SocketOpState::Accept(ref mut accept_result) => accept_result,
+            _ => unreachable!("must be an accept operation"),
+        };
+
         // NB Windows docs are unclear whether the "bytes transferred" overlapped result should be 0 for AcceptEx with
         // no receive, or whether it is equal to the local+remote address buffer length. It is safe to assume addresses
         // were provisioned correctly by the API.
         // Safety: the socket does not require structural pinning.
-        let new_socket = unsafe { accept_result.as_mut().get_unchecked_mut() }
+        let new_socket = accept_result
             .new_socket
             .take()
             .ok_or_else(|| Fail::new(libc::EINVAL, "invalid state"))?;
@@ -465,14 +473,19 @@ impl Socket {
     /// Start a pop operation, as intended for use with `IoCompletionPort::do_io_with`. The operation may complete
     /// immediately, in which case an overlapped completion is not scheduled. To indicate this case, this method will
     /// return EAGAIN and update `buffer` according to the number of bytes received.
-    pub fn start_pop(&self, mut pop_state: Pin<&mut PopState>, overlapped: *mut OVERLAPPED) -> Result<(), Fail> {
+    pub fn start_pop(&self, state: Pin<&mut SocketOpState>, overlapped: *mut OVERLAPPED) -> Result<(), Fail> {
+        let pop_state: &mut PopState = match state.get_mut() {
+            SocketOpState::Pop(ref mut pop_state) => pop_state,
+            _ => unreachable!("must be an accept operation"),
+        };
+
         let mut bytes_transferred: u32 = 0;
         let mut flags: u32 = 0;
         let success: bool = unsafe {
             let wsa_buffer: WSABUF = WSABUF {
                 len: pop_state.buffer.len() as u32,
                 // Safety: loading the buffer pointer won't violate pinning invariants.
-                buf: PSTR::from_raw(pop_state.as_mut().get_unchecked_mut().buffer.as_mut_ptr()),
+                buf: PSTR::from_raw(pop_state.buffer.as_mut_ptr()),
             };
 
             // NB winsock service providers are required to capture the entire WSABUF array inline with the call, so
@@ -482,8 +495,8 @@ impl Socket {
                 std::slice::from_ref(&wsa_buffer),
                 Some(&mut bytes_transferred),
                 &mut flags,
-                Some(pop_state.as_mut().get_unchecked_mut().address.as_mut_ptr() as *mut SOCKADDR),
-                Some(&mut pop_state.as_mut().get_unchecked_mut().addr_len),
+                Some(pop_state.address.as_mut_ptr() as *mut SOCKADDR),
+                Some(&mut pop_state.addr_len),
                 Some(overlapped),
                 None,
             );
@@ -497,7 +510,7 @@ impl Socket {
     /// Finish an overlapped pop operation started with start_pop.
     pub fn finish_pop(
         &self,
-        mut pop_state: Pin<&mut PopState>,
+        state: Pin<&mut SocketOpState>,
         result: OverlappedResult,
     ) -> Result<(usize, Option<SocketAddr>), Fail> {
         // Note: the `flags` output of WSARecvFrom is not immediately avialable as written. These can be rehydrated by
@@ -509,14 +522,17 @@ impl Socket {
             return Err(err);
         }
 
+        let pop_state: &mut PopState = match state.get_mut() {
+            SocketOpState::Pop(ref mut pop_state) => pop_state,
+            _ => unreachable!("must be an accept operation"),
+        };
+
         let addr: Option<SocketAddr> = if pop_state.addr_len > 0 {
             // Safety: since we are done with the overlapped API, pinning is no longer required for pop_state. The
             // returned address and addr_len values come from the OS, so they will be valid to pass to socket2.
             unsafe {
                 socket2::SockAddr::new(
-                    std::mem::transmute(std::mem::take(
-                        pop_state.as_mut().get_unchecked_mut().address.assume_init_mut(),
-                    )),
+                    std::mem::transmute(std::mem::take(pop_state.address.assume_init_mut())),
                     pop_state.addr_len,
                 )
             }
@@ -531,16 +547,21 @@ impl Socket {
     /// Start a push operation, as intended for use with `IoCompletionPort::do_io_with`.
     pub fn start_push(
         &self,
-        buffer: Pin<&mut DemiBuffer>,
+        state: Pin<&mut SocketOpState>,
         addr: Option<SocketAddr>,
         overlapped: *mut OVERLAPPED,
     ) -> Result<(), Fail> {
+        let buffer: &mut DemiBuffer = match state.get_mut() {
+            SocketOpState::Push(ref mut buffer) => buffer,
+            _ => unreachable!("must be an accept operation"),
+        };
+
         let mut bytes_transferred: u32 = 0;
         let success: bool = unsafe {
             let wsa_buffer: WSABUF = WSABUF {
                 len: buffer.len() as u32,
                 // Safety: loading the buffer pointer won't violate pinning invariants.
-                buf: PSTR::from_raw(buffer.get_unchecked_mut().as_mut_ptr()),
+                buf: PSTR::from_raw(buffer.as_mut_ptr()),
             };
 
             let addr: Option<socket2::SockAddr> = addr.map(socket2::SockAddr::from);
@@ -570,7 +591,7 @@ impl Socket {
     }
 
     /// Finish a push operation started with start_push.
-    pub fn finish_push(&self, _buffer: Pin<&mut DemiBuffer>, result: OverlappedResult) -> Result<usize, Fail> {
+    pub fn finish_push(&self, result: OverlappedResult) -> Result<usize, Fail> {
         result.ok().and(Ok(result.bytes_transferred as usize))
     }
 }

--- a/src/rust/catnap/win/transport.rs
+++ b/src/rust/catnap/win/transport.rs
@@ -38,6 +38,7 @@ use crate::{
             AcceptState,
             PopState,
             Socket,
+            SocketOpState,
         },
         winsock::WinsockRuntime,
     },
@@ -46,8 +47,7 @@ use crate::{
         fail::Fail,
         memory::DemiBuffer,
         network::transport::NetworkTransport,
-        scheduler::Yielder,
-        yield_once,
+        poll_yield,
         DemiRuntime,
         SharedDemiRuntime,
         SharedObject,
@@ -77,7 +77,7 @@ pub struct CatnapTransport {
     winsock: WinsockRuntime,
 
     /// I/O completion port for overlapped I/O.
-    iocp: IoCompletionPort,
+    iocp: IoCompletionPort<SocketOpState>,
 
     /// Configuration values.
     config: WinConfig,
@@ -125,7 +125,6 @@ impl SharedCatnapTransport {
 
     /// Run a coroutine which pulls the I/O completion port for events.
     async fn run_event_processor(&mut self) {
-        let yielder: Yielder = Yielder::new();
         loop {
             if let Err(err) = self.0.iocp.process_events() {
                 error!("Completion port error: {}", err);
@@ -171,13 +170,12 @@ impl NetworkTransport for SharedCatnapTransport {
     }
 
     /// Asynchronously disconnect and shut down a socket.
-    async fn close(&mut self, socket: &mut Self::SocketDescriptor, yielder: Yielder) -> Result<(), Fail> {
+    async fn close(&mut self, socket: &mut Self::SocketDescriptor) -> Result<(), Fail> {
         match unsafe {
             self.0.iocp.do_io(
-                &yielder,
-                |overlapped: *mut OVERLAPPED| socket.start_disconnect(overlapped),
-                |_| Err(Fail::new(libc::EFAULT, "cannot cancel a disconnect")),
-                |result: OverlappedResult| socket.finish_disconnect(result),
+                SocketOpState::Close,
+                |_: Pin<&mut SocketOpState>, overlapped: *mut OVERLAPPED| socket.start_disconnect(overlapped),
+                |_: Pin<&mut SocketOpState>, result: OverlappedResult| socket.finish_disconnect(result),
             )
         }
         .await
@@ -200,19 +198,12 @@ impl NetworkTransport for SharedCatnapTransport {
 
     /// Accept a connection on the specified socket. The coroutine will not finish until a connection is successfully
     /// accepted or `yielder` is cancelled.
-    async fn accept(
-        &mut self,
-        socket: &mut Self::SocketDescriptor,
-        yielder: Yielder,
-    ) -> Result<(Socket, SocketAddr), Fail> {
-        let start = |accept_result: Pin<&mut AcceptState>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
+    async fn accept(&mut self, socket: &mut Self::SocketDescriptor) -> Result<(Socket, SocketAddr), Fail> {
+        let start = |accept_result: Pin<&mut SocketOpState>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
             socket.start_accept(accept_result, overlapped)
         };
-        let cancel = |_: Pin<&mut AcceptState>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
-            socket.cancel_io(overlapped)
-        };
         let me_finish: Self = self.clone();
-        let finish = |accept_result: Pin<&mut AcceptState>,
+        let finish = |accept_result: Pin<&mut SocketOpState>,
                       result: OverlappedResult|
          -> Result<(Socket, SocketAddr, SocketAddr), Fail> {
             socket.finish_accept(accept_result, &me_finish.0.iocp, result)
@@ -221,7 +212,7 @@ impl NetworkTransport for SharedCatnapTransport {
         let (socket, _local_addr, remote_addr) = unsafe {
             self.0
                 .iocp
-                .do_io_with(AcceptState::new(), &yielder, start, cancel, finish)
+                .do_io(SocketOpState::Accept(AcceptState::new()), start, finish)
         }
         .await?;
 
@@ -229,18 +220,16 @@ impl NetworkTransport for SharedCatnapTransport {
     }
 
     /// Connect a socket to a remote address.
-    async fn connect(
-        &mut self,
-        socket: &mut Self::SocketDescriptor,
-        remote: SocketAddr,
-        yielder: Yielder,
-    ) -> Result<(), Fail> {
+    async fn connect(&mut self, socket: &mut Self::SocketDescriptor, remote: SocketAddr) -> Result<(), Fail> {
         unsafe {
             self.0.iocp.do_io(
-                &yielder,
-                |overlapped: *mut OVERLAPPED| -> Result<(), Fail> { socket.start_connect(remote, overlapped) },
-                |overlapped: *mut OVERLAPPED| -> Result<(), Fail> { socket.cancel_io(overlapped) },
-                |result: OverlappedResult| -> Result<(), Fail> { socket.finish_connect(result) },
+                SocketOpState::Connect,
+                |_: Pin<&mut SocketOpState>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
+                    socket.start_connect(remote, overlapped)
+                },
+                |_: Pin<&mut SocketOpState>, result: OverlappedResult| -> Result<(), Fail> {
+                    socket.finish_connect(result)
+                },
             )
         }
         .await
@@ -252,21 +241,16 @@ impl NetworkTransport for SharedCatnapTransport {
         socket: &mut Self::SocketDescriptor,
         buf: &mut DemiBuffer,
         size: usize,
-        yielder: Yielder,
     ) -> Result<Option<SocketAddr>, Fail> {
         unsafe {
-            self.0.iocp.do_io_with(
-                PopState::new(buf.clone()),
-                &yielder,
-                |pop_state: Pin<&mut PopState>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
-                    socket.start_pop(pop_state, overlapped)
+            self.0.iocp.do_io(
+                SocketOpState::Pop(PopState::new(buf.clone())),
+                |state: Pin<&mut SocketOpState>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
+                    socket.start_pop(state, overlapped)
                 },
-                |_pop_state: Pin<&mut PopState>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
-                    socket.cancel_io(overlapped)
-                },
-                |pop_state: Pin<&mut PopState>,
+                |state: Pin<&mut SocketOpState>,
                  result: OverlappedResult|
-                 -> Result<(usize, Option<SocketAddr>), Fail> { socket.finish_pop(pop_state, result) },
+                 -> Result<(usize, Option<SocketAddr>), Fail> { socket.finish_pop(state, result) },
             )
         }
         .await
@@ -289,21 +273,16 @@ impl NetworkTransport for SharedCatnapTransport {
         socket: &mut Self::SocketDescriptor,
         buf: &mut DemiBuffer,
         addr: Option<SocketAddr>,
-        yielder: Yielder,
     ) -> Result<(), Fail> {
         loop {
             let result: Result<usize, Fail> = unsafe {
-                self.0.iocp.do_io_with(
-                    buf.clone(),
-                    &yielder,
-                    |buffer: Pin<&mut DemiBuffer>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
-                        socket.start_push(buffer, addr, overlapped)
+                self.0.iocp.do_io(
+                    SocketOpState::Push(buf.clone()),
+                    |state: Pin<&mut SocketOpState>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
+                        socket.start_push(state, addr, overlapped)
                     },
-                    |_buffer: Pin<&mut DemiBuffer>, overlapped: *mut OVERLAPPED| -> Result<(), Fail> {
-                        socket.cancel_io(overlapped)
-                    },
-                    |buffer: Pin<&mut DemiBuffer>, result: OverlappedResult| -> Result<usize, Fail> {
-                        socket.finish_push(buffer, result)
+                    |_: Pin<&mut SocketOpState>, result: OverlappedResult| -> Result<usize, Fail> {
+                        socket.finish_push(result)
                     },
                 )
             }

--- a/src/rust/catnap/win/winsock.rs
+++ b/src/rust/catnap/win/winsock.rs
@@ -18,7 +18,10 @@ use crate::{
     catnap::transport::{
         error::expect_last_wsa_error,
         overlapped::IoCompletionPort,
-        socket::Socket,
+        socket::{
+            Socket,
+            SocketOpState,
+        },
         WinConfig,
     },
     runtime::fail::Fail,
@@ -330,7 +333,7 @@ impl WinsockRuntime {
         typ: libc::c_int,
         protocol: libc::c_int,
         config: &WinConfig,
-        iocp: &IoCompletionPort,
+        iocp: &IoCompletionPort<SocketOpState>,
     ) -> Result<Socket, Fail> {
         // Safety: SOCKET is a loose handle; it must be closed with `closesocket` to clean up resources. Socket struct
         // will take ownership by end of method; failures after this call need to be cause a `closesocket` call.

--- a/src/rust/demikernel/libos/name.rs
+++ b/src/rust/demikernel/libos/name.rs
@@ -12,6 +12,7 @@ use ::std::env;
 // Structures
 //======================================================================================================================
 
+#[derive(Clone, Copy)]
 /// Names of LibOSes.
 pub enum LibOSName {
     Catpowder,


### PR DESCRIPTION
This PR add support for multicore execution to our tcp-echo benchmark as an example of how we will handle basic multi-core architectures with RSS support. It currently only works with Catnap because there is more configuration that needs to be done for DPDK support. Since it has a share nothing architecture, it should work fine with Catloop and Catmem but is not currently supported.