### PR TITLE
[inetstack] Bug Fix: TCP accept and Window Scale

### DIFF
--- a/nettest/input/pop-blocking.pkt
+++ b/nettest/input/pop-blocking.pkt
@@ -22,7 +22,7 @@
 // Receive data packet.
 +.1 < P. seq 1(1000) ack 1 win 65535 <nop>
 // Send ACK packet.
-+.6 > . seq 1(0) ack 1001 win 64535 <nop>
++.6 > . seq 1(0) ack 1001 win 65535 <nop>
 
 // Data read.
 +.0 wait(501, ...) = 0

--- a/nettest/input/pop-push-blocking.pkt
+++ b/nettest/input/pop-push-blocking.pkt
@@ -22,7 +22,7 @@
 // Receive data packet.
 +.1 < P. seq 1(1000) ack 1 win 65535 <nop>
 // Send ACK packet.
-+.6 > . seq 1(0) ack 1001 win 64535 <nop>
++.6 > . seq 1(0) ack 1001 win 65535 <nop>
 
 // Data read.
 +.0 wait(501, ...) = 0

--- a/src/rust/inetstack/protocols/tcp/peer.rs
+++ b/src/rust/inetstack/protocols/tcp/peer.rs
@@ -135,9 +135,15 @@ impl<N: NetworkRuntime> SharedTcpPeer<N> {
     }
 
     /// Runs until a new connection is accepted.
-    pub async fn accept(&self, socket: &mut SharedTcpSocket<N>) -> Result<SharedTcpSocket<N>, Fail> {
+    pub async fn accept(&mut self, socket: &mut SharedTcpSocket<N>) -> Result<SharedTcpSocket<N>, Fail> {
         // Wait for accept to complete.
-        Ok(socket.accept().await?)
+        match socket.accept().await {
+            Ok(socket) => {
+                self.addresses.insert(SocketId::Active(socket.local().unwrap(), socket.remote().unwrap()), socket.clone());
+                Ok(socket)
+            }
+            Err(e) => Err(e),
+        }
     }
 
     /// Runs until the connect to remote is made or times out.


### PR DESCRIPTION
This PR fixes the TCP accept function to insert the connected peer in the TcpPeer::addresses and calculate the window scale.