### PR TITLE
[libos] Remove copy from transport API

### DIFF
--- a/src/rust/catloop/transport.rs
+++ b/src/rust/catloop/transport.rs
@@ -149,10 +149,9 @@ impl NetworkTransport for SharedCatloopTransport {
     async fn pop(
         &mut self,
         sd: &mut Self::SocketDescriptor,
-        buf: &mut DemiBuffer,
         size: usize,
-    ) -> Result<Option<SocketAddr>, Fail> {
-        sd.pop(self.catmem.clone(), buf, size).await
+    ) -> Result<(Option<SocketAddr>, DemiBuffer), Fail> {
+        sd.pop(self.catmem.clone(), size).await
     }
 
     fn get_runtime(&self) -> &SharedDemiRuntime {

--- a/src/rust/catnap/linux/socket.rs
+++ b/src/rust/catnap/linux/socket.rs
@@ -132,10 +132,10 @@ impl SharedSocketData {
     }
 
     /// Pop some data on an active established connection.
-    pub async fn pop(&mut self, buf: &mut DemiBuffer, size: usize) -> Result<Option<SocketAddr>, Fail> {
+    pub async fn pop(&mut self, size: usize) -> Result<(Option<SocketAddr>, DemiBuffer), Fail> {
         match self.deref_mut() {
             SocketData::Inactive(_) => unreachable!("Cannot read on an inactive socket"),
-            SocketData::Active(data) => data.pop(buf, size).await,
+            SocketData::Active(data) => data.pop(size).await,
             SocketData::Passive(_) => unreachable!("Cannot read on a passive socket"),
         }
     }

--- a/src/rust/catnap/linux/transport.rs
+++ b/src/rust/catnap/linux/transport.rs
@@ -429,7 +429,7 @@ impl NetworkTransport for SharedCatnapTransport {
                         libc::ENOTCONN => break,
                         errno if DemiRuntime::should_retry(errno) => {
                             // Wait for a new incoming event.
-                            data.pop(&mut DemiBuffer::new(0), 0).await?;
+                            data.pop(0).await?;
                             continue;
                         },
                         errno => return Err(Fail::new(errno, "operation failed")),
@@ -469,10 +469,9 @@ impl NetworkTransport for SharedCatnapTransport {
     async fn pop(
         &mut self,
         sd: &mut Self::SocketDescriptor,
-        buf: &mut DemiBuffer,
         size: usize,
-    ) -> Result<Option<SocketAddr>, Fail> {
-        self.data_from_sd(sd).pop(buf, size).await
+    ) -> Result<(Option<SocketAddr>, DemiBuffer), Fail> {
+        self.data_from_sd(sd).pop(size).await
     }
 
     /// Close the socket on the underlying transport. Also unregisters the socket with epoll.

--- a/src/rust/catnap/win/transport.rs
+++ b/src/rust/catnap/win/transport.rs
@@ -244,9 +244,9 @@ impl NetworkTransport for SharedCatnapTransport {
     async fn pop(
         &mut self,
         socket: &mut Self::SocketDescriptor,
-        buf: &mut DemiBuffer,
         size: usize,
-    ) -> Result<Option<SocketAddr>, Fail> {
+    ) -> Result<(Option<SocketAddr>, DemiBuffer), Fail> {
+        let mut buf: DemiBuffer = DemiBuffer::new(size as u16);
         unsafe {
             self.0.iocp.do_io(
                 SocketOpState::Pop(PopState::new(buf.clone())),
@@ -266,7 +266,7 @@ impl NetworkTransport for SharedCatnapTransport {
             } else {
                 trace!("not data received");
             }
-            Ok(sockaddr)
+            Ok((sockaddr, buf))
         })
     }
 

--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -432,12 +432,11 @@ impl<N: NetworkRuntime> NetworkTransport for SharedInetStack<N> {
     async fn pop(
         &mut self,
         sd: &mut Self::SocketDescriptor,
-        buf: &mut DemiBuffer,
         size: usize,
-    ) -> Result<Option<SocketAddr>, Fail> {
+    ) -> Result<(Option<SocketAddr>, DemiBuffer), Fail> {
         match sd {
-            Socket::Tcp(socket) => self.ipv4.tcp.pop(socket, buf, size).await,
-            Socket::Udp(socket) => self.ipv4.udp.pop(socket, buf, size).await,
+            Socket::Tcp(socket) => self.ipv4.tcp.pop(socket, size).await,
+            Socket::Udp(socket) => self.ipv4.udp.pop(socket, size).await,
         }
     }
 

--- a/src/rust/inetstack/protocols/tcp/peer.rs
+++ b/src/rust/inetstack/protocols/tcp/peer.rs
@@ -186,18 +186,13 @@ impl<N: NetworkRuntime> SharedTcpPeer<N> {
     pub async fn pop(
         &self,
         socket: &mut SharedTcpSocket<N>,
-        buf: &mut DemiBuffer,
         size: usize,
-    ) -> Result<Option<SocketAddr>, Fail> {
+    ) -> Result<(Option<SocketAddr>, DemiBuffer), Fail> {
         // Grab the queue, make sure it hasn't been closed in the meantime.
         // This will bump the Rc refcount so the coroutine can have it's own reference to the shared queue data
         // structure and the SharedTcpQueue will not be freed until this coroutine finishes.
         let incoming: DemiBuffer = socket.pop(Some(size)).await?;
-        let len: usize = incoming.len();
-        // TODO: Remove this copy. Our API should support passing back a buffer without sending in a buffer.
-        buf.trim(size - len)?;
-        buf.copy_from_slice(&incoming[0..len]);
-        Ok(None)
+        Ok((None, incoming))
     }
 
     /// Frees an ephemeral port (if any) allocated to a given socket.

--- a/src/rust/inetstack/protocols/udp/peer.rs
+++ b/src/rust/inetstack/protocols/udp/peer.rs
@@ -150,15 +150,10 @@ impl<N: NetworkRuntime> SharedUdpPeer<N> {
     pub async fn pop(
         &mut self,
         socket: &mut SharedUdpSocket<N>,
-        buf: &mut DemiBuffer,
         size: usize,
-    ) -> Result<Option<SocketAddr>, Fail> {
-        let (addr, incoming): (SocketAddrV4, DemiBuffer) = socket.pop(size).await?;
-        // TODO: Remove copy.
-        let len: usize = incoming.len();
-        buf.trim(size - len)?;
-        buf.copy_from_slice(&incoming[0..len]);
-        Ok(Some(addr.into()))
+    ) -> Result<(Option<SocketAddr>, DemiBuffer), Fail> {
+        let (addr, buf) = socket.pop(size).await?;
+        Ok((Some(addr.into()), buf))
     }
 
     /// Consumes the payload from a buffer.

--- a/src/rust/runtime/network/transport.rs
+++ b/src/rust/runtime/network/transport.rs
@@ -69,9 +69,8 @@ pub trait NetworkTransport: Clone + 'static + MemoryRuntime {
     fn pop(
         &mut self,
         sd: &mut Self::SocketDescriptor,
-        buf: &mut DemiBuffer,
         size: usize,
-    ) -> impl std::future::Future<Output = Result<Option<SocketAddr>, Fail>>;
+    ) -> impl std::future::Future<Output = Result<(Option<SocketAddr>, DemiBuffer), Fail>>;
 
     /// Asynchronously close a socket.
     fn close(&mut self, sd: &mut Self::SocketDescriptor) -> impl std::future::Future<Output = Result<(), Fail>>;


### PR DESCRIPTION
When we added the transport trait we introduced a copy into almost all of the libOSes because the pop API took a DemiBuffer in and filled it. This removes those copies and lets the transport allocate the DemiBuffer and directly return it.