### PR TITLE
[libos] Bug Fix: Unify DemiBuffer allocation

### DIFF
--- a/src/rust/catloop/transport.rs
+++ b/src/rust/catloop/transport.rs
@@ -8,7 +8,10 @@ use crate::{
     demikernel::config::Config,
     runtime::{
         fail::Fail,
-        memory::DemiBuffer,
+        memory::{
+            DemiBuffer,
+            MemoryRuntime,
+        },
         network::{
             transport::NetworkTransport,
             unwrap_socketaddr,
@@ -174,3 +177,5 @@ impl DerefMut for SharedCatloopTransport {
         self.0.deref_mut()
     }
 }
+
+impl MemoryRuntime for SharedCatloopTransport {}

--- a/src/rust/catmem/mod.rs
+++ b/src/rust/catmem/mod.rs
@@ -11,6 +11,7 @@ mod ring;
 use self::queue::SharedCatmemQueue;
 use crate::{
     demikernel::config::Config,
+    pal::linux::socketaddrv4_to_sockaddr,
     runtime::{
         fail::Fail,
         limits,
@@ -19,7 +20,12 @@ use crate::{
             MemoryRuntime,
         },
         queue::downcast_queue,
-        types::demi_sgarray_t,
+        types::{
+            demi_opcode_t,
+            demi_qr_value_t,
+            demi_qresult_t,
+            demi_sgarray_t,
+        },
         Operation,
         OperationResult,
         SharedDemiRuntime,
@@ -30,11 +36,13 @@ use crate::{
 };
 use ::futures::FutureExt;
 use ::std::{
+    mem,
     ops::{
         Deref,
         DerefMut,
     },
     pin::Pin,
+    time::Duration,
 };
 
 //======================================================================================================================
@@ -149,7 +157,7 @@ impl SharedCatmemLibOS {
     pub fn push(&mut self, qd: QDesc, sga: &demi_sgarray_t) -> Result<QToken, Fail> {
         trace!("push() qd={:?}", qd);
 
-        let buf: DemiBuffer = self.runtime.clone_sgarray(sga)?;
+        let buf: DemiBuffer = self.clone_sgarray(sga)?;
 
         if buf.len() == 0 {
             let cause: String = format!("zero-length buffer (qd={:?})", qd);
@@ -204,6 +212,73 @@ impl SharedCatmemLibOS {
         (qd, OperationResult::Pop(None, buf))
     }
 
+    /// Waits for any of the given pending I/O operations to complete or a timeout to expire.
+    pub fn wait_any(&mut self, qts: &[QToken], timeout: Duration) -> Result<(usize, demi_qresult_t), Fail> {
+        let (offset, qt, qd, result) = self.runtime.wait_any(qts, timeout)?;
+        Ok((offset, self.create_result(result, qd, qt)))
+    }
+
+    /// Waits for any operation in an I/O queue.
+    pub fn poll(&mut self) {
+        self.runtime.poll()
+    }
+
+    pub fn create_result(&self, result: OperationResult, qd: QDesc, qt: QToken) -> demi_qresult_t {
+        match result {
+            OperationResult::Connect => unreachable!("Memory libOSes do not support connect"),
+            OperationResult::Accept((_, _)) => unreachable!("Memory libOSes do not support connect"),
+            OperationResult::Push => demi_qresult_t {
+                qr_opcode: demi_opcode_t::DEMI_OPC_PUSH,
+                qr_qd: qd.into(),
+                qr_qt: qt.into(),
+                qr_ret: 0,
+                qr_value: unsafe { mem::zeroed() },
+            },
+            OperationResult::Pop(addr, bytes) => match self.into_sgarray(bytes) {
+                Ok(mut sga) => {
+                    if let Some(addr) = addr {
+                        sga.sga_addr = socketaddrv4_to_sockaddr(&addr);
+                    }
+                    let qr_value: demi_qr_value_t = demi_qr_value_t { sga };
+                    demi_qresult_t {
+                        qr_opcode: demi_opcode_t::DEMI_OPC_POP,
+                        qr_qd: qd.into(),
+                        qr_qt: qt.into(),
+                        qr_ret: 0,
+                        qr_value,
+                    }
+                },
+                Err(e) => {
+                    warn!("Operation Failed: {:?}", e);
+                    demi_qresult_t {
+                        qr_opcode: demi_opcode_t::DEMI_OPC_FAILED,
+                        qr_qd: qd.into(),
+                        qr_qt: qt.into(),
+                        qr_ret: e.errno as i64,
+                        qr_value: unsafe { mem::zeroed() },
+                    }
+                },
+            },
+            OperationResult::Close => demi_qresult_t {
+                qr_opcode: demi_opcode_t::DEMI_OPC_CLOSE,
+                qr_qd: qd.into(),
+                qr_qt: qt.into(),
+                qr_ret: 0,
+                qr_value: unsafe { mem::zeroed() },
+            },
+            OperationResult::Failed(e) => {
+                warn!("Operation Failed: {:?}", e);
+                demi_qresult_t {
+                    qr_opcode: demi_opcode_t::DEMI_OPC_FAILED,
+                    qr_qd: qd.into(),
+                    qr_qt: qt.into(),
+                    qr_ret: e.errno as i64,
+                    qr_value: unsafe { mem::zeroed() },
+                }
+            },
+        }
+    }
+
     pub fn get_queue(&self, qd: &QDesc) -> Result<SharedCatmemQueue, Fail> {
         Ok(self.runtime.get_qtable().get::<SharedCatmemQueue>(qd)?.clone())
     }
@@ -240,3 +315,5 @@ impl Drop for CatmemLibOS {
         }
     }
 }
+
+impl MemoryRuntime for SharedCatmemLibOS {}

--- a/src/rust/catnap/linux/transport.rs
+++ b/src/rust/catnap/linux/transport.rs
@@ -21,7 +21,10 @@ use crate::{
     demikernel::config::Config,
     runtime::{
         fail::Fail,
-        memory::DemiBuffer,
+        memory::{
+            DemiBuffer,
+            MemoryRuntime,
+        },
         network::transport::NetworkTransport,
         poll_yield,
         DemiRuntime,
@@ -500,3 +503,5 @@ impl NetworkTransport for SharedCatnapTransport {
         &self.runtime
     }
 }
+
+impl MemoryRuntime for SharedCatnapTransport {}

--- a/src/rust/catnap/win/transport.rs
+++ b/src/rust/catnap/win/transport.rs
@@ -45,7 +45,10 @@ use crate::{
     demikernel::config::Config,
     runtime::{
         fail::Fail,
-        memory::DemiBuffer,
+        memory::{
+            DemiBuffer,
+            MemoryRuntime,
+        },
         network::transport::NetworkTransport,
         poll_yield,
         DemiRuntime,
@@ -311,3 +314,5 @@ impl NetworkTransport for SharedCatnapTransport {
         &self.0.runtime
     }
 }
+
+impl MemoryRuntime for SharedCatnapTransport {}

--- a/src/rust/demikernel/libos/memory.rs
+++ b/src/rust/demikernel/libos/memory.rs
@@ -17,11 +17,9 @@ use crate::runtime::{
 use ::std::time::Duration;
 
 #[cfg(feature = "catmem-libos")]
-use crate::{
-    catmem::SharedCatmemLibOS,
-    runtime::memory::MemoryRuntime,
-    runtime::SharedDemiRuntime,
-};
+use crate::catmem::SharedCatmemLibOS;
+#[cfg(feature = "catmem-libos")]
+use crate::runtime::memory::MemoryRuntime;
 
 //======================================================================================================================
 // Structures
@@ -30,10 +28,7 @@ use crate::{
 /// Associated functions for Memory LibOSes.
 pub enum MemoryLibOS {
     #[cfg(feature = "catmem-libos")]
-    Catmem {
-        runtime: SharedDemiRuntime,
-        libos: SharedCatmemLibOS,
-    },
+    Catmem(SharedCatmemLibOS),
 }
 
 //======================================================================================================================
@@ -47,7 +42,7 @@ impl MemoryLibOS {
     pub fn create_pipe(&mut self, name: &str) -> Result<QDesc, Fail> {
         match self {
             #[cfg(feature = "catmem-libos")]
-            MemoryLibOS::Catmem { runtime: _, libos } => libos.create_pipe(name),
+            MemoryLibOS::Catmem(libos) => libos.create_pipe(name),
             _ => unreachable!("unknown memory libos"),
         }
     }
@@ -57,7 +52,7 @@ impl MemoryLibOS {
     pub fn open_pipe(&mut self, name: &str) -> Result<QDesc, Fail> {
         match self {
             #[cfg(feature = "catmem-libos")]
-            MemoryLibOS::Catmem { runtime: _, libos } => libos.open_pipe(name),
+            MemoryLibOS::Catmem(libos) => libos.open_pipe(name),
             _ => unreachable!("unknown memory libos"),
         }
     }
@@ -67,7 +62,7 @@ impl MemoryLibOS {
     pub fn async_close(&mut self, memqd: QDesc) -> Result<QToken, Fail> {
         match self {
             #[cfg(feature = "catmem-libos")]
-            MemoryLibOS::Catmem { runtime: _, libos } => libos.async_close(memqd),
+            MemoryLibOS::Catmem(libos) => libos.async_close(memqd),
             _ => unreachable!("unknown memory libos"),
         }
     }
@@ -77,7 +72,7 @@ impl MemoryLibOS {
     pub fn push(&mut self, memqd: QDesc, sga: &demi_sgarray_t) -> Result<QToken, Fail> {
         match self {
             #[cfg(feature = "catmem-libos")]
-            MemoryLibOS::Catmem { runtime: _, libos } => libos.push(memqd, sga),
+            MemoryLibOS::Catmem(libos) => libos.push(memqd, sga),
             _ => unreachable!("unknown memory libos"),
         }
     }
@@ -87,7 +82,7 @@ impl MemoryLibOS {
     pub fn pop(&mut self, memqd: QDesc, size: Option<usize>) -> Result<QToken, Fail> {
         match self {
             #[cfg(feature = "catmem-libos")]
-            MemoryLibOS::Catmem { runtime: _, libos } => libos.pop(memqd, size),
+            MemoryLibOS::Catmem(libos) => libos.pop(memqd, size),
             _ => unreachable!("unknown memory libos"),
         }
     }
@@ -107,11 +102,12 @@ impl MemoryLibOS {
     }
 
     /// Waits for any of the given pending I/O operations to complete or a timeout to expire.
+    #[allow(unreachable_patterns, unused_variables)]
     pub fn wait_any(&mut self, qts: &[QToken], timeout: Duration) -> Result<(usize, demi_qresult_t), Fail> {
         trace!("wait_any(): qts={:?}, timeout={:?}", qts, timeout);
         match self {
             #[cfg(feature = "catmem-libos")]
-            MemoryLibOS::Catmem { runtime, libos: _ } => runtime.wait_any(qts, timeout),
+            MemoryLibOS::Catmem(libos) => libos.wait_any(qts, timeout),
             _ => unreachable!("unknown memory libos"),
         }
     }
@@ -121,7 +117,7 @@ impl MemoryLibOS {
     pub fn sgaalloc(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
         match self {
             #[cfg(feature = "catmem-libos")]
-            MemoryLibOS::Catmem { runtime, libos: _ } => runtime.sgaalloc(size),
+            MemoryLibOS::Catmem(libos) => libos.sgaalloc(size),
             _ => unreachable!("unknown memory libos"),
         }
     }
@@ -131,7 +127,7 @@ impl MemoryLibOS {
     pub fn sgafree(&self, sga: demi_sgarray_t) -> Result<(), Fail> {
         match self {
             #[cfg(feature = "catmem-libos")]
-            MemoryLibOS::Catmem { runtime, libos: _ } => runtime.sgafree(sga),
+            MemoryLibOS::Catmem(libos) => libos.sgafree(sga),
             _ => unreachable!("unknown memory libos"),
         }
     }
@@ -141,7 +137,7 @@ impl MemoryLibOS {
     pub fn poll(&mut self) {
         match self {
             #[cfg(feature = "catmem-libos")]
-            MemoryLibOS::Catmem { runtime, libos: _ } => runtime.poll(),
+            MemoryLibOS::Catmem(libos) => libos.poll(),
             _ => unreachable!("unknown memory libos"),
         }
     }

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -98,13 +98,13 @@ impl LibOS {
         #[allow(unreachable_patterns)]
         let libos: LibOS = match libos_name {
             #[cfg(all(feature = "catnap-libos"))]
-            LibOSName::Catnap => Self::NetworkLibOS(NetworkLibOSWrapper::Catnap {
-                runtime: runtime.clone(),
-                libos: SharedNetworkLibOS::<SharedCatnapTransport>::new(
-                    runtime.clone(),
-                    SharedCatnapTransport::new(&config, &mut runtime),
-                ),
-            }),
+            LibOSName::Catnap => Self::NetworkLibOS(NetworkLibOSWrapper::Catnap(SharedNetworkLibOS::<
+                SharedCatnapTransport,
+            >::new(
+                runtime.clone(),
+                SharedCatnapTransport::new(&config, &mut runtime),
+            ))),
+
             #[cfg(feature = "catpowder-libos")]
             LibOSName::Catpowder => {
                 // TODO: Remove some of these clones once we are done merging the libOSes.
@@ -112,10 +112,11 @@ impl LibOS {
                 // This is our transport for Catpowder.
                 let inetstack: SharedInetStack<LinuxRuntime> =
                     SharedInetStack::<LinuxRuntime>::new(config.clone(), runtime.clone(), transport).unwrap();
-                Self::NetworkLibOS(NetworkLibOSWrapper::Catpowder {
-                    runtime: runtime.clone(),
-                    libos: SharedNetworkLibOS::<SharedInetStack<LinuxRuntime>>::new(runtime.clone(), inetstack),
-                })
+                Self::NetworkLibOS(NetworkLibOSWrapper::Catpowder(SharedNetworkLibOS::<
+                    SharedInetStack<LinuxRuntime>,
+                >::new(
+                    runtime.clone(), inetstack
+                )))
             },
             #[cfg(feature = "catnip-libos")]
             LibOSName::Catnip => {
@@ -124,24 +125,23 @@ impl LibOS {
                 let inetstack: SharedInetStack<SharedDPDKRuntime> =
                     SharedInetStack::<SharedDPDKRuntime>::new(config.clone(), runtime.clone(), transport).unwrap();
 
-                Self::NetworkLibOS(NetworkLibOSWrapper::Catnip {
-                    runtime: runtime.clone(),
-                    libos: SharedNetworkLibOS::<SharedInetStack<SharedDPDKRuntime>>::new(runtime.clone(), inetstack),
-                })
+                Self::NetworkLibOS(NetworkLibOSWrapper::Catnip(SharedNetworkLibOS::<
+                    SharedInetStack<SharedDPDKRuntime>,
+                >::new(
+                    runtime.clone(), inetstack
+                )))
             },
             #[cfg(feature = "catmem-libos")]
-            LibOSName::Catmem => Self::MemoryLibOS(MemoryLibOS::Catmem {
-                runtime: runtime.clone(),
-                libos: SharedCatmemLibOS::new(&config, runtime.clone()),
-            }),
+            LibOSName::Catmem => {
+                Self::MemoryLibOS(MemoryLibOS::Catmem(SharedCatmemLibOS::new(&config, runtime.clone())))
+            },
             #[cfg(feature = "catloop-libos")]
-            LibOSName::Catloop => Self::NetworkLibOS(NetworkLibOSWrapper::Catloop {
-                runtime: runtime.clone(),
-                libos: SharedNetworkLibOS::<SharedCatloopTransport>::new(
-                    runtime.clone(),
-                    SharedCatloopTransport::new(&config, runtime.clone()),
-                ),
-            }),
+            LibOSName::Catloop => Self::NetworkLibOS(NetworkLibOSWrapper::Catloop(SharedNetworkLibOS::<
+                SharedCatloopTransport,
+            >::new(
+                runtime.clone(),
+                SharedCatloopTransport::new(&config, runtime.clone()),
+            ))),
             _ => panic!("unsupported libos"),
         };
 

--- a/src/rust/demikernel/libos/network/mod.rs
+++ b/src/rust/demikernel/libos/network/mod.rs
@@ -18,14 +18,12 @@ use crate::{
     pal::constants::SOMAXCONN,
     runtime::{
         fail::Fail,
-        memory::MemoryRuntime,
         types::{
             demi_qresult_t,
             demi_sgarray_t,
         },
         QDesc,
         QToken,
-        SharedDemiRuntime,
     },
 };
 use ::std::{
@@ -52,25 +50,13 @@ use crate::catpowder::runtime::LinuxRuntime;
 /// Network LIBOS.
 pub enum NetworkLibOSWrapper {
     #[cfg(feature = "catpowder-libos")]
-    Catpowder {
-        runtime: SharedDemiRuntime,
-        libos: SharedNetworkLibOS<SharedInetStack<LinuxRuntime>>,
-    },
+    Catpowder(SharedNetworkLibOS<SharedInetStack<LinuxRuntime>>),
     #[cfg(all(feature = "catnap-libos"))]
-    Catnap {
-        runtime: SharedDemiRuntime,
-        libos: SharedNetworkLibOS<SharedCatnapTransport>,
-    },
+    Catnap(SharedNetworkLibOS<SharedCatnapTransport>),
     #[cfg(feature = "catnip-libos")]
-    Catnip {
-        runtime: SharedDemiRuntime,
-        libos: SharedNetworkLibOS<SharedInetStack<SharedDPDKRuntime>>,
-    },
+    Catnip(SharedNetworkLibOS<SharedInetStack<SharedDPDKRuntime>>),
     #[cfg(feature = "catloop-libos")]
-    Catloop {
-        runtime: SharedDemiRuntime,
-        libos: SharedNetworkLibOS<SharedCatloopTransport>,
-    },
+    Catloop(SharedNetworkLibOS<SharedCatloopTransport>),
 }
 
 //======================================================================================================================
@@ -88,21 +74,13 @@ impl NetworkLibOSWrapper {
     ) -> Result<QDesc, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOSWrapper::Catpowder { runtime: _, libos } => {
-                libos.socket(domain.into(), socket_type.into(), protocol.into())
-            },
+            NetworkLibOSWrapper::Catpowder(libos) => libos.socket(domain.into(), socket_type.into(), protocol.into()),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOSWrapper::Catnap { runtime: _, libos } => {
-                libos.socket(domain.into(), socket_type.into(), protocol.into())
-            },
+            NetworkLibOSWrapper::Catnap(libos) => libos.socket(domain.into(), socket_type.into(), protocol.into()),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOSWrapper::Catnip { runtime: _, libos } => {
-                libos.socket(domain.into(), socket_type.into(), protocol.into())
-            },
+            NetworkLibOSWrapper::Catnip(libos) => libos.socket(domain.into(), socket_type.into(), protocol.into()),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOSWrapper::Catloop { runtime: _, libos } => {
-                libos.socket(domain.into(), socket_type.into(), protocol.into())
-            },
+            NetworkLibOSWrapper::Catloop(libos) => libos.socket(domain.into(), socket_type.into(), protocol.into()),
         }
     }
 
@@ -110,13 +88,13 @@ impl NetworkLibOSWrapper {
     pub fn bind(&mut self, sockqd: QDesc, local: SocketAddr) -> Result<(), Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOSWrapper::Catpowder { runtime: _, libos } => libos.bind(sockqd, local),
+            NetworkLibOSWrapper::Catpowder(libos) => libos.bind(sockqd, local),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOSWrapper::Catnap { runtime: _, libos } => libos.bind(sockqd, local),
+            NetworkLibOSWrapper::Catnap(libos) => libos.bind(sockqd, local),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOSWrapper::Catnip { runtime: _, libos } => libos.bind(sockqd, local),
+            NetworkLibOSWrapper::Catnip(libos) => libos.bind(sockqd, local),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOSWrapper::Catloop { runtime: _, libos } => libos.bind(sockqd, local),
+            NetworkLibOSWrapper::Catloop(libos) => libos.bind(sockqd, local),
         }
     }
 
@@ -139,13 +117,13 @@ impl NetworkLibOSWrapper {
 
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOSWrapper::Catpowder { runtime: _, libos } => libos.listen(sockqd, backlog),
+            NetworkLibOSWrapper::Catpowder(libos) => libos.listen(sockqd, backlog),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOSWrapper::Catnap { runtime: _, libos } => libos.listen(sockqd, backlog),
+            NetworkLibOSWrapper::Catnap(libos) => libos.listen(sockqd, backlog),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOSWrapper::Catnip { runtime: _, libos } => libos.listen(sockqd, backlog),
+            NetworkLibOSWrapper::Catnip(libos) => libos.listen(sockqd, backlog),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOSWrapper::Catloop { runtime: _, libos } => libos.listen(sockqd, backlog),
+            NetworkLibOSWrapper::Catloop(libos) => libos.listen(sockqd, backlog),
         }
     }
 
@@ -153,13 +131,13 @@ impl NetworkLibOSWrapper {
     pub fn accept(&mut self, sockqd: QDesc) -> Result<QToken, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOSWrapper::Catpowder { runtime: _, libos } => libos.accept(sockqd),
+            NetworkLibOSWrapper::Catpowder(libos) => libos.accept(sockqd),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOSWrapper::Catnap { runtime: _, libos } => libos.accept(sockqd),
+            NetworkLibOSWrapper::Catnap(libos) => libos.accept(sockqd),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOSWrapper::Catnip { runtime: _, libos } => libos.accept(sockqd),
+            NetworkLibOSWrapper::Catnip(libos) => libos.accept(sockqd),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOSWrapper::Catloop { runtime: _, libos } => libos.accept(sockqd),
+            NetworkLibOSWrapper::Catloop(libos) => libos.accept(sockqd),
         }
     }
 
@@ -167,26 +145,26 @@ impl NetworkLibOSWrapper {
     pub fn connect(&mut self, sockqd: QDesc, remote: SocketAddr) -> Result<QToken, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOSWrapper::Catpowder { runtime: _, libos } => libos.connect(sockqd, remote),
+            NetworkLibOSWrapper::Catpowder(libos) => libos.connect(sockqd, remote),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOSWrapper::Catnap { runtime: _, libos } => libos.connect(sockqd, remote),
+            NetworkLibOSWrapper::Catnap(libos) => libos.connect(sockqd, remote),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOSWrapper::Catnip { runtime: _, libos } => libos.connect(sockqd, remote),
+            NetworkLibOSWrapper::Catnip(libos) => libos.connect(sockqd, remote),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOSWrapper::Catloop { runtime: _, libos } => libos.connect(sockqd, remote),
+            NetworkLibOSWrapper::Catloop(libos) => libos.connect(sockqd, remote),
         }
     }
 
     pub fn async_close(&mut self, sockqd: QDesc) -> Result<QToken, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOSWrapper::Catpowder { runtime: _, libos } => libos.async_close(sockqd),
+            NetworkLibOSWrapper::Catpowder(libos) => libos.async_close(sockqd),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOSWrapper::Catnap { runtime: _, libos } => libos.async_close(sockqd),
+            NetworkLibOSWrapper::Catnap(libos) => libos.async_close(sockqd),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOSWrapper::Catnip { runtime: _, libos } => libos.async_close(sockqd),
+            NetworkLibOSWrapper::Catnip(libos) => libos.async_close(sockqd),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOSWrapper::Catloop { runtime: _, libos } => libos.async_close(sockqd),
+            NetworkLibOSWrapper::Catloop(libos) => libos.async_close(sockqd),
         }
     }
 
@@ -194,13 +172,13 @@ impl NetworkLibOSWrapper {
     pub fn push(&mut self, sockqd: QDesc, sga: &demi_sgarray_t) -> Result<QToken, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOSWrapper::Catpowder { runtime: _, libos } => libos.push(sockqd, sga),
+            NetworkLibOSWrapper::Catpowder(libos) => libos.push(sockqd, sga),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOSWrapper::Catnap { runtime: _, libos } => libos.push(sockqd, sga),
+            NetworkLibOSWrapper::Catnap(libos) => libos.push(sockqd, sga),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOSWrapper::Catnip { runtime: _, libos } => libos.push(sockqd, sga),
+            NetworkLibOSWrapper::Catnip(libos) => libos.push(sockqd, sga),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOSWrapper::Catloop { runtime: _, libos } => libos.push(sockqd, sga),
+            NetworkLibOSWrapper::Catloop(libos) => libos.push(sockqd, sga),
         }
     }
 
@@ -208,15 +186,13 @@ impl NetworkLibOSWrapper {
     pub fn pushto(&mut self, sockqd: QDesc, sga: &demi_sgarray_t, to: SocketAddr) -> Result<QToken, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOSWrapper::Catpowder { runtime: _, libos } => libos.pushto(sockqd, sga, to),
+            NetworkLibOSWrapper::Catpowder(libos) => libos.pushto(sockqd, sga, to),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOSWrapper::Catnap { runtime: _, libos } => libos.pushto(sockqd, sga, to),
+            NetworkLibOSWrapper::Catnap(libos) => libos.pushto(sockqd, sga, to),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOSWrapper::Catnip { runtime: _, libos } => libos.pushto(sockqd, sga, to),
+            NetworkLibOSWrapper::Catnip(libos) => libos.pushto(sockqd, sga, to),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOSWrapper::Catloop { runtime: _, libos: _ } => {
-                Err(Fail::new(libc::ENOTSUP, "operation not supported"))
-            },
+            NetworkLibOSWrapper::Catloop(_) => Err(Fail::new(libc::ENOTSUP, "operation not supported")),
         }
     }
 
@@ -224,13 +200,13 @@ impl NetworkLibOSWrapper {
     pub fn pop(&mut self, sockqd: QDesc, size: Option<usize>) -> Result<QToken, Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOSWrapper::Catpowder { runtime: _, libos } => libos.pop(sockqd, size),
+            NetworkLibOSWrapper::Catpowder(libos) => libos.pop(sockqd, size),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOSWrapper::Catnap { runtime: _, libos } => libos.pop(sockqd, size),
+            NetworkLibOSWrapper::Catnap(libos) => libos.pop(sockqd, size),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOSWrapper::Catnip { runtime: _, libos } => libos.pop(sockqd, size),
+            NetworkLibOSWrapper::Catnip(libos) => libos.pop(sockqd, size),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOSWrapper::Catloop { runtime: _, libos } => libos.pop(sockqd, size),
+            NetworkLibOSWrapper::Catloop(libos) => libos.pop(sockqd, size),
         }
     }
 
@@ -252,13 +228,13 @@ impl NetworkLibOSWrapper {
     pub fn wait_any(&mut self, qts: &[QToken], timeout: Duration) -> Result<(usize, demi_qresult_t), Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOSWrapper::Catpowder { runtime, libos: _ } => runtime.wait_any(qts, timeout),
+            NetworkLibOSWrapper::Catpowder(libos) => libos.wait_any(qts, timeout),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOSWrapper::Catnap { runtime, libos: _ } => runtime.wait_any(qts, timeout),
+            NetworkLibOSWrapper::Catnap(libos) => libos.wait_any(qts, timeout),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOSWrapper::Catnip { runtime, libos: _ } => runtime.wait_any(qts, timeout),
+            NetworkLibOSWrapper::Catnip(libos) => libos.wait_any(qts, timeout),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOSWrapper::Catloop { runtime, libos: _ } => runtime.wait_any(qts, timeout),
+            NetworkLibOSWrapper::Catloop(libos) => libos.wait_any(qts, timeout),
         }
     }
 
@@ -266,13 +242,13 @@ impl NetworkLibOSWrapper {
     pub fn poll(&mut self) {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOSWrapper::Catpowder { runtime, libos: _ } => runtime.poll(),
+            NetworkLibOSWrapper::Catpowder(libos) => libos.poll(),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOSWrapper::Catnap { runtime, libos: _ } => runtime.poll(),
+            NetworkLibOSWrapper::Catnap(libos) => libos.poll(),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOSWrapper::Catnip { runtime, libos: _ } => runtime.poll(),
+            NetworkLibOSWrapper::Catnip(libos) => libos.poll(),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOSWrapper::Catloop { runtime, libos: _ } => runtime.poll(),
+            NetworkLibOSWrapper::Catloop(libos) => libos.poll(),
         }
     }
 
@@ -282,15 +258,15 @@ impl NetworkLibOSWrapper {
             #[cfg(feature = "catpowder-libos")]
             // TODO: Move this over to the transport once we set that up.
             // FIXME: https://github.com/microsoft/demikernel/issues/1057
-            NetworkLibOSWrapper::Catpowder { runtime: _, libos } => libos.sgaalloc(size),
+            NetworkLibOSWrapper::Catpowder(libos) => libos.sgaalloc(size),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOSWrapper::Catnap { runtime: _, libos } => libos.sgaalloc(size),
+            NetworkLibOSWrapper::Catnap(libos) => libos.sgaalloc(size),
             #[cfg(feature = "catnip-libos")]
             // TODO: Move this over to the transport once we set that up.
             // FIXME: https://github.com/microsoft/demikernel/issues/1057
-            NetworkLibOSWrapper::Catnip { runtime: _, libos } => libos.sgaalloc(size),
+            NetworkLibOSWrapper::Catnip(libos) => libos.sgaalloc(size),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOSWrapper::Catloop { runtime, libos: _ } => runtime.sgaalloc(size),
+            NetworkLibOSWrapper::Catloop(libos) => libos.sgaalloc(size),
         }
     }
 
@@ -298,13 +274,13 @@ impl NetworkLibOSWrapper {
     pub fn sgafree(&self, sga: demi_sgarray_t) -> Result<(), Fail> {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOSWrapper::Catpowder { runtime, libos: _ } => runtime.sgafree(sga),
+            NetworkLibOSWrapper::Catpowder(libos) => libos.sgafree(sga),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOSWrapper::Catnap { runtime, libos: _ } => runtime.sgafree(sga),
+            NetworkLibOSWrapper::Catnap(libos) => libos.sgafree(sga),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOSWrapper::Catnip { runtime, libos: _ } => runtime.sgafree(sga),
+            NetworkLibOSWrapper::Catnip(libos) => libos.sgafree(sga),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOSWrapper::Catloop { runtime, libos: _ } => runtime.sgafree(sga),
+            NetworkLibOSWrapper::Catloop(libos) => libos.sgafree(sga),
         }
     }
 }

--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -447,7 +447,7 @@ impl<N: NetworkRuntime> NetworkTransport for SharedInetStack<N> {
 
 /// This implements the memory runtime trait for the inetstack. Other libOSes without a network runtime can directly
 /// use OS memory but the inetstack requires specialized memory allocated by the lower-level runtime.
-impl<N: NetworkRuntime> MemoryRuntime for InetStack<N> {
+impl<N: NetworkRuntime + MemoryRuntime> MemoryRuntime for SharedInetStack<N> {
     fn clone_sgarray(&self, sga: &demi_sgarray_t) -> Result<DemiBuffer, Fail> {
         self.network.clone_sgarray(sga)
     }

--- a/src/rust/runtime/network/transport.rs
+++ b/src/rust/runtime/network/transport.rs
@@ -5,16 +5,13 @@
 // Imports
 //======================================================================================================================
 
-use crate::{
-    demi_sgarray_t,
-    runtime::{
-        fail::Fail,
-        memory::{
-            DemiBuffer,
-            MemoryRuntime,
-        },
-        SharedDemiRuntime,
+use crate::runtime::{
+    fail::Fail,
+    memory::{
+        DemiBuffer,
+        MemoryRuntime,
     },
+    SharedDemiRuntime,
 };
 use ::socket2::{
     Domain,
@@ -31,7 +28,7 @@ use ::std::{
 
 /// This trait represents a high-level network API that supports both connection-based and connection-less
 /// communication using sockets.
-pub trait NetworkTransport: Clone + 'static {
+pub trait NetworkTransport: Clone + 'static + MemoryRuntime {
     type SocketDescriptor: Debug;
 
     /// Create a socket using the network transport layer.
@@ -81,22 +78,4 @@ pub trait NetworkTransport: Clone + 'static {
 
     /// Pull the common runtime out of the transport. We only need this because traits do not support members.
     fn get_runtime(&self) -> &SharedDemiRuntime;
-}
-
-impl<N: NetworkTransport> MemoryRuntime for N {
-    fn clone_sgarray(&self, sga: &demi_sgarray_t) -> Result<DemiBuffer, Fail> {
-        self.get_runtime().clone_sgarray(sga)
-    }
-
-    fn into_sgarray(&self, buf: DemiBuffer) -> Result<demi_sgarray_t, Fail> {
-        self.get_runtime().into_sgarray(buf)
-    }
-
-    fn sgaalloc(&self, size: usize) -> Result<demi_sgarray_t, Fail> {
-        self.get_runtime().sgaalloc(size)
-    }
-
-    fn sgafree(&self, sga: demi_sgarray_t) -> Result<(), Fail> {
-        self.get_runtime().sgafree(sga)
-    }
 }


### PR DESCRIPTION
This PR closes #1173 by unifying the hierarchy of memory allocation for DemiBuffers. In the past, we were allocating Demibuffers out of the libOS and then freeing them through the shared runtime, which caused a memory leak because those were two different instances of the MemoryRuntime. Now, all DemiBuffer allocations go through the libOS first, then the transport and then the Network(Memory)Runtime. Since not all libOSes have NetworkRuntimes, some of the simply use the default heap allocator in the transport. However, we need to be careful in the future when supporting multiple libOSes with multiple transports to free DemiBuffers back to the right pool. In fact, we should probably have more tags to enable this.