### PR TITLE
[catpowder] Bug Fix: Doubling time out for tcp push pop

### DIFF
--- a/examples/rust/tcp-push-pop.rs
+++ b/examples/rust/tcp-push-pop.rs
@@ -47,7 +47,7 @@ use ::demikernel::perftools::profiler;
 
 const BUFFER_SIZE: usize = 64;
 const FILL_CHAR: u8 = 0x65;
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
 
 //======================================================================================================================
 // mksga()


### PR DESCRIPTION
I believe that Catpowder is timing out on the accept for the release build on the CI. I was not able to reproduce on my machine.