### PR TITLE
[examples] Abort Server on Idle Client

### DIFF
--- a/examples/rust/tcp-push-pop.rs
+++ b/examples/rust/tcp-push-pop.rs
@@ -176,6 +176,11 @@ impl TcpServer {
                 Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_POP => unsafe { Some(qr.qr_value.sga) },
                 Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED => anyhow::bail!("pop failed: {}", qr.qr_ret),
                 Ok(qr) => anyhow::bail!("unexpected opcode: {:?}", qr.qr_opcode),
+                Err(e) if e.errno == libc::ETIMEDOUT => {
+                    // We haven't heard from the client in a while, so we'll assume it's done.
+                    eprintln!("we haven't heard from the client in a while, aborting");
+                    break;
+                },
                 Err(e) => anyhow::bail!("operation failed: {:?}", e.cause),
             };
 


### PR DESCRIPTION
## Description

This PR fixes the `tcp-push-pop` example to abort server execution if client goes idle.

## Related Issues

https://github.com/microsoft/demikernel/issues/1018