### PR TITLE
[runtime] Bug Fix: Clean up spurious wake ups in the timer

### DIFF
--- a/nettest/input/pop-blocking.pkt
+++ b/nettest/input/pop-blocking.pkt
@@ -22,7 +22,7 @@
 // Receive data packet.
 +.1 < P. seq 1(1000) ack 1 win 65535 <nop>
 // Send ACK packet.
-+.6 > . seq 1(0) ack 1001 win 65535 <nop>
++.6 > . seq 1(0) ack 1001 win 64535 <nop>
 
 // Data read.
 +.0 wait(501, ...) = 0


### PR DESCRIPTION
This PR removes entries from the ordered heap in the global timer when a coroutine is no longer waiting on it. It also reduces the scope of the global variable that holds the timer since another PR will soon remove the global reference to the scheduler.