### PR TITLE
[runtime] Enhancement: add BufferPool and MemoryPool types for pooling DemiBuffer allocation

### DIFF
--- a/src/rust/pal/arch.rs
+++ b/src/rust/pal/arch.rs
@@ -8,3 +8,5 @@
 // ------------------------
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub const CPU_DATA_CACHE_LINE_SIZE: usize = 64;
+
+const _: () = assert!(CPU_DATA_CACHE_LINE_SIZE.is_power_of_two());

--- a/src/rust/runtime/memory/buffer_pool.rs
+++ b/src/rust/runtime/memory/buffer_pool.rs
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//==============================================================================
+// Imports
+//==============================================================================
+
+use std::{
+    alloc::LayoutError,
+    num::NonZeroUsize,
+    rc::Rc,
+};
+
+use crate::{
+    pal::arch::CPU_DATA_CACHE_LINE_SIZE,
+    runtime::memory::{
+        demibuffer::MetaData,
+        memory_pool::MemoryPool,
+    },
+};
+
+//======================================================================================================================
+// Structures
+//======================================================================================================================
+
+/// This structure is a wrapper around the [`MemoryPool`] concept to allow easier interoperation between that type and
+/// [`DemiBuffer`]. This pool will create a buffer layout compatible with the metadata and requested user data size.
+/// `DemiBuffer` can operate directly on this pool type.
+pub struct BufferPool(Rc<MemoryPool>);
+
+//======================================================================================================================
+// Associated Functions
+//======================================================================================================================
+
+impl BufferPool {
+    pub fn new(buffer_data_size: u16) -> Result<Self, LayoutError> {
+        Ok(Self(MemoryPool::new(
+            NonZeroUsize::new(std::mem::size_of::<MetaData>() + buffer_data_size as usize).unwrap(),
+            NonZeroUsize::new(CPU_DATA_CACHE_LINE_SIZE).unwrap(),
+        )?))
+    }
+
+    /// Get a reference to the underlying [`MemoryPool`].
+    pub fn pool(&self) -> &Rc<MemoryPool> {
+        &self.0
+    }
+}
+
+// Unit tests for `BufferPool` type.
+#[cfg(test)]
+mod tests {
+    use std::{
+        mem::MaybeUninit,
+        num::NonZeroUsize,
+        ptr::NonNull,
+    };
+
+    use ::anyhow::Result;
+    use anyhow::{
+        anyhow,
+        ensure,
+    };
+
+    use crate::{
+        ensure_eq,
+        runtime::memory::{
+            BufferPool,
+            DemiBuffer,
+            MetaData,
+        },
+    };
+
+    #[test]
+    fn get_buffer_from_pool() -> Result<()> {
+        const BUFFER_SIZE: usize = 0x1000;
+        const PAGE_SIZE: usize = 0x80000000;
+        let mut buffer: Vec<MaybeUninit<u8>> = Vec::with_capacity(BUFFER_SIZE);
+        buffer.resize(buffer.capacity(), MaybeUninit::uninit());
+        let pool: BufferPool = BufferPool::new(u16::try_from(buffer.len() - std::mem::size_of::<MetaData>())?)?;
+
+        unsafe {
+            pool.pool().populate(
+                NonNull::from(buffer.as_mut_slice()),
+                NonZeroUsize::new(PAGE_SIZE).unwrap(),
+            )?
+        };
+
+        ensure_eq!(pool.pool().len(), 1);
+
+        let buffer: DemiBuffer = DemiBuffer::new_in_pool(&pool).ok_or(anyhow!("could not create buffer"))?;
+
+        ensure_eq!(buffer.len(), BUFFER_SIZE - std::mem::size_of::<MetaData>());
+        ensure!(pool.pool().is_empty());
+
+        std::mem::drop(buffer);
+        ensure_eq!(pool.pool().len(), 1);
+
+        ensure_eq!(pool.pool().get().unwrap().len(), BUFFER_SIZE);
+
+        Ok(())
+    }
+}

--- a/src/rust/runtime/memory/demibuffer.rs
+++ b/src/rust/runtime/memory/demibuffer.rs
@@ -30,7 +30,16 @@
 
 use crate::{
     pal::arch,
-    runtime::fail::Fail,
+    runtime::{
+        fail::Fail,
+        memory::{
+            buffer_pool::BufferPool,
+            memory_pool::{
+                MemoryPool,
+                PoolBuf,
+            },
+        },
+    },
 };
 #[cfg(feature = "libdpdk")]
 use ::dpdk_rs::{
@@ -52,6 +61,7 @@ use ::std::{
     mem::{
         self,
         size_of,
+        MaybeUninit,
     },
     num::NonZeroUsize,
     ops::{
@@ -66,6 +76,7 @@ use ::std::{
     },
     slice,
 };
+use std::rc::Rc;
 
 // Buffer Metadata.
 // This is defined to match a DPDK MBuf (rte_mbuf) in order to potentially use the same code for some DemiBuffer
@@ -77,12 +88,12 @@ use ::std::{
 #[repr(C)]
 #[repr(align(64))]
 #[derive(Debug)]
-struct MetaData {
+pub(super) struct MetaData {
     // Virtual address of the start of the actual data.
     buf_addr: *mut u8,
 
     // Physical address of the buffer.
-    _buf_iova: u64,
+    _buf_iova: MaybeUninit<u64>,
 
     // Data offset.
     data_off: u16,
@@ -91,32 +102,32 @@ struct MetaData {
     // Number of segments in this buffer chain (only valid in first segment's MetaData).
     nb_segs: u16,
     // Input port.
-    _port: u16,
+    _port: MaybeUninit<u16>,
 
     // Offload features.
     // Note, despite the "offload" name, the indirect buffer flag (METADATA_F_INDIRECT) lives here.
     ol_flags: u64,
 
     // L2/L3/L4 and tunnel information.
-    _packet_type: u32,
+    _packet_type: MaybeUninit<u32>,
     // Total packet data length (sum of all segments' data_len).
     pkt_len: u32,
 
     // Amount of data in this segment buffer.
     data_len: u16,
     // VLAN TCI.
-    _vlan_tci: u16,
+    _vlan_tci: MaybeUninit<u16>,
     // Potentially used for various things, including RSS hash.
-    _various1: u32,
+    _various1: MaybeUninit<u32>,
 
     // Potentially used for various things, including RSS hash.
-    _various2: u32,
-    _vlan_tci_outer: u16,
+    _various2: MaybeUninit<u32>,
+    _vlan_tci_outer: MaybeUninit<u16>,
     // Allocated length of the buffer that buf_addr points to.
     buf_len: u16,
 
     // Pointer to memory pool (rte_mempool) from which mbuf was allocated.
-    _pool: u64,
+    pool: Option<Rc<MemoryPool>>,
 
     // Second cache line (64 bytes) begins here.
 
@@ -124,17 +135,51 @@ struct MetaData {
     next: Option<NonNull<MetaData>>,
 
     // Various fields for TX offload.
-    _tx_offload: u64,
+    _tx_offload: MaybeUninit<u64>,
 
-    // Pointer to shared info (rte_mbuf_ext_shared_info).  DPDK uses this for external MBufs.
-    _shinfo: u64,
+    // Pointer to shared info. Used to manage external buffers.
+    _shinfo: MaybeUninit<u64>,
 
     // Size of private data (between rte_mbuf struct and the data) in direct MBufs.
-    _priv_size: u16,
+    _priv_size: MaybeUninit<u16>,
     // Timesync flags for use with IEEE 1588 "Precision Time Protocol" (PTP).
-    _timesync: u16,
+    _timesync: MaybeUninit<u16>,
     // Reserved for dynamic fields.
-    _dynfield: [u32; 9],
+    _dynfield: MaybeUninit<[u32; 9]>,
+}
+
+/// The minimal set of metadata used by the Demikernel runtime. Used to safely initialize MetaData.
+struct DemiMetaData {
+    // Virtual address of the start of the actual data.
+    buf_addr: *mut u8,
+
+    // Data offset.
+    data_off: u16,
+
+    // Reference counter.
+    refcnt: u16,
+
+    // Number of segments in this buffer chain (only valid in first segment's MetaData).
+    nb_segs: u16,
+
+    // Offload features.
+    // Note, despite the "offload" name, the indirect buffer flag (METADATA_F_INDIRECT) lives here.
+    ol_flags: u64,
+
+    // Total packet data length (sum of all segments' data_len).
+    pkt_len: u32,
+
+    // Amount of data in this segment buffer.
+    data_len: u16,
+
+    // Allocated length of the buffer that buf_addr points to.
+    buf_len: u16,
+
+    // Pointer to memory pool (rte_mempool) from which mbuf was allocated.
+    pool: Option<Rc<MemoryPool>>,
+
+    // Pointer to the MetaData of the next segment in this packet's chain (must be NULL in last segment).
+    next: Option<NonNull<MetaData>>,
 }
 
 // Check MetaData structure alignment and size at compile time.
@@ -142,6 +187,7 @@ struct MetaData {
 // be used.  So, if the alignment assert is firing, change the value in the align() to match CPU_DATA_CACHE_LINE_SIZE.
 const _: () = assert!(std::mem::align_of::<MetaData>() == arch::CPU_DATA_CACHE_LINE_SIZE);
 const _: () = assert!(std::mem::size_of::<MetaData>() == 2 * arch::CPU_DATA_CACHE_LINE_SIZE);
+const _: () = assert!(std::mem::size_of::<Option<Rc<MemoryPool>>>() == std::mem::size_of::<*const ()>());
 
 // MetaData "offload flags".  These exactly mimic those of DPDK MBufs.
 
@@ -155,6 +201,43 @@ impl MetaData {
     // We should rework the implementation of inc_refcnt() and dec_refcnt() to use atomic operations if this changes.
     // Also, we intentionally don't check for refcnt overflow.  This matches DPDK's behavior, which doesn't check for
     // reference count overflow either (we're highly unlikely to ever have 2^16 copies of the same data).
+
+    // Hydrate a MetaData instance from the subset of values used by Demikernel.
+    fn new(values: DemiMetaData) -> Self {
+        MetaData {
+            buf_addr: values.buf_addr,
+            data_off: values.data_off,
+            refcnt: values.refcnt,
+            nb_segs: values.nb_segs,
+            ol_flags: values.ol_flags,
+            pkt_len: values.pkt_len,
+            data_len: values.data_len,
+            buf_len: values.buf_len,
+            pool: values.pool,
+            next: values.next,
+
+            // Unused fields
+            _buf_iova: MaybeUninit::uninit(),
+            _port: MaybeUninit::uninit(),
+            _packet_type: MaybeUninit::uninit(),
+            _shinfo: MaybeUninit::uninit(),
+            _vlan_tci: MaybeUninit::uninit(),
+            _various1: MaybeUninit::uninit(),
+            _various2: MaybeUninit::uninit(),
+            _vlan_tci_outer: MaybeUninit::uninit(),
+            _tx_offload: MaybeUninit::uninit(),
+            _timesync: MaybeUninit::uninit(),
+            _dynfield: MaybeUninit::uninit(),
+
+            // Initialize select MetaData fields in debug builds for sanity checking.
+            // We check in debug builds that they aren't accidentally messed with.
+            _priv_size: if cfg!(debug_assertions) {
+                MaybeUninit::new(0)
+            } else {
+                MaybeUninit::uninit()
+            },
+        }
+    }
 
     // Increments the reference count and returns the new value.
     #[inline]
@@ -251,7 +334,7 @@ impl DemiBuffer {
 
     // Implementation Note:
     // This function is replacing the new() function of DataBuffer, which could return failure.  However, the only
-    // failure it actually reported was if the new DataBuffer request was for zero size.  A seperate empty() function
+    // failure it actually reported was if the new DataBuffer request was for zero size.  A separate empty() function
     // was provided to allocate zero-size buffers.  This new implementation does not have a special case for this,
     // instead, zero is a valid argument to new().  So we no longer need the failure return case of this function.
     //
@@ -262,37 +345,72 @@ impl DemiBuffer {
     // status quo, and assume this allocation never fails.
     pub fn new(capacity: u16) -> Self {
         // Allocate some memory off the heap.
-        let mut temp: NonNull<MetaData> = allocate_metadata_data(capacity);
+        let (metadata_buf, buffer): (&mut MaybeUninit<MetaData>, &mut [MaybeUninit<u8>]) =
+            allocate_metadata_data(capacity);
 
-        // Initialize the MetaData.
-        {
-            // Safety: This is safe, as temp is aligned, dereferenceable, and metadata isn't aliased in this block.
-            let metadata: &mut MetaData = unsafe { temp.as_mut() };
+        Self::new_from_parts(metadata_buf, buffer.as_mut_ptr(), capacity, None)
+    }
 
-            // Point buf_addr at the newly allocated data space (if any).
-            if capacity == 0 {
-                // No direct data, so don't point buf_addr at anything.
-                metadata.buf_addr = null_mut();
-            } else {
-                // The direct data immediately follows the MetaData struct.
-                let address: *mut u8 = temp.cast::<u8>().as_ptr();
-                // Safety: The call to offset is safe, as the provided offset is known to be within the allocation.
-                metadata.buf_addr = unsafe { address.offset(size_of::<MetaData>() as isize) };
-            }
+    /// Create a new buffer using a buffer from the specified [`BufferPool`]. If the pool is empty, this method returns
+    /// `None`.
+    ///
+    /// Note that currently `DemiBuffer` carries static lifetime, so the `BufferPool` must also meet this requirement.
+    /// Possibly this requirement could be relaxed with more buffer reference types, or buffers which carry an explicit
+    /// lifetime. Until a compelling use case arises, this will cap to `'static`.
+    pub fn new_in_pool(pool: &BufferPool) -> Option<Self> {
+        let buffer: PoolBuf = match pool.pool().get() {
+            Some(buffer) => buffer,
+            None => return None,
+        };
 
-            // Set field values as appropriate.
-            metadata.data_off = 0;
-            metadata.refcnt = 1;
-            metadata.nb_segs = 1;
-            metadata.ol_flags = 0;
-            metadata.pkt_len = capacity as u32;
-            metadata.data_len = capacity;
-            metadata.buf_len = capacity;
-            metadata.next = None;
-        }
+        let (mut buffer, pool): (NonNull<[MaybeUninit<u8>]>, Rc<MemoryPool>) = PoolBuf::into_raw(buffer);
+
+        // Safety: the buffer size and alignment requirements are enforced by BufferPool.
+        let (metadata_buf, buffer): (&mut MaybeUninit<MetaData>, &mut [MaybeUninit<u8>]) =
+            unsafe { split_buffer_for_metadata(buffer.as_mut()) };
+
+        assert!(buffer.len() <= (u16::MAX as usize));
+
+        Some(Self::new_from_parts(
+            metadata_buf,
+            buffer.as_mut_ptr(),
+            buffer.len() as u16,
+            Some(pool),
+        ))
+    }
+
+    /// Create a new DemiBuffer in the specified memory, with relevant configuration values.
+    fn new_from_parts(
+        metadata_buf: &mut MaybeUninit<MetaData>,
+        buf_addr: *mut MaybeUninit<u8>,
+        capacity: u16,
+        pool: Option<Rc<MemoryPool>>,
+    ) -> Self {
+        let buf_addr: *mut u8 = if capacity > 0 {
+            // TODO: casting the MaybeUninit away can cause UB (when deref'd). Change the exposed data type from
+            // DemiBuffer to better expose un/initialized values.
+            buf_addr.cast()
+        } else {
+            ptr::null_mut()
+        };
+
+        let metadata: NonNull<MetaData> = NonNull::from(metadata_buf.write(MetaData::new(DemiMetaData {
+            buf_addr,
+            data_off: 0,
+            refcnt: 1,
+            nb_segs: 1,
+            ol_flags: 0,
+            pkt_len: capacity as u32,
+            // Note: this is not consistent with DPDK behavior: presumably, zero bytes of data are initialized at this
+            // point
+            data_len: capacity,
+            buf_len: capacity,
+            next: None,
+            pool,
+        })));
 
         // Embed the buffer type into the lower bits of the pointer.
-        let tagged: NonNull<MetaData> = temp.with_addr(temp.addr() | Tag::Heap);
+        let tagged: NonNull<MetaData> = metadata.with_addr(metadata.addr() | Tag::Heap);
 
         // Return the new DemiBuffer.
         DemiBuffer {
@@ -301,7 +419,7 @@ impl DemiBuffer {
         }
     }
 
-    /// Create a new Heap-allocated `DemiBuffer` from a byte slice.
+    /// Allocate a new DemiBuffer and copy the contents from a byte slice.
     pub fn from_slice(slice: &[u8]) -> Result<Self, Fail> {
         // Note: The implementation of the TryFrom trait (see below, under "Trait Implementations") automatically
         // provides us with a TryInto trait implementation (which is where try_into comes from).
@@ -651,7 +769,7 @@ impl DemiBuffer {
 // ----------------
 
 // Allocates the MetaData (plus the space for any directly attached data) for a new heap-allocated DemiBuffer.
-fn allocate_metadata_data(direct_data_size: u16) -> NonNull<MetaData> {
+fn allocate_metadata_data<'a>(direct_data_size: u16) -> (&'a mut MaybeUninit<MetaData>, &'a mut [MaybeUninit<u8>]) {
     // We need space for the MetaData struct, plus any extra memory for directly attached data.
     let amount: usize = size_of::<MetaData>() + direct_data_size as usize;
 
@@ -659,50 +777,83 @@ fn allocate_metadata_data(direct_data_size: u16) -> NonNull<MetaData> {
     let layout: Layout = Layout::from_size_align(amount, arch::CPU_DATA_CACHE_LINE_SIZE).unwrap();
 
     // Safety: This is safe, as we check for a null return value before dereferencing "allocation".
-    let allocation: *mut u8 = unsafe { alloc(layout) };
+    let allocation: *mut MaybeUninit<u8> = unsafe { alloc(layout) }.cast();
     if allocation.is_null() {
         handle_alloc_error(layout);
     }
 
-    let metadata: *mut MetaData = allocation.cast::<MetaData>();
+    // Safety: the slice is valid based on the constraints to the above allocation.
+    let buffer: &mut [MaybeUninit<u8>] = unsafe { slice::from_raw_parts_mut(allocation, amount) };
 
-    // Initialize select MetaData fields in debug builds for sanity checking.
-    // We check in debug builds that they aren't accidentally messed with.
-    // Safety: The `metadata` dereferences in this block are safe, as it is known to be aligned and dereferenceable.
-    #[cfg(debug_assertions)]
-    unsafe {
-        // This field should only be non-null for DPDK-allocated DemiBuffers.
-        (*metadata)._pool = 0;
+    // Safety: buffer is aligned to CPU_DATA_CACHE_LINE_SIZE (which is overaligned for MetaData) and will always be no
+    // smaller than MetaData.
+    unsafe { split_buffer_for_metadata(buffer) }
+}
 
-        // We don't currently use a "private data" feature akin to DPDK's.
-        (*metadata)._priv_size = 0;
-    }
+/// Split a buffer into (metadata, data) parts.
+///
+/// # Panics:
+/// panics if `buffer.len() < size_of::<MetaData>()`.
+///
+/// # Safety:
+/// `buffer` must be suitably aligned for and large enough to hold a [`MetaData`].
+unsafe fn split_buffer_for_metadata<'a>(
+    buffer: &'a mut [MaybeUninit<u8>],
+) -> (&'a mut MaybeUninit<MetaData>, &'a mut [MaybeUninit<u8>]) {
+    assert!(buffer.len() >= size_of::<MetaData>());
 
-    // Convert to NonNull<MetaData> type and return.
-    // Safety: The call to NonNull::new_unchecked is safe, as `allocation` is known to be non-null.
-    unsafe { NonNull::new_unchecked(metadata) }
+    let (metadata_buf, data_buf) = buffer.split_at_mut(size_of::<MetaData>());
+
+    // Safety: buffer is not null and properly aligned since it comes from a reference. MaybeUninit does not
+    // require initialization.
+    let metadata: &mut MaybeUninit<MetaData> =
+        unsafe { &mut *metadata_buf.as_mut_ptr().cast::<MaybeUninit<MetaData>>() };
+
+    (metadata, data_buf)
 }
 
 // Frees the MetaData (plus the space for any directly attached data) for a heap-allocated DemiBuffer.
-fn free_metadata_data(buffer: NonNull<MetaData>) {
-    // Safety: This is safe, as `buffer` is aligned, dereferenceable, and we don't let `metadata` escape this function.
-    let metadata: &MetaData = unsafe { buffer.as_ref() };
+fn free_metadata_data(mut buffer: NonNull<MetaData>) {
+    let (amount, pool): (usize, Option<Rc<MemoryPool>>) = {
+        // Safety: This is safe, as `buffer` is aligned, dereferenceable, and we don't let `metadata` escape this function.
+        let metadata: &mut MetaData = unsafe { buffer.as_mut() };
 
-    // Check in debug builds that we weren't accidentally passed a DPDK-allocated MBuf to free.
-    debug_assert_eq!(metadata._pool, 0);
+        // Determine the size of the original allocation.
+        // Note that this code currently assumes we're not using a "private data" feature akin to DPDK's.
+        // Safety: _priv_size will be initialized when debug_assertions is turned on.
+        debug_assert_eq!(unsafe { metadata._priv_size.assume_init() }, 0);
 
-    // Determine the size of the original allocation.
-    // Note that this code currently assumes we're not using a "private data" feature akin to DPDK's.
-    debug_assert_eq!(metadata._priv_size, 0);
-    let amount: usize = size_of::<MetaData>() + metadata.buf_len as usize;
+        (size_of::<MetaData>() + metadata.buf_len as usize, metadata.pool.take())
+    };
+
+    // Drop the instance.
+    // Safety: the pointer `buffer` is valid, aligned, and properly initialized.
+    unsafe { ptr::drop_in_place(buffer.as_ptr()) };
+
     // This unwrap will never panic, as we pass a known allocation amount and a fixed alignment to from_size_align().
-    let layout: Layout = Layout::from_size_align(amount, arch::CPU_DATA_CACHE_LINE_SIZE).unwrap();
+    match pool {
+        Some(pool) => {
+            // Safety: the pool pointer is populated from a 'static reference, so will be valid and dereferenceable.
+            // Because the MetaData buffer must come from `pool`, the slice with size `pool.layout()` starting at
+            // `buffer` will also be valid and dereferenceable. The `MetaData` buffer is created from
+            // `PoolBuf::into_raw` by the constructor, so the buffer may be passed back to `PoolBuf::from_raw`.
+            unsafe {
+                let pool_layout: Layout = pool.layout();
+                let mem_slice: &mut [MaybeUninit<u8>] =
+                    slice::from_raw_parts_mut(buffer.cast::<MaybeUninit<u8>>().as_ptr(), pool_layout.size());
+                mem::drop(PoolBuf::from_raw(NonNull::from(mem_slice), pool));
+            }
+        },
 
-    // Convert buffer pointer into a raw allocation pointer.
-    let allocation: *mut u8 = buffer.cast::<u8>().as_ptr();
+        None => {
+            // Convert buffer pointer into a raw allocation pointer.
+            let allocation: *mut u8 = buffer.cast::<u8>().as_ptr();
+            let layout: Layout = Layout::from_size_align(amount, arch::CPU_DATA_CACHE_LINE_SIZE).unwrap();
 
-    // Safety: this is safe because we're using the same (de)allocator and Layout used for allocation.
-    unsafe { dealloc(allocation, layout) };
+            // Safety: this is safe because we're using the same (de)allocator and Layout used for allocation.
+            unsafe { dealloc(allocation, layout) };
+        },
+    }
 }
 
 // ---------------------
@@ -720,14 +871,15 @@ impl Clone for DemiBuffer {
                 // we increment the reference count on that data.
 
                 // Allocate space for a new MetaData struct without any direct data.  This will become the clone.
-                let head: NonNull<MetaData> = allocate_metadata_data(0);
-                let mut temp = head;
+                // TODO: Pooled MetaData should be reallocated from the pool.
+                let (head, _): (&mut MaybeUninit<MetaData>, _) = allocate_metadata_data(0);
+                let mut temp: NonNull<MaybeUninit<MetaData>> = NonNull::from(&*head);
 
                 // This might be a chain of buffers.  If so, we'll walk the list.  There is always a first one.
                 let mut next_entry: Option<NonNull<MetaData>> = Some(self.get_ptr::<MetaData>());
                 while let Some(mut entry) = next_entry {
-                    // Safety: This is safe, as `entry` is aligned, dereferenceable, and the MetaData struct it points
-                    // to is initialized.
+                    // Safety: This is safe, as `entry` is aligned, dereferenceable, and the MetaData struct it
+                    // points to is initialized.
                     let original: &mut MetaData = unsafe { entry.as_mut() };
 
                     // Remember the next entry in the chain.
@@ -736,42 +888,50 @@ impl Clone for DemiBuffer {
                     // Initialize the MetaData of the indirect buffer.
                     {
                         // Safety: Safe, as `temp` is aligned, dereferenceable, and `clone` isn't aliased in this block.
-                        let clone: &mut MetaData = unsafe { temp.as_mut() };
-
-                        // Our cloned segment has only one reference (the one we return from this function).
-                        clone.refcnt = 1;
+                        let clone: &mut MaybeUninit<MetaData> = unsafe { temp.as_mut() };
 
                         // Next needs to point to the next entry in the cloned chain, not the original.
-                        if next_entry.is_none() {
-                            clone.next = None;
+                        let next: Option<NonNull<MetaData>> = if next_entry.is_none() {
+                            None
                         } else {
                             // Allocate space for the next segment's MetaData struct.
-                            temp = allocate_metadata_data(0);
-                            clone.next = Some(temp);
-                        }
+                            let (new_metadata, _) = allocate_metadata_data(0);
+                            temp = NonNull::from(new_metadata);
+                            Some(temp.cast())
+                        };
+
+                        // Add indirect flag to clone for non-empty buffers. Empty buffers don't reference any data, so
+                        // aren't indirect.
+                        let ol_flags: u64 =
+                            original.ol_flags | if original.buf_len != 0 { METADATA_F_INDIRECT } else { 0 };
 
                         // Copy other relevant fields from our progenitor.
-                        clone.buf_addr = original.buf_addr;
-                        clone.buf_len = original.buf_len;
-                        clone.data_off = original.data_off;
-                        clone.nb_segs = original.nb_segs;
-                        clone.pkt_len = original.pkt_len;
-                        clone.data_len = original.data_len;
+                        let values: DemiMetaData = DemiMetaData {
+                            // Our cloned segment has only one reference (the one we return from this function).
+                            refcnt: 1,
+                            next,
+                            buf_addr: original.buf_addr,
+                            buf_len: original.buf_len,
+                            data_off: original.data_off,
+                            nb_segs: original.nb_segs,
+                            pkt_len: original.pkt_len,
+                            data_len: original.data_len,
+                            ol_flags,
+                            pool: None,
+                        };
+
+                        clone.write(MetaData::new(values));
 
                         // Special case for zero-length buffers.
                         if original.buf_len == 0 {
-                            debug_assert_eq!(clone.buf_len, 0);
-                            debug_assert_eq!(clone.buf_addr, ptr::null_mut());
-                            // Since there is no data to clone, we don't need to make this an indirect buffer or
-                            // increment any reference counts.  Instead we just create a new zero-length direct buffer.
-                            clone.ol_flags = original.ol_flags;
+                            debug_assert_eq!(original.buf_addr, ptr::null_mut());
+                            // Since there is no data to clone, we don't need to increment any reference counts.
+                            // Instead we just create a new zero-length direct buffer.
                             continue;
-                        } else {
-                            clone.ol_flags = original.ol_flags | METADATA_F_INDIRECT; // Add indirect flag to clone.
                         }
                     }
 
-                    // Incrememnt the reference count on the data.  It resides in the MetaData structure that the data
+                    // Increment the reference count on the data.  It resides in the MetaData structure that the data
                     // is directly attached to.  If the buffer we're cloning is itself an indirect buffer, then we need
                     // to find the original direct buffer in order to increment the correct reference count.
                     if original.ol_flags & METADATA_F_INDIRECT == 0 {
@@ -793,7 +953,9 @@ impl Clone for DemiBuffer {
                 }
 
                 // Embed the buffer type into the lower bits of the pointer.
-                let tagged: NonNull<MetaData> = head.with_addr(head.addr() | Tag::Heap);
+                // Safety: head is initialized by the above loop.
+                let head_ptr: NonNull<MetaData> = NonNull::from(unsafe { head.assume_init_mut() });
+                let tagged: NonNull<MetaData> = head_ptr.with_addr(head_ptr.addr() | Tag::Heap);
 
                 // Return the new DemiBuffer.
                 DemiBuffer {
@@ -883,6 +1045,7 @@ impl Drop for DemiBuffer {
                     // Remember the next entry in the chain (if any) before we potentially free the current one.
                     next_entry = metadata.next;
                     metadata.next = None;
+                    metadata.nb_segs = 1;
 
                     // Decrement the reference count.
                     if metadata.dec_refcnt() == 0 {
@@ -948,42 +1111,38 @@ impl TryFrom<&[u8]> for DemiBuffer {
         };
 
         // Allocate some memory off the heap.
-        let mut temp: NonNull<MetaData> = allocate_metadata_data(size);
+        let (temp, buffer): (&mut MaybeUninit<MetaData>, &mut [MaybeUninit<u8>]) = allocate_metadata_data(size);
 
-        // Initialize the MetaData.
-        {
-            // Safety: This is safe, as temp is aligned, dereferenceable, and metadata isn't aliased in this block.
-            let metadata: &mut MetaData = unsafe { temp.as_mut() };
+        // Point buf_addr at the newly allocated data space (if any).
+        let buf_addr: *mut u8 = if size == 0 {
+            // No direct data, so don't point buf_addr at anything.
+            null_mut()
+        } else {
+            let buf_addr: *mut u8 = buffer.as_mut_ptr().cast();
 
-            // Point buf_addr at the newly allocated data space (if any).
-            if size == 0 {
-                // No direct data, so don't point buf_addr at anything.
-                metadata.buf_addr = null_mut();
-            } else {
-                // The direct data immediately follows the MetaData struct.
-                let address: *mut u8 = temp.cast::<u8>().as_ptr();
-                // Safety: The call to offset is safe, as the provided offset is known to be within the allocation.
-                metadata.buf_addr = unsafe { address.offset(size_of::<MetaData>() as isize) };
+            // Copy the data from the slice into the DemiBuffer.
+            // Safety: This is safe, as the src/dst argument pointers are valid for reads/writes of `size` bytes,
+            // are aligned (trivial for u8 pointers), and the regions they specify do not overlap one another.
+            unsafe { ptr::copy_nonoverlapping(slice.as_ptr(), buf_addr, size as usize) };
+            buf_addr
+        };
 
-                // Copy the data from the slice into the DemiBuffer.
-                // Safety: This is safe, as the src/dst argument pointers are valid for reads/writes of `size` bytes,
-                // are aligned (trivial for u8 pointers), and the regions they specify do not overlap one another.
-                unsafe { ptr::copy_nonoverlapping(slice.as_ptr(), metadata.buf_addr, size as usize) };
-            }
-
-            // Set field values as appropriate.
-            metadata.data_off = 0;
-            metadata.refcnt = 1;
-            metadata.nb_segs = 1;
-            metadata.ol_flags = 0;
-            metadata.pkt_len = size as u32;
-            metadata.data_len = size;
-            metadata.buf_len = size;
-            metadata.next = None;
-        }
+        // Set field values as appropriate.
+        let metadata: NonNull<MetaData> = NonNull::from(temp.write(MetaData::new(DemiMetaData {
+            buf_addr,
+            data_off: 0,
+            refcnt: 1,
+            nb_segs: 1,
+            ol_flags: 0,
+            pkt_len: size as u32,
+            data_len: size,
+            buf_len: size,
+            next: None,
+            pool: None,
+        })));
 
         // Embed the buffer type into the lower bits of the pointer.
-        let tagged: NonNull<MetaData> = temp.with_addr(temp.addr() | Tag::Heap);
+        let tagged: NonNull<MetaData> = metadata.with_addr(metadata.addr() | Tag::Heap);
 
         // Return the new DemiBuffer.
         Ok(DemiBuffer {

--- a/src/rust/runtime/memory/memory_pool.rs
+++ b/src/rust/runtime/memory/memory_pool.rs
@@ -1,0 +1,577 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//==============================================================================
+// Imports
+//==============================================================================
+
+use std::{
+    self,
+    alloc::{
+        Layout,
+        LayoutError,
+    },
+    cell::UnsafeCell,
+    marker::PhantomData,
+    mem::{
+        ManuallyDrop,
+        MaybeUninit,
+    },
+    num::NonZeroUsize,
+    ops::{
+        Deref,
+        DerefMut,
+    },
+    ptr::NonNull,
+    rc::Rc,
+};
+
+use crate::runtime::fail::Fail;
+
+//======================================================================================================================
+// Structures
+//======================================================================================================================
+
+/// A single-threaded, page-aware pool of homogeneously-sized buffers.
+#[derive(Debug)]
+pub struct MemoryPool {
+    buffers: UnsafeCell<Vec<NonNull<[MaybeUninit<u8>]>>>,
+
+    buf_layout: Layout,
+}
+
+/// A buffer from a [`MemoryPool`]
+#[derive(Debug)]
+pub struct PoolBuf {
+    buffer: NonNull<[MaybeUninit<u8>]>,
+    pool: Rc<MemoryPool>,
+}
+
+/// This struct tracks consumption of a buffer, allowing the caller to take subspans and skip bytes, with useful
+/// pointer-alignment methods.
+struct BufferCursor {
+    /// The pointer to the location of the cursor. Ideally, this would be stored as a slice, but the DST pointer support
+    /// with non-null is underwhelming.
+    cursor: NonNull<MaybeUninit<u8>>,
+
+    /// Size of the memory span pointed to by cursor.
+    len: usize,
+}
+
+/// An iterator which will pack objects of a specific layout into a series of memory pages. The algorithm will try to
+/// minimize the number of pages each object spans, which may result in unused bytes at the end of each page. When the
+/// aligned size is a factor or multiple of the page size, objects will be tightly packed.
+struct PackingIterator<'a> {
+    cursor: BufferCursor,
+    layout: Layout,
+    page_size: NonZeroUsize,
+    _marker: PhantomData<&'a mut [MaybeUninit<u8>]>,
+}
+
+//======================================================================================================================
+// Associated Functions
+//======================================================================================================================
+
+impl MemoryPool {
+    /// Create a new empty pool of buffers of the specified size.
+    pub fn new(size: NonZeroUsize, align: NonZeroUsize) -> Result<Rc<Self>, LayoutError> {
+        Ok(Rc::new(Self {
+            buffers: UnsafeCell::new(Vec::new()),
+            buf_layout: Layout::from_size_align(size.get(), align.get())?,
+        }))
+    }
+
+    /// Get the buffer layout for this pool.
+    pub fn layout(self: &Rc<Self>) -> Layout {
+        self.buf_layout
+    }
+
+    /// Get one buffer from the pool. If no buffers remain, returns None.
+    pub fn get(self: &Rc<Self>) -> Option<PoolBuf> {
+        let buffers: &mut Vec<NonNull<[MaybeUninit<u8>]>> = unsafe { &mut *self.buffers.get() };
+        let pool: Rc<Self> = self.clone();
+        buffers
+            .pop()
+            .map(|buffer: NonNull<[MaybeUninit<u8>]>| PoolBuf { buffer, pool })
+    }
+
+    /// Return a buffer to the pool.
+    fn return_buffer(self: &Rc<Self>, buffer: NonNull<[MaybeUninit<u8>]>) {
+        // Safety: buffers is only granted a &mut alias during the methods of this class. As long as these methods are
+        // neither called asynchronously nor nested, aliasing is obeyed.
+        let buffers: &mut Vec<NonNull<[MaybeUninit<u8>]>> = unsafe { &mut *self.buffers.get() };
+        buffers.push(buffer);
+    }
+
+    /// Populate the pool by adding buffers from a series of memory pages given by `buffer`. This method will pack
+    /// buffers of the configured size into the pages such that each buffer spans the minimum number of pages. Returns
+    /// any unused bytes after the final buffer.
+    ///
+    /// # Safety:
+    /// The caller must ensure that `buffer` is a valid pointer which lives at least as long as the `MemoryPool`.
+    pub unsafe fn populate(
+        self: &Rc<Self>,
+        mut buffer: NonNull<[MaybeUninit<u8>]>,
+        page_size: NonZeroUsize,
+    ) -> Result<NonNull<[MaybeUninit<u8>]>, Fail> {
+        let mut iter: PackingIterator = PackingIterator::new(unsafe { buffer.as_mut() }, page_size, self.buf_layout)?;
+
+        // Safety: buffers is only granted a &mut alias during the methods of this class. As long as these methods are
+        // neither called asynchronously nor nested, aliasing is obeyed.
+        let buffers: &mut Vec<NonNull<[MaybeUninit<u8>]>> = unsafe { &mut *self.buffers.get() };
+        buffers.extend(std::iter::from_fn(|| iter.next()).map(NonNull::from));
+
+        Ok(NonNull::from(iter.into_slice()))
+    }
+
+    /// Returns the number of free buffers in the pool.
+    pub fn len(self: &Rc<Self>) -> usize {
+        // Safety: buffers is only granted a &mut alias during the methods of this class. As long as these methods are
+        // neither called asynchronously nor nested, aliasing is obeyed.
+        let buffers: &Vec<NonNull<[MaybeUninit<u8>]>> = unsafe { &*self.buffers.get() };
+        buffers.len()
+    }
+
+    /// Returns a flag indicating whether the pool is out of buffers.
+    pub fn is_empty(self: &Rc<Self>) -> bool {
+        self.len() == 0
+    }
+}
+
+impl PoolBuf {
+    /// Get the pool associated with the buffer.
+    pub fn pool(&self) -> Rc<MemoryPool> {
+        self.pool.clone()
+    }
+
+    /// Consume a PoolBuf and return the underlying buffer and memory pool. The caller is responsible for returning the
+    /// buffer to the memory pool by later calling [`PoolBuf::into_raw`]. Failing to call this method will result in the
+    /// buffer leaking from the memory pool. Because the pool does not own the allocated memory, this may or may not
+    /// result in a memory leak after the pool is deallocated.
+    ///
+    /// Note that this is an associated function to match idioms in e.g., [`Box::into_raw`].
+    pub fn into_raw(b: PoolBuf) -> (NonNull<[MaybeUninit<u8>]>, Rc<MemoryPool>) {
+        let b: ManuallyDrop<Self> = ManuallyDrop::new(b);
+
+        // Safety: pool field is valid and readable.
+        let pool: Rc<MemoryPool> = unsafe { std::ptr::read(&b.pool) };
+        (b.buffer, pool)
+    }
+
+    /// Create a PoolBuf from a buffer pointer and memory pool reference previously returned from [`PoolBuf::into_raw`].
+    ///
+    /// # Safety:
+    /// This method is only safe when called on values returned from [`PoolBuf::into_raw`], and only once for each call
+    /// to that method.
+    pub unsafe fn from_raw(buffer: NonNull<[MaybeUninit<u8>]>, pool: Rc<MemoryPool>) -> Self {
+        PoolBuf { buffer, pool }
+    }
+}
+
+impl BufferCursor {
+    /// Create a new buffer cursor over the specified slice.
+    pub fn new(buffer: &mut [MaybeUninit<u8>]) -> Self {
+        // NB, we could support this, but it's not practically necessary.
+        assert!(buffer.len() < isize::MAX as usize);
+        Self {
+            len: buffer.len(),
+            cursor: NonNull::from(buffer).cast(),
+        }
+    }
+
+    /// Reborrow the reference to the underlying buffer, creating a new cursor.
+    pub fn reborrow(&mut self) -> Self {
+        Self {
+            cursor: self.cursor,
+            len: self.len,
+        }
+    }
+
+    /// Take at most `bytes` bytes starting at the cursor. If not enough bytes remain in the buffer, the returned value
+    /// will be shorter than the requested number of bytes. Otherwise, the returned slice will have a length equal to
+    /// `bytes`.
+    pub fn take_at_most<'a>(&mut self, bytes: usize) -> &'a mut [MaybeUninit<u8>] {
+        debug_assert!(bytes <= isize::MAX as usize);
+
+        let bytes: usize = std::cmp::min(bytes, self.len);
+
+        // Safety: the offset from cursor is within the originally allocated span and not larger than isize::MAX.
+        let result: &mut [MaybeUninit<u8>] = unsafe { std::slice::from_raw_parts_mut(self.cursor.as_ptr(), bytes) };
+        self.cursor = unsafe { NonNull::new_unchecked(self.cursor.as_ptr().offset(bytes as isize)) };
+        self.len -= bytes;
+        result
+    }
+
+    /// Skip at most `bytes` bytes. Returns true iff `bytes` were skipped and the cursor points to at least one byte.
+    /// `bytes` must be no larger than [`isize::MAX`].
+    pub fn skip(&mut self, bytes: usize) -> bool {
+        self.take_at_most(bytes).len() == bytes
+    }
+
+    /// Align the cursor to `align`, skipping at most align bytes. Returns true iff the cursor is aligned to `align` and
+    /// points to at least one byte.
+    pub fn skip_to_align(&mut self, align: usize) -> bool {
+        let bytes: usize = self.cursor.as_ptr().align_offset(align);
+        self.skip(bytes)
+    }
+
+    /// Try to take `size` bytes starting at the cursor. The cursor is updated iff the return value is not None. This
+    /// method will return None if the remaining length of the buffer is less than `size`.
+    pub fn try_take<'a>(&mut self, size: usize) -> Option<&'a mut [MaybeUninit<u8>]> {
+        (size <= self.len).then(|| self.take_at_most(size))
+    }
+
+    /// Similar to [std::ptr::align_offset], but computes the next alignment after the cursor.
+    pub fn next_align_offset(&self, align: NonZeroUsize) -> Option<NonZeroUsize> {
+        (!self.is_empty())
+            .then(|| unsafe { NonZeroUsize::new_unchecked(self.cursor.as_ptr().add(1).align_offset(align.get()) + 1) })
+    }
+
+    /// Whether any bytes remain at the cursor.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Consume `self` and produce a reference to the remaining buffer.
+    pub fn into_slice<'a>(mut self) -> &'a mut [MaybeUninit<u8>] {
+        self.take_at_most(self.len)
+    }
+}
+
+impl<'a> PackingIterator<'a> {
+    pub fn new(buffer: &'a mut [MaybeUninit<u8>], page_size: NonZeroUsize, layout: Layout) -> Result<Self, Fail> {
+        if buffer.len() == 0 {
+            return Err(Fail::new(libc::EINVAL, "memory buffer too short"));
+        }
+
+        if !page_size.is_power_of_two() || page_size.get() < layout.align() {
+            return Err(Fail::new(libc::EINVAL, "page size is not valid"));
+        }
+
+        Ok(Self {
+            cursor: BufferCursor::new(buffer),
+            layout: layout,
+            page_size: page_size,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Consume `self` and produce a reference to the remaining buffer.
+    pub fn into_slice(self) -> &'a mut [MaybeUninit<u8>] {
+        self.cursor.into_slice()
+    }
+}
+
+impl Drop for PoolBuf {
+    fn drop(&mut self) {
+        MemoryPool::return_buffer(&self.pool, self.buffer);
+    }
+}
+
+impl Deref for PoolBuf {
+    type Target = [MaybeUninit<u8>];
+
+    fn deref(&self) -> &Self::Target {
+        // Safety: the pointer is valid, as it comes from a valid slice reference. Since PoolBuf is a unique owner of
+        // the buffer, aliasing rules are enforced automatically.
+        unsafe { self.buffer.as_ref() }
+    }
+}
+
+impl DerefMut for PoolBuf {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // Safety: the pointer is valid, as it comes from a valid slice reference. Since PoolBuf is a unique owner of
+        // the buffer, aliasing rules are enforced automatically.
+        unsafe { self.buffer.as_mut() }
+    }
+}
+
+impl<'a> Iterator for PackingIterator<'a> {
+    type Item = &'a mut [MaybeUninit<u8>];
+
+    fn next(&mut self) -> Option<&'a mut [MaybeUninit<u8>]> {
+        // Reborrow cursor into a temporary so we can back out our changes if we fail.
+        let mut temp: BufferCursor = self.cursor.reborrow();
+
+        if !temp.skip_to_align(self.layout.align()) {
+            return None;
+        }
+
+        // The number of bytes required to be in a page to span the minimum number of pages. The algorithm here
+        // prioritizes minimizing the number of pages per object, which can result in sparse "packing".
+        let req_bytes_in_page: usize = self.layout.size() % self.page_size;
+
+        // Check how many bytes left in the page; see if we need to realign to reduce page spanning.
+        match temp.next_align_offset(self.page_size) {
+            Some(next_page_align) => {
+                if next_page_align.get() < req_bytes_in_page {
+                    // Need to align to prevent the next object from spanning an extra page.
+                    if !temp.skip(next_page_align.get()) {
+                        // Transitively, if we need to align to the next page but can't, we also can't fit  any more
+                        // objects.
+                        return None;
+                    }
+                }
+            },
+
+            // Cursor is empty.
+            None => return None,
+        };
+
+        if let Some(buffer) = temp.try_take(self.layout.size()) {
+            // Commit the cursor update.
+            self.cursor = temp;
+            Some(buffer)
+        } else {
+            None
+        }
+    }
+}
+
+// Unit tests for `BufferPool` type.
+#[cfg(test)]
+mod tests {
+    use std::{
+        mem::MaybeUninit,
+        num::NonZeroUsize,
+        ptr::NonNull,
+        rc::Rc,
+    };
+
+    use ::anyhow::{
+        anyhow,
+        Result,
+    };
+    use anyhow::ensure;
+
+    use crate::ensure_eq;
+
+    use super::{
+        MemoryPool,
+        PoolBuf,
+    };
+
+    fn alloc_page_buf(page_size: usize, alloc_size: usize, store: &mut Vec<MaybeUninit<u8>>) -> &mut [MaybeUninit<u8>] {
+        store.clear();
+        store.reserve(alloc_size + page_size);
+        store.extend(std::iter::repeat(MaybeUninit::<u8>::zeroed()).take(alloc_size + page_size));
+
+        let align_bytes: usize = store.as_ptr().align_offset(page_size);
+        assert!(align_bytes + alloc_size <= store.len());
+        &mut store.as_mut_slice()[align_bytes..alloc_size + align_bytes]
+    }
+
+    struct BasicTestSettings {
+        page_size: usize,
+        pool_size: usize,
+        buf_size_ea: usize,
+        buf_align: usize,
+    }
+
+    struct BasicTestResults {
+        number_of_buffers: usize,
+        bytes_left_over: usize,
+    }
+
+    fn run_basic_test(settings: BasicTestSettings, results: BasicTestResults) -> Result<()> {
+        let page_size: NonZeroUsize = NonZeroUsize::new(settings.page_size).ok_or(anyhow!("bad page size"))?;
+        let buf_size_ea: NonZeroUsize = NonZeroUsize::new(settings.buf_size_ea).ok_or(anyhow!("bad buffer size"))?;
+        let buf_align: NonZeroUsize = NonZeroUsize::new(settings.buf_align).ok_or(anyhow!("bad buffer alignment"))?;
+
+        let mut store: Vec<MaybeUninit<u8>> = Vec::new();
+        let buffer: &mut [MaybeUninit<u8>] = alloc_page_buf(settings.page_size, settings.pool_size, &mut store);
+        let pool: Rc<MemoryPool> = MemoryPool::new(buf_size_ea, buf_align)?;
+
+        ensure_eq!(pool.len(), 0);
+        ensure!(pool.get().is_none());
+
+        let remaining: &mut [MaybeUninit<u8>] = unsafe { pool.populate(NonNull::from(buffer), page_size)?.as_mut() };
+        ensure_eq!(remaining.len(), results.bytes_left_over);
+
+        ensure_eq!(pool.len(), results.number_of_buffers);
+
+        let mut bufs: Vec<Option<PoolBuf>> = Vec::from_iter(std::iter::from_fn(|| Some(pool.get())).take(pool.len()));
+
+        ensure_eq!(bufs.len(), results.number_of_buffers);
+        ensure!(bufs.iter().all(|o: &Option<_>| o.is_some()));
+        ensure_eq!(pool.len(), 0);
+        ensure!(pool.get().is_none());
+
+        // Sort by address so we can validate the alignment of successive buffers.
+        bufs.sort_by(|a: &Option<PoolBuf>, b: &Option<PoolBuf>| {
+            a.as_ref().unwrap().as_ptr().cmp(&b.as_ref().unwrap().as_ptr())
+        });
+
+        let expected: Vec<u8> = Vec::from_iter(std::iter::repeat(0xAAu8).take(buf_size_ea.get()));
+
+        // NB if the buffer size is a factor or multiple of the page size, no bytes will be wasted at the end of the
+        // page.
+        let span: usize = if settings.buf_size_ea.is_power_of_two() {
+            0
+        } else {
+            settings.buf_size_ea % settings.page_size
+        };
+        let align: usize = std::cmp::max(settings.buf_size_ea, settings.buf_align);
+        let mut last_buffer_ptr: usize = bufs[0].as_ref().unwrap().as_ptr().addr() - align;
+
+        for buf_holder in bufs.iter_mut() {
+            let mut buf: PoolBuf = buf_holder.take().unwrap();
+            ensure_eq!(buf.len(), buf_size_ea.get());
+
+            ensure!(
+                buf.as_ptr().addr() >= last_buffer_ptr + align && buf.as_ptr().addr() <= last_buffer_ptr + align + span
+            );
+            last_buffer_ptr = buf.as_ptr().addr();
+
+            buf.fill(MaybeUninit::new(0xAAu8));
+            std::mem::drop(buf);
+
+            ensure_eq!(pool.len(), 1);
+
+            // NB MemoryPool does not guarantee LIFO, but since the pool only has one buffer in it, it must be the same
+            // buffer.
+            let buf: PoolBuf = pool.get().ok_or(anyhow!("pool should not be empty"))?;
+            ensure_eq!(expected, unsafe {
+                std::slice::from_raw_parts(buf.as_ptr().cast::<u8>(), buf.len())
+            });
+            *buf_holder = Some(buf);
+        }
+
+        ensure_eq!(pool.len(), 0);
+        ensure!(pool.get().is_none());
+
+        if !bufs.is_empty() {
+            bufs.pop().unwrap();
+        }
+        if !bufs.is_empty() {
+            bufs.pop().unwrap();
+        }
+
+        ensure_eq!(pool.len(), std::cmp::min(2, results.number_of_buffers));
+
+        if results.number_of_buffers > 0 {
+            ensure!(pool.get().is_some());
+        }
+
+        std::mem::drop(bufs);
+
+        ensure_eq!(pool.len(), results.number_of_buffers);
+        ensure!(pool.get().is_some());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_small_power_2_one_page() -> Result<()> {
+        run_basic_test(
+            BasicTestSettings {
+                pool_size: 128,
+                page_size: 128,
+                buf_size_ea: 32,
+                buf_align: 1,
+            },
+            BasicTestResults {
+                number_of_buffers: 4,
+                bytes_left_over: 0,
+            },
+        )
+    }
+
+    #[test]
+    fn test_small_power_2_many_pages() -> Result<()> {
+        run_basic_test(
+            BasicTestSettings {
+                pool_size: 2048,
+                page_size: 128,
+                buf_size_ea: 32,
+                buf_align: 1,
+            },
+            BasicTestResults {
+                number_of_buffers: 64,
+                bytes_left_over: 0,
+            },
+        )
+    }
+
+    #[test]
+    fn test_small_odd_size_many_pages() -> Result<()> {
+        run_basic_test(
+            BasicTestSettings {
+                pool_size: 2048,
+                page_size: 128,
+                buf_size_ea: 59,
+                buf_align: 1,
+            },
+            BasicTestResults {
+                number_of_buffers: 32,
+                bytes_left_over: 10,
+            },
+        )
+    }
+
+    #[test]
+    fn test_small_power_2_overaligned() -> Result<()> {
+        run_basic_test(
+            BasicTestSettings {
+                pool_size: 2048,
+                page_size: 128,
+                buf_size_ea: 32,
+                buf_align: 64,
+            },
+            BasicTestResults {
+                number_of_buffers: 32,
+                bytes_left_over: 32,
+            },
+        )
+    }
+
+    #[test]
+    fn test_large_power_2_one_page() -> Result<()> {
+        run_basic_test(
+            BasicTestSettings {
+                pool_size: 128,
+                page_size: 128,
+                buf_size_ea: 128,
+                buf_align: 1,
+            },
+            BasicTestResults {
+                number_of_buffers: 1,
+                bytes_left_over: 0,
+            },
+        )
+    }
+
+    #[test]
+    fn test_large_power_2_many_pages() -> Result<()> {
+        run_basic_test(
+            BasicTestSettings {
+                pool_size: 2048,
+                page_size: 128,
+                buf_size_ea: 256,
+                buf_align: 1,
+            },
+            BasicTestResults {
+                number_of_buffers: 8,
+                bytes_left_over: 0,
+            },
+        )
+    }
+
+    #[test]
+    fn test_large_odd_size_many_pages() -> Result<()> {
+        // NB 2048 bytes could fit 9 227-byte buffers if they were packed; each buffer here will get over-aligned to
+        // 256 bytes to prevent any buffer spanning three pages.
+        run_basic_test(
+            BasicTestSettings {
+                pool_size: 2048,
+                page_size: 128,
+                buf_size_ea: 227,
+                buf_align: 1,
+            },
+            BasicTestResults {
+                number_of_buffers: 8,
+                bytes_left_over: 29,
+            },
+        )
+    }
+}

--- a/src/rust/runtime/memory/mod.rs
+++ b/src/rust/runtime/memory/mod.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+mod buffer_pool;
 mod demibuffer;
+mod memory_pool;
 
 //==============================================================================
 // Imports
@@ -22,11 +24,15 @@ use ::std::{
         NonNull,
     },
 };
+
 //==============================================================================
 // Exports
 //==============================================================================
 
-pub use self::demibuffer::*;
+pub use self::{
+    buffer_pool::*,
+    demibuffer::*,
+};
 
 //==============================================================================
 // Traits


### PR DESCRIPTION
This PR adds two new structs: `MemoryPool` and `BufferPool`. `MemoryPool` is a pool of homogeneously-sized buffers. `BufferPool` wraps and imposes additional requirements on `MemoryPool` to be useful with `DemiBuffer`. Additionally, `DemiBuffer`s can not be created from pooled memory using `DemiBuffer::new_in_pool`.