### PR TITLE
[perf] Remove Task Name

### DIFF
--- a/nettest/input/pop-blocking.pkt
+++ b/nettest/input/pop-blocking.pkt
@@ -22,7 +22,7 @@
 // Receive data packet.
 +.1 < P. seq 1(1000) ack 1 win 65535 <nop>
 // Send ACK packet.
-+.6 > . seq 1(0) ack 1001 win 65535 <nop>
++.6 > . seq 1(0) ack 1001 win 64535 <nop>
 
 // Data read.
 +.0 wait(501, ...) = 0

--- a/src/rust/catmem/mod.rs
+++ b/src/rust/catmem/mod.rs
@@ -117,9 +117,14 @@ impl SharedCatmemLibOS {
         trace!("async_close() qd={:?}", qd);
         let mut queue: SharedCatmemQueue = self.get_queue(&qd)?;
         let coroutine_constructor = || -> Result<QToken, Fail> {
+            #[cfg(debug)]
             let task_name: String = format!("Catmem::async_close for qd={:?}", qd);
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().close_coroutine(qd).fuse());
-            self.runtime.clone().insert_io_coroutine(&task_name, coroutine)
+            self.runtime.clone().insert_io_coroutine(
+                #[cfg(debug)]
+                &task_name,
+                coroutine,
+            )
         };
 
         queue.async_close(coroutine_constructor)
@@ -164,10 +169,15 @@ impl SharedCatmemLibOS {
             return Err(Fail::new(libc::EINVAL, &cause));
         }
 
+        #[cfg(debug)]
         let task_name: String = format!("Catmem::push for qd={:?}", qd);
         let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().push_coroutine(qd, buf).fuse());
 
-        self.runtime.clone().insert_io_coroutine(&task_name, coroutine)
+        self.runtime.clone().insert_io_coroutine(
+            #[cfg(debug)]
+            &task_name,
+            coroutine,
+        )
     }
 
     pub async fn push_coroutine(self, qd: QDesc, buf: DemiBuffer) -> (QDesc, OperationResult) {
@@ -190,10 +200,15 @@ impl SharedCatmemLibOS {
         // We just assert 'size' here, because it was previously checked at PDPIX layer.
         debug_assert!(size.is_none() || ((size.unwrap() > 0) && (size.unwrap() <= limits::POP_SIZE_MAX)));
 
+        #[cfg(debug)]
         let task_name: String = format!("Catmem::pop for qd={:?}", qd);
         let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().pop_coroutine(qd, size).fuse());
 
-        self.runtime.clone().insert_io_coroutine(&task_name, coroutine)
+        self.runtime.clone().insert_io_coroutine(
+            #[cfg(debug)]
+            &task_name,
+            coroutine,
+        )
     }
 
     pub async fn pop_coroutine(self, qd: QDesc, size: Option<usize>) -> (QDesc, OperationResult) {

--- a/src/rust/catnap/linux/transport.rs
+++ b/src/rust/catnap/linux/transport.rs
@@ -109,6 +109,7 @@ impl SharedCatnapTransport {
         let mut me2: Self = me.clone();
         expect_ok!(
             runtime.insert_background_coroutine(
+                #[cfg(debug)]
                 "catnap::transport::epoll",
                 Box::pin(async move { me2.poll().await }.fuse()),
             ),

--- a/src/rust/catnap/win/overlapped.rs
+++ b/src/rust/catnap/win/overlapped.rs
@@ -534,7 +534,13 @@ mod tests {
         })
         .fuse();
 
-        let server_task: QToken = runtime.insert_io_coroutine("server", Box::pin(server)).unwrap();
+        let server_task: QToken = runtime
+            .insert_io_coroutine(
+                #[cfg(debug)]
+                "server",
+                Box::pin(server),
+            )
+            .unwrap();
         ensure!(runtime.run_any(&[server_task]).is_none());
         post_completion(&iocp, overlapped.as_mut().marshal(), COMPLETION_KEY)?;
 
@@ -644,7 +650,13 @@ mod tests {
         );
 
         let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
-        let server_task: QToken = runtime.insert_io_coroutine("server", server).unwrap();
+        let server_task: QToken = runtime
+            .insert_io_coroutine(
+                #[cfg(debug)]
+                "server",
+                server,
+            )
+            .unwrap();
 
         let mut wait_for_state = |state| -> Result<(), Fail> {
             while server_state_view.load(Ordering::Relaxed) < state {
@@ -750,7 +762,13 @@ mod tests {
         .fuse();
 
         let mut runtime: SharedDemiRuntime = SharedDemiRuntime::default();
-        let server_task: QToken = runtime.insert_io_coroutine("server", Box::pin(server)).unwrap();
+        let server_task: QToken = runtime
+            .insert_io_coroutine(
+                #[cfg(debug)]
+                "server",
+                Box::pin(server),
+            )
+            .unwrap();
 
         ensure!(
             server_state_view.load(Ordering::Relaxed) < 1,

--- a/src/rust/catnap/win/transport.rs
+++ b/src/rust/catnap/win/transport.rs
@@ -116,6 +116,7 @@ impl SharedCatnapTransport {
 
         expect_ok!(
             runtime.insert_background_coroutine(
+                #[cfg(debug)]
                 "catnap::transport::epoll",
                 Box::pin({
                     let mut me: Self = me.clone();

--- a/src/rust/demikernel/libos/network/libos.rs
+++ b/src/rust/demikernel/libos/network/libos.rs
@@ -206,9 +206,14 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
 
         let mut queue: SharedNetworkQueue<T> = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<QToken, Fail> {
+            #[cfg(debug)]
             let task_name: String = format!("NetworkLibOS::accept for qd={:?}", qd);
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().accept_coroutine(qd).fuse());
-            self.runtime.clone().insert_io_coroutine(&task_name, coroutine)
+            self.runtime.clone().insert_io_coroutine(
+                #[cfg(debug)]
+                &task_name,
+                coroutine,
+            )
         };
 
         queue.accept(coroutine_constructor)
@@ -256,9 +261,14 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
         // FIXME: add IPv6 support; https://github.com/microsoft/demikernel/issues/935
         let mut queue: SharedNetworkQueue<T> = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<QToken, Fail> {
+            #[cfg(debug)]
             let task_name: String = format!("NetworkLibOS::connect for qd={:?}", qd);
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().connect_coroutine(qd, remote).fuse());
-            self.runtime.clone().insert_io_coroutine(&task_name, coroutine)
+            self.runtime.clone().insert_io_coroutine(
+                #[cfg(debug)]
+                &task_name,
+                coroutine,
+            )
         };
 
         queue.connect(coroutine_constructor)
@@ -295,9 +305,14 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
 
         let mut queue: SharedNetworkQueue<T> = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<QToken, Fail> {
+            #[cfg(debug)]
             let task_name: String = format!("NetworkLibOS::close for qd={:?}", qd);
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().close_coroutine(qd).fuse());
-            self.runtime.clone().insert_io_coroutine(&task_name, coroutine)
+            self.runtime.clone().insert_io_coroutine(
+                #[cfg(debug)]
+                &task_name,
+                coroutine,
+            )
         };
 
         queue.close(coroutine_constructor)
@@ -363,9 +378,14 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
 
         let mut queue: SharedNetworkQueue<T> = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<QToken, Fail> {
+            #[cfg(debug)]
             let task_name: String = format!("NetworkLibOS::push for qd={:?}", qd);
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().push_coroutine(qd, buf).fuse());
-            self.runtime.clone().insert_io_coroutine(&task_name, coroutine)
+            self.runtime.clone().insert_io_coroutine(
+                #[cfg(debug)]
+                &task_name,
+                coroutine,
+            )
         };
 
         queue.push(coroutine_constructor)
@@ -405,9 +425,14 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
 
         let mut queue: SharedNetworkQueue<T> = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<QToken, Fail> {
+            #[cfg(debug)]
             let task_name: String = format!("NetworkLibOS::pushto for qd={:?}", qd);
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().pushto_coroutine(qd, buf, remote).fuse());
-            self.runtime.clone().insert_io_coroutine(&task_name, coroutine)
+            self.runtime.clone().insert_io_coroutine(
+                #[cfg(debug)]
+                &task_name,
+                coroutine,
+            )
         };
 
         queue.push(coroutine_constructor)
@@ -445,9 +470,14 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
 
         let mut queue: SharedNetworkQueue<T> = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<QToken, Fail> {
+            #[cfg(debug)]
             let task_name: String = format!("NetworkLibOS::pop for qd={:?}", qd);
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().pop_coroutine(qd, size).fuse());
-            self.runtime.clone().insert_io_coroutine(&task_name, coroutine)
+            self.runtime.clone().insert_io_coroutine(
+                #[cfg(debug)]
+                &task_name,
+                coroutine,
+            )
         };
 
         queue.pop(coroutine_constructor)

--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -144,8 +144,13 @@ impl<N: NetworkRuntime> SharedInetStack<N> {
             network,
             local_link_addr: local_link_addr,
         }));
+        #[cfg(debug)]
         let background_task: String = format!("inetstack::poll_recv");
-        runtime.insert_background_coroutine(&background_task, Box::pin(me.clone().poll().fuse()))?;
+        runtime.insert_background_coroutine(
+            #[cfg(debug)]
+            &background_task,
+            Box::pin(me.clone().poll().fuse()),
+        )?;
         Ok(me)
     }
 

--- a/src/rust/inetstack/protocols/arp/peer.rs
+++ b/src/rust/inetstack/protocols/arp/peer.rs
@@ -107,7 +107,11 @@ impl<N: NetworkRuntime> SharedArpPeer<N> {
             recv_queue: AsyncQueue::<DemiBuffer>::default(),
         }));
         // This is a future returned by the async function.
-        runtime.insert_background_coroutine("Inetstack::arp::background", Box::pin(peer.clone().poll().fuse()))?;
+        runtime.insert_background_coroutine(
+            #[cfg(debug)]
+            "Inetstack::arp::background",
+            Box::pin(peer.clone().poll().fuse()),
+        )?;
         Ok(peer.clone())
     }
 

--- a/src/rust/inetstack/protocols/arp/tests.rs
+++ b/src/rust/inetstack/protocols/arp/tests.rs
@@ -201,7 +201,11 @@ fn arp_cache_timeout() -> Result<()> {
     let mut engine: SharedEngine = new_engine(now, &local_mac, &local_ipv4, &remote_mac, &remote_ipv4)?;
 
     let coroutine = Box::pin(engine.clone().arp_query(other_remote_ipv4).fuse());
-    let qt: QToken = engine.get_runtime().clone().insert_coroutine("arp query", coroutine)?;
+    let qt: QToken = engine.get_runtime().clone().insert_coroutine(
+        #[cfg(debug)]
+        "arp query",
+        coroutine,
+    )?;
     engine.poll();
     engine.poll();
 

--- a/src/rust/inetstack/protocols/icmpv4/peer.rs
+++ b/src/rust/inetstack/protocols/icmpv4/peer.rs
@@ -122,7 +122,11 @@ impl<N: NetworkRuntime> SharedIcmpv4Peer<N> {
             rng,
             inflight: HashMap::<(u16, u16), InflightRequest>::new(),
         }));
-        runtime.insert_background_coroutine("Inetstack::ICMP::background", Box::pin(peer.clone().poll().fuse()))?;
+        runtime.insert_background_coroutine(
+            #[cfg(debug)]
+            "Inetstack::ICMP::background",
+            Box::pin(peer.clone().poll().fuse()),
+        )?;
         Ok(peer)
     }
 

--- a/src/rust/inetstack/protocols/tcp/established/mod.rs
+++ b/src/rust/inetstack/protocols/tcp/established/mod.rs
@@ -102,6 +102,7 @@ impl<N: NetworkRuntime> EstablishedSocket<N> {
             ack_queue.clone(),
         );
         let qt: QToken = runtime.insert_background_coroutine(
+            #[cfg(debug)]
             "Inetstack::TCP::established::background",
             Box::pin(background::background(cb.clone(), dead_socket_tx).fuse()),
         )?;

--- a/src/rust/inetstack/protocols/tcp/passive_open.rs
+++ b/src/rust/inetstack/protocols/tcp/passive_open.rs
@@ -126,8 +126,11 @@ impl<N: NetworkRuntime> SharedPassiveSocket<N> {
             dead_socket_tx,
             background_task_qt: None,
         }));
-        let qt: QToken =
-            runtime.insert_background_coroutine("passive_listening::poll", Box::pin(me.clone().poll().fuse()))?;
+        let qt: QToken = runtime.insert_background_coroutine(
+            #[cfg(debug)]
+            "passive_listening::poll",
+            Box::pin(me.clone().poll().fuse()),
+        )?;
         me.background_task_qt = Some(qt);
         Ok(me)
     }
@@ -209,10 +212,11 @@ impl<N: NetworkRuntime> SharedPassiveSocket<N> {
             .clone()
             .send_syn_ack_and_wait_for_ack(remote, remote_isn, local_isn, tcp_hdr, recv_queue.clone(), ack_queue)
             .fuse();
-        match self
-            .runtime
-            .insert_background_coroutine("Inetstack::TCP::passiveopen::background", Box::pin(future))
-        {
+        match self.runtime.insert_background_coroutine(
+            #[cfg(debug)]
+            "Inetstack::TCP::passiveopen::background",
+            Box::pin(future),
+        ) {
             Ok(qt) => qt,
             Err(e) => {
                 let cause = "Could not allocate coroutine for passive open";

--- a/src/rust/runtime/scheduler/group.rs
+++ b/src/rust/runtime/scheduler/group.rs
@@ -74,6 +74,7 @@ impl TaskGroup {
         };
         waker_page_ref.clear(waker_page_offset);
         if let Some(task) = self.tasks.remove_unpin(pin_slab_index) {
+            #[cfg(debug)]
             trace!(
                 "remove(): name={:?}, id={:?}, pin_slab_index={:?}",
                 task.get_name(),
@@ -92,6 +93,7 @@ impl TaskGroup {
 
     /// Insert a new task into our scheduler returning a handle corresponding to it.
     pub fn insert(&mut self, task: Box<dyn Task>) -> Option<TaskId> {
+        #[cfg(debug)]
         let task_name: String = task.get_name();
         // The pin slab index can be reverse-computed in a page index and an offset within the page.
         let pin_slab_index: usize = self.tasks.insert(task)?;
@@ -106,6 +108,7 @@ impl TaskGroup {
         };
         waker_page_ref.initialize(waker_page_offset);
 
+        #[cfg(debug)]
         trace!(
             "insert(): name={:?}, id={:?}, pin_slab_index={:?}",
             task_name,

--- a/src/rust/runtime/scheduler/scheduler.rs
+++ b/src/rust/runtime/scheduler/scheduler.rs
@@ -415,13 +415,21 @@ mod tests {
         let mut scheduler: Scheduler = Scheduler::default();
 
         // Insert a task and make sure the task id is not a simple counter.
-        let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(0).fuse()));
+        let task: DummyTask = DummyTask::new(
+            #[cfg(debug)]
+            String::from("testing"),
+            Box::pin(DummyCoroutine::new(0).fuse()),
+        );
         let Some(task_id) = scheduler.insert_task(task) else {
             anyhow::bail!("insert() failed")
         };
 
         // Insert another task and make sure the task id is not sequentially after the previous one.
-        let task2: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(0).fuse()));
+        let task2: DummyTask = DummyTask::new(
+            #[cfg(debug)]
+            String::from("testing"),
+            Box::pin(DummyCoroutine::new(0).fuse()),
+        );
         let Some(task_id2) = scheduler.insert_task(task2) else {
             anyhow::bail!("insert() failed")
         };
@@ -436,7 +444,11 @@ mod tests {
         let mut scheduler: Scheduler = Scheduler::default();
 
         // Insert a single future in the scheduler. This future shall complete with a single poll operation.
-        let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(0).fuse()));
+        let task: DummyTask = DummyTask::new(
+            #[cfg(debug)]
+            String::from("testing"),
+            Box::pin(DummyCoroutine::new(0).fuse()),
+        );
         let Some(task_id) = scheduler.insert_task(task) else {
             anyhow::bail!("insert() failed")
         };
@@ -456,7 +468,11 @@ mod tests {
         let mut scheduler: Scheduler = Scheduler::default();
 
         // Insert a single future in the scheduler. This future shall complete with a single poll operation.
-        let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(0).fuse()));
+        let task: DummyTask = DummyTask::new(
+            #[cfg(debug)]
+            String::from("testing"),
+            Box::pin(DummyCoroutine::new(0).fuse()),
+        );
         let Some(task_id) = scheduler.insert_task(task) else {
             anyhow::bail!("insert() failed")
         };
@@ -477,7 +493,11 @@ mod tests {
 
         // Insert a single future in the scheduler. This future shall complete
         // with two poll operations.
-        let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(1).fuse()));
+        let task: DummyTask = DummyTask::new(
+            #[cfg(debug)]
+            String::from("testing"),
+            Box::pin(DummyCoroutine::new(1).fuse()),
+        );
         let Some(task_id) = scheduler.insert_task(task) else {
             anyhow::bail!("insert() failed")
         };
@@ -503,7 +523,11 @@ mod tests {
         let mut scheduler: Scheduler = Scheduler::default();
 
         // Insert a single future in the scheduler. This future shall complete with a single poll operation.
-        let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(0).fuse()));
+        let task: DummyTask = DummyTask::new(
+            #[cfg(debug)]
+            String::from("testing"),
+            Box::pin(DummyCoroutine::new(0).fuse()),
+        );
         let Some(task_id) = scheduler.insert_task(task) else {
             anyhow::bail!("insert() failed")
         };
@@ -524,7 +548,11 @@ mod tests {
         let mut scheduler: Scheduler = Scheduler::default();
 
         // Create and run a task.
-        let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(0).fuse()));
+        let task: DummyTask = DummyTask::new(
+            #[cfg(debug)]
+            String::from("testing"),
+            Box::pin(DummyCoroutine::new(0).fuse()),
+        );
         let Some(task_id) = scheduler.insert_task(task) else {
             anyhow::bail!("insert() failed")
         };
@@ -536,7 +564,11 @@ mod tests {
         }
 
         // Create another task.
-        let task2: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(0).fuse()));
+        let task2: DummyTask = DummyTask::new(
+            #[cfg(debug)]
+            String::from("testing"),
+            Box::pin(DummyCoroutine::new(0).fuse()),
+        );
         let Some(task_id2) = scheduler.insert_task(task2) else {
             anyhow::bail!("insert() failed")
         };
@@ -558,7 +590,11 @@ mod tests {
         crate::ensure_eq!(scheduler.num_tasks(), 0);
 
         for val in 0..NUM_TASKS {
-            let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(val).fuse()));
+            let task: DummyTask = DummyTask::new(
+                #[cfg(debug)]
+                String::from("testing"),
+                Box::pin(DummyCoroutine::new(val).fuse()),
+            );
             let Some(task_id) = scheduler.insert_task(task) else {
                 panic!("insert() failed");
             };
@@ -589,6 +625,7 @@ mod tests {
 
         b.iter(|| {
             let task: DummyTask = DummyTask::new(
+                #[cfg(debug)]
                 String::from("testing"),
                 Box::pin(black_box(DummyCoroutine::default().fuse())),
             );
@@ -604,7 +641,11 @@ mod tests {
         let mut task_ids: Vec<TaskId> = Vec::<TaskId>::with_capacity(NUM_TASKS);
 
         for val in 0..NUM_TASKS {
-            let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(val).fuse()));
+            let task: DummyTask = DummyTask::new(
+                #[cfg(debug)]
+                String::from("testing"),
+                Box::pin(DummyCoroutine::new(val).fuse()),
+            );
             let Some(task_id) = scheduler.insert_task(task) else {
                 panic!("insert() failed");
             };
@@ -623,7 +664,11 @@ mod tests {
         let mut task_ids: Vec<TaskId> = Vec::<TaskId>::with_capacity(NUM_TASKS);
 
         for val in 0..NUM_TASKS {
-            let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(val).fuse()));
+            let task: DummyTask = DummyTask::new(
+                #[cfg(debug)]
+                String::from("testing"),
+                Box::pin(DummyCoroutine::new(val).fuse()),
+            );
             let Some(task_id) = scheduler.insert_task(task) else {
                 panic!("insert() failed");
             };

--- a/src/rust/runtime/scheduler/task.rs
+++ b/src/rust/runtime/scheduler/task.rs
@@ -50,6 +50,7 @@ pub struct TaskId(pub u64);
 /// Task runs a single coroutine to completion and stores the result for later. Thus, it implements Future but
 /// never directly returns anything.
 pub trait Task: FusedFuture<Output = ()> + Unpin + Any {
+    #[cfg(debug)]
     fn get_name(&self) -> String;
     fn as_any(self: Box<Self>) -> Box<dyn Any>;
     fn get_id(&self) -> TaskId;
@@ -66,6 +67,7 @@ pub trait TaskWith: TryFrom<Box<dyn Any>> {
 /// A specific instance of Task that returns a particular return type [R].
 pub struct TaskWithResult<R: Unpin + Clone + Any> {
     /// Task name. The libOS should use this to identify the type of task.
+    #[cfg(debug)]
     name: String,
     /// Task identifier.
     task_id: Option<TaskId>,
@@ -82,8 +84,9 @@ pub struct TaskWithResult<R: Unpin + Clone + Any> {
 /// Associate Functions for TaskWithResults.
 impl<R: Unpin + Clone + Any> TaskWithResult<R> {
     /// Instantiates a new Task.
-    pub fn new(name: String, coroutine: Pin<<Self as TaskWith>::Coroutine>) -> Self {
+    pub fn new(#[cfg(debug)] name: String, coroutine: Pin<<Self as TaskWith>::Coroutine>) -> Self {
         Self {
+            #[cfg(debug)]
             name,
             task_id: None,
             coroutine,
@@ -132,6 +135,7 @@ impl<R: Unpin + Clone + Any> TryFrom<Box<dyn Any>> for TaskWithResult<R> {
 
 impl<R: Unpin + Clone + Any> Task for TaskWithResult<R> {
     // The coroutine type that this task will run.
+    #[cfg(debug)]
     fn get_name(&self) -> String {
         self.name.clone()
     }


### PR DESCRIPTION
## Description

This PR removes tasks names from the Task structure to avoid memory allocations in the critical path.