### PR TITLE
[perf] Feature: Adding support for async profiling

### DIFF
--- a/examples/rust/pipe-ping-pong.rs
+++ b/examples/rust/pipe-ping-pong.rs
@@ -16,9 +16,6 @@ use ::demikernel::{
 };
 use ::std::env;
 
-#[cfg(feature = "profiler")]
-use ::demikernel::perftools::profiler;
-
 //======================================================================================================================
 // Constants
 //======================================================================================================================
@@ -194,9 +191,6 @@ impl PipeServer {
             println!("pong {:?}", i);
         }
 
-        #[cfg(feature = "profiler")]
-        profiler::write(&mut std::io::stdout(), None).expect("failed to write to stdout");
-
         Ok(())
     }
 
@@ -246,9 +240,6 @@ impl PipeClient {
             }
             println!("pong {:?}", i);
         }
-
-        #[cfg(feature = "profiler")]
-        profiler::write(&mut std::io::stdout(), None).expect("failed to write to stdout");
 
         Ok(())
     }

--- a/examples/rust/pipe-push-pop.rs
+++ b/examples/rust/pipe-push-pop.rs
@@ -16,9 +16,6 @@ use ::demikernel::{
 use ::std::env;
 use core::slice;
 
-#[cfg(feature = "profiler")]
-use ::demikernel::perftools::profiler;
-
 //======================================================================================================================
 // Constants
 //======================================================================================================================
@@ -172,9 +169,6 @@ impl PipeServer {
             println!("pop {:?} bytes", nbytes);
         }
 
-        #[cfg(feature = "profiler")]
-        profiler::write(&mut std::io::stdout(), None).expect("failed to write to stdout");
-
         Ok(())
     }
 }
@@ -220,9 +214,6 @@ impl PipeClient {
             }
             println!("push {:?}", i);
         }
-
-        #[cfg(feature = "profiler")]
-        profiler::write(&mut std::io::stdout(), None).expect("failed to write to stdout");
 
         Ok(())
     }

--- a/examples/rust/tcp-ping-pong.rs
+++ b/examples/rust/tcp-ping-pong.rs
@@ -39,9 +39,6 @@ pub const AF_INET: i32 = libc::AF_INET;
 #[cfg(target_os = "linux")]
 pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
 
-#[cfg(feature = "profiler")]
-use ::demikernel::perftools::profiler;
-
 //======================================================================================================================
 // Constants
 //======================================================================================================================
@@ -295,9 +292,6 @@ impl TcpServer {
             println!("pong {:?}", i);
         }
 
-        #[cfg(feature = "profiler")]
-        profiler::write(&mut std::io::stdout(), None).expect("failed to write to stdout");
-
         // TODO: close socket when we get close working properly in catnip.
 
         Ok(())
@@ -387,9 +381,6 @@ impl TcpClient {
 
             println!("ping {:?}", i);
         }
-
-        #[cfg(feature = "profiler")]
-        profiler::write(&mut std::io::stdout(), None).expect("failed to write to stdout");
 
         // TODO: close socket when we get close working properly in catnip.
 

--- a/examples/rust/tcp-push-pop.rs
+++ b/examples/rust/tcp-push-pop.rs
@@ -38,9 +38,6 @@ pub const AF_INET: i32 = libc::AF_INET;
 #[cfg(target_os = "linux")]
 pub const SOCK_STREAM: i32 = libc::SOCK_STREAM;
 
-#[cfg(feature = "profiler")]
-use ::demikernel::perftools::profiler;
-
 //======================================================================================================================
 // Constants
 //======================================================================================================================
@@ -202,9 +199,6 @@ impl TcpServer {
             println!("pop {:?}", i);
         }
 
-        #[cfg(feature = "profiler")]
-        profiler::write(&mut std::io::stdout(), None).expect("failed to write to stdout");
-
         // TODO: close socket when we get close working properly in catnip.
         Ok(())
     }
@@ -298,9 +292,6 @@ impl TcpClient {
 
             println!("push {:?}", i);
         }
-
-        #[cfg(feature = "profiler")]
-        profiler::write(&mut std::io::stdout(), None).expect("failed to write to stdout");
 
         // TODO: close socket when we get close working properly in catnip.
         Ok(())

--- a/examples/rust/udp-ping-pong.rs
+++ b/examples/rust/udp-ping-pong.rs
@@ -37,9 +37,6 @@ pub const AF_INET: i32 = libc::AF_INET;
 #[cfg(target_os = "linux")]
 pub const SOCK_DGRAM: i32 = libc::SOCK_DGRAM;
 
-#[cfg(feature = "profiler")]
-use ::demikernel::perftools::profiler;
-
 //======================================================================================================================
 // Constants
 //======================================================================================================================
@@ -303,9 +300,6 @@ impl UdpClient {
                 _ => anyhow::bail!("unexpected operation result"),
             }
         }
-
-        #[cfg(feature = "profiler")]
-        profiler::write(&mut std::io::stdout(), None).expect("failed to write to stdout");
 
         // TODO: close socket when we get close working properly in catnip.
 

--- a/examples/rust/udp-push-pop.rs
+++ b/examples/rust/udp-push-pop.rs
@@ -38,9 +38,6 @@ pub const AF_INET: i32 = libc::AF_INET;
 #[cfg(target_os = "linux")]
 pub const SOCK_DGRAM: i32 = libc::SOCK_DGRAM;
 
-#[cfg(feature = "profiler")]
-use ::demikernel::perftools::profiler;
-
 //======================================================================================================================
 // Constants
 //======================================================================================================================
@@ -173,9 +170,6 @@ impl UdpServer {
             println!("pop ({:?})", i);
         }
 
-        #[cfg(feature = "profiler")]
-        profiler::write(&mut std::io::stdout(), None).expect("failed to write to stdout");
-
         // TODO: close socket when we get close working properly in catnip.
         Ok(())
     }
@@ -258,9 +252,6 @@ impl UdpClient {
 
             println!("push ({:?})", i);
         }
-
-        #[cfg(feature = "profiler")]
-        profiler::write(&mut std::io::stdout(), None).expect("failed to write to stdout");
 
         // TODO: close socket when we get close working properly in catnip.
         Ok(())

--- a/src/rust/catmem/mod.rs
+++ b/src/rust/catmem/mod.rs
@@ -117,9 +117,10 @@ impl SharedCatmemLibOS {
         trace!("async_close() qd={:?}", qd);
         let mut queue: SharedCatmemQueue = self.get_queue(&qd)?;
         let coroutine_constructor = || -> Result<QToken, Fail> {
-            let task_name: String = format!("Catmem::async_close for qd={:?}", qd);
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().close_coroutine(qd).fuse());
-            self.runtime.clone().insert_io_coroutine(&task_name, coroutine)
+            self.runtime
+                .clone()
+                .insert_io_coroutine("Catmem::async_close", coroutine)
         };
 
         queue.async_close(coroutine_constructor)
@@ -164,10 +165,9 @@ impl SharedCatmemLibOS {
             return Err(Fail::new(libc::EINVAL, &cause));
         }
 
-        let task_name: String = format!("Catmem::push for qd={:?}", qd);
         let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().push_coroutine(qd, buf).fuse());
 
-        self.runtime.clone().insert_io_coroutine(&task_name, coroutine)
+        self.runtime.clone().insert_io_coroutine("Catmem::push", coroutine)
     }
 
     pub async fn push_coroutine(self, qd: QDesc, buf: DemiBuffer) -> (QDesc, OperationResult) {
@@ -190,10 +190,9 @@ impl SharedCatmemLibOS {
         // We just assert 'size' here, because it was previously checked at PDPIX layer.
         debug_assert!(size.is_none() || ((size.unwrap() > 0) && (size.unwrap() <= limits::POP_SIZE_MAX)));
 
-        let task_name: String = format!("Catmem::pop for qd={:?}", qd);
         let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().pop_coroutine(qd, size).fuse());
 
-        self.runtime.clone().insert_io_coroutine(&task_name, coroutine)
+        self.runtime.clone().insert_io_coroutine("Catmem::pop", coroutine)
     }
 
     pub async fn pop_coroutine(self, qd: QDesc, size: Option<usize>) -> (QDesc, OperationResult) {

--- a/src/rust/collections/concurrent_ring.rs
+++ b/src/rust/collections/concurrent_ring.rs
@@ -29,7 +29,6 @@ use ::std::{
     ptr::copy,
 };
 
-#[cfg(feature = "profiler")]
 use crate::timer;
 
 //======================================================================================================================
@@ -87,7 +86,6 @@ impl ConcurrentRingBuffer {
     /// Creates a ring buffer.
     #[allow(unused)]
     pub fn new(capacity: usize) -> Result<Self, Fail> {
-        #[cfg(feature = "profiler")]
         timer!("collections::concurrent_ring::new");
         // Check if capacity is invalid.
         if capacity == 0 {
@@ -118,14 +116,12 @@ impl ConcurrentRingBuffer {
     /// Returns the effective capacity of the target ring buffer in bytes.
     #[allow(unused)]
     pub fn capacity(&self) -> usize {
-        #[cfg(feature = "profiler")]
         timer!("collections::concurrent_ring::capacity");
         self.buffer.capacity()
     }
 
     #[allow(unused)]
     pub fn remaining_capacity(&self) -> usize {
-        #[cfg(feature = "profiler")]
         timer!("collections::concurrent_ring::remaining_capacity");
         let push_offset: usize = peek(self.push_offset);
         let pop_offset: usize = peek(self.pop_offset);
@@ -134,7 +130,6 @@ impl ConcurrentRingBuffer {
 
     /// Attempts to insert a buffer of [len] bytes into the ring buffer.
     pub fn try_push(&self, buf: &[u8]) -> Result<usize, Fail> {
-        #[cfg(feature = "profiler")]
         timer!("collections::concurrent_ring::try_push");
         let len: usize = buf.len();
         if len == 0 {
@@ -183,7 +178,6 @@ impl ConcurrentRingBuffer {
     /// Inserts an item at the enqueue of the target ring buffer. This function may block (spin).
     #[allow(unused)]
     pub fn push(&self, buf: &[u8]) -> Option<usize> {
-        #[cfg(feature = "profiler")]
         timer!("collections::concurrent_ring::push");
         loop {
             match self.try_push(buf) {
@@ -197,7 +191,6 @@ impl ConcurrentRingBuffer {
     /// Attempts to remove next message from the ring buffer up to [len] bytes and copies into [buf]. This function
     /// does not block.
     pub fn try_pop(&self, buf: &mut [u8]) -> Result<usize, Fail> {
-        #[cfg(feature = "profiler")]
         timer!("collections::concurrent_ring::try_pop");
         let len: usize = buf.len();
         if len == 0 {
@@ -255,7 +248,6 @@ impl ConcurrentRingBuffer {
     /// (spin).
     #[allow(unused)]
     pub fn pop(&self, buf: &mut [u8]) -> Option<usize> {
-        #[cfg(feature = "profiler")]
         timer!("collections::concurrent_ring::pop");
         loop {
             match self.try_pop(buf) {
@@ -268,7 +260,6 @@ impl ConcurrentRingBuffer {
 
     /// Atomically writes a header at the indicated offset and returns the previous one.
     fn write_header(&self, offset: usize, val: usize) -> usize {
-        #[cfg(feature = "profiler")]
         timer!("collections::concurrent_ring::write_header");
         assert!(offset % 2 == 0);
         let buffer_ptr: *mut u8 = unsafe { self.buffer.get_mut() }.as_mut_ptr();
@@ -280,7 +271,6 @@ impl ConcurrentRingBuffer {
     /// Given a [push_offset] and [pop_offset] into the ring buffer, return available space for writing data. Always
     /// leave one [HEADER_SIZE] space for distinguishing a full from empty buffer.
     fn available_space(&self, push_offset: usize, pop_offset: usize) -> usize {
-        #[cfg(feature = "profiler")]
         timer!("collections::concurrent_ring::available_space");
         debug_assert!(push_offset + self.capacity() > pop_offset);
         let used_space: usize = (push_offset + self.capacity() - pop_offset) % self.capacity();
@@ -291,7 +281,6 @@ impl ConcurrentRingBuffer {
     /// Reserves [len] + HEADER_SIZE bytes from the ring buffer. If successful, returns the offset of the beginning of
     /// the buffer, else returns `None`.
     fn reserve_space(&self, len: usize) -> Option<usize> {
-        #[cfg(feature = "profiler")]
         timer!("collections::concurrent_ring::reserve_space");
         let len_: usize = align_header(len + HEADER_SIZE);
         let push_offset: usize = peek(self.push_offset);
@@ -315,7 +304,6 @@ impl ConcurrentRingBuffer {
 
     /// Frees [len] + HEADER_SIZE bytes from the ring buffer.
     fn release_space(&self, current_offset: usize, len: usize) {
-        #[cfg(feature = "profiler")]
         timer!("collections::concurrent_ring::release_space");
         let len_: usize = align_header(len + HEADER_SIZE);
         let new_offset: usize = (current_offset + len_) % self.capacity();
@@ -325,7 +313,6 @@ impl ConcurrentRingBuffer {
 
     #[allow(unused)]
     pub fn is_full(&self) -> bool {
-        #[cfg(feature = "profiler")]
         timer!("collections::concurrent_ring::is_full");
         let push_offset = peek(self.push_offset);
         let pop_offset = peek(self.pop_offset);
@@ -336,7 +323,6 @@ impl ConcurrentRingBuffer {
     /// Peeks the target ring buffer and checks if it is empty.
     #[allow(unused)]
     pub fn is_empty(&self) -> bool {
-        #[cfg(feature = "profiler")]
         timer!("collections::concurrent_ring::is_empty");
         let push_offset = peek(self.push_offset);
         let pop_offset = peek(self.pop_offset);
@@ -346,7 +332,6 @@ impl ConcurrentRingBuffer {
 
     /// Allocates a memory area.
     fn alloc<T>() -> Result<*mut T, Fail> {
-        #[cfg(feature = "profiler")]
         timer!("collections::concurrent_ring::alloc");
         let layout: Layout = Layout::new::<T>();
         let ptr: *mut T = unsafe { alloc::alloc(layout) as *mut T };
@@ -365,7 +350,6 @@ impl Ring for ConcurrentRingBuffer {
     /// the amount of storage space in bytes that should be available. [size] must be at least large enough to hold
     /// capacity, plus the push and pop offsets and a [HEADER_SIZE] piece of padding.
     fn from_raw_parts(init: bool, ptr: *mut u8, capacity: usize) -> Result<Self, Fail> {
-        #[cfg(feature = "profiler")]
         timer!("collections::concurrent_ring::from_raw_parts");
         // Check if we have a valid pointer.
         if ptr.is_null() {

--- a/src/rust/collections/raw_array.rs
+++ b/src/rust/collections/raw_array.rs
@@ -17,7 +17,6 @@ use ::core::{
 };
 use ::std::alloc;
 
-#[cfg(feature = "profiler")]
 use crate::timer;
 
 //======================================================================================================================
@@ -42,7 +41,6 @@ pub struct RawArray<T> {
 impl<T> RawArray<T> {
     /// Creates a managed raw array.
     pub fn new(cap: usize) -> Result<RawArray<T>, Fail> {
-        #[cfg(feature = "profiler")]
         timer!("collections::raw_array::new");
         // Check if capacity is invalid.
         if cap == 0 {
@@ -71,7 +69,6 @@ impl<T> RawArray<T> {
 
     /// Constructs an unmanaged raw array from a pointer and a length.
     pub fn from_raw_parts(ptr: *mut T, len: usize) -> Result<RawArray<T>, Fail> {
-        #[cfg(feature = "profiler")]
         timer!("collections::raw_array::from_raw_parts");
         // Check if capacity is invalid.
         if len == 0 {
@@ -93,21 +90,18 @@ impl<T> RawArray<T> {
 
     /// Gets a mutable slice to the underlying data in the target raw array.
     pub unsafe fn get_mut(&self) -> &mut [T] {
-        #[cfg(feature = "profiler")]
         timer!("collections::raw_array::get_mut");
         slice::from_raw_parts_mut(self.ptr.as_ptr(), self.cap)
     }
 
     /// Gets a slice to the underlying data in the target raw array.
     pub unsafe fn get(&self) -> &[T] {
-        #[cfg(feature = "profiler")]
         timer!("collections::raw_array::get");
         slice::from_raw_parts(self.ptr.as_ptr(), self.cap)
     }
 
     /// Returns the capacity of the target raw array.
     pub fn capacity(&self) -> usize {
-        #[cfg(feature = "profiler")]
         timer!("collections::raw_array::capacity");
         self.cap
     }

--- a/src/rust/collections/ring.rs
+++ b/src/rust/collections/ring.rs
@@ -31,7 +31,6 @@ use std::{
     },
 };
 
-#[cfg(feature = "profiler")]
 use crate::timer;
 
 //======================================================================================================================
@@ -119,7 +118,6 @@ where
     /// Creates a ring buffer.
     #[allow(unused)]
     fn new<'a>(capacity: usize) -> Result<RingBuffer<T, S>, Fail> {
-        #[cfg(feature = "profiler")]
         timer!("collections::ring::new");
         assert!(mem::size_of::<S>() > 0);
 
@@ -166,7 +164,6 @@ where
     /// Returns the effective capacity of the target ring buffer.
     #[allow(unused)]
     pub fn capacity(&self) -> S {
-        #[cfg(feature = "profiler")]
         timer!("collections::ring::capacity");
         // Safety: capacity fits in S, as validated during construction.
         S::from_usize(self.buffer.capacity() - 1)
@@ -175,7 +172,6 @@ where
     /// Peeks the target ring buffer and checks if it is full.
     #[allow(unused)]
     pub fn is_full(&self) -> bool {
-        #[cfg(feature = "profiler")]
         timer!("collections::ring::is_null");
         let front_cached: S = self.get_front();
         let back_cached: S = self.get_back();
@@ -191,7 +187,6 @@ where
     /// Peeks the target ring buffer and checks if it is empty.
     #[allow(unused)]
     pub fn is_empty(&self) -> bool {
-        #[cfg(feature = "profiler")]
         timer!("collections::ring::is_empty");
         let front_cached: S = self.get_front();
         let back_cached: S = self.get_back();
@@ -213,7 +208,6 @@ where
 
     /// Atomically load and acquire the `front` index.
     fn get_front(&self) -> S {
-        #[cfg(feature = "profiler")]
         timer!("collections::ring::get_front");
         S::atomic_load_acquire(unsafe { &mut *self.front_ptr })
     }
@@ -221,14 +215,12 @@ where
     /// Atomically store and release the `front` index.
     #[allow(unused)]
     fn set_front(&self, val: S) {
-        #[cfg(feature = "profiler")]
         timer!("collections::ring::set_front");
         S::atomic_store_release(unsafe { &mut *self.front_ptr }, val);
     }
 
     /// Atomically load and acquire the `back` index.
     fn get_back(&self) -> S {
-        #[cfg(feature = "profiler")]
         timer!("collections::ring::get_back");
         S::atomic_load_acquire(unsafe { &mut *self.back_ptr })
     }
@@ -236,7 +228,6 @@ where
     /// Atomically store and release the `back` index.
     #[allow(unused)]
     fn set_back(&self, val: S) {
-        #[cfg(feature = "profiler")]
         timer!("collections::ring::set_back");
         S::atomic_store_release(unsafe { &mut *self.back_ptr }, val);
     }
@@ -458,7 +449,6 @@ where
 {
     /// Constructs a ring buffer from raw parts.
     fn from_raw_parts(init: bool, mut ptr: *mut u8, size: usize) -> Result<RingBuffer<T, S>, Fail> {
-        #[cfg(feature = "profiler")]
         timer!("collections::ring::from_raw_parts");
         // Check if we have a valid pointer.
         if ptr.is_null() {

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -20,7 +20,7 @@ use crate::catnip::runtime::SharedDPDKRuntime;
 use crate::catpowder::runtime::LinuxRuntime;
 #[cfg(any(feature = "catpowder-libos", feature = "catnip-libos"))]
 use crate::inetstack::SharedInetStack;
-#[cfg(feature = "profiler")]
+
 use crate::timer;
 
 use crate::{
@@ -77,7 +77,6 @@ pub enum LibOS {
 impl LibOS {
     /// Instantiates a new LibOS.
     pub fn new(libos_name: LibOSName) -> Result<Self, Fail> {
-        #[cfg(feature = "profiler")]
         timer!("demikernel::new");
 
         logging::initialize();
@@ -151,7 +150,6 @@ impl LibOS {
     /// Creates a new memory queue and connect to consumer end.
     pub fn create_pipe(&mut self, name: &str) -> Result<QDesc, Fail> {
         let result: Result<QDesc, Fail> = {
-            #[cfg(feature = "profiler")]
             timer!("demikernel::create_pipe");
             match self {
                 LibOS::NetworkLibOS(_) => Err(Fail::new(
@@ -170,7 +168,6 @@ impl LibOS {
     /// Opens an existing memory queue and connects to producer end.
     pub fn open_pipe(&mut self, name: &str) -> Result<QDesc, Fail> {
         let result: Result<QDesc, Fail> = {
-            #[cfg(feature = "profiler")]
             timer!("demikernel::open_pipe");
             match self {
                 LibOS::NetworkLibOS(_) => Err(Fail::new(
@@ -194,7 +191,6 @@ impl LibOS {
         protocol: libc::c_int,
     ) -> Result<QDesc, Fail> {
         let result: Result<QDesc, Fail> = {
-            #[cfg(feature = "profiler")]
             timer!("demikernel::socket");
             match self {
                 LibOS::NetworkLibOS(libos) => libos.socket(domain, socket_type, protocol),
@@ -210,7 +206,6 @@ impl LibOS {
     /// Binds a socket to a local address.
     pub fn bind(&mut self, sockqd: QDesc, local: SocketAddr) -> Result<(), Fail> {
         let result: Result<(), Fail> = {
-            #[cfg(feature = "profiler")]
             timer!("demikernel::bind");
             match self {
                 LibOS::NetworkLibOS(libos) => libos.bind(sockqd, local),
@@ -226,7 +221,6 @@ impl LibOS {
     /// Marks a socket as a passive one.
     pub fn listen(&mut self, sockqd: QDesc, backlog: usize) -> Result<(), Fail> {
         let result: Result<(), Fail> = {
-            #[cfg(feature = "profiler")]
             timer!("demikernel::listen");
             match self {
                 LibOS::NetworkLibOS(libos) => libos.listen(sockqd, backlog),
@@ -242,7 +236,6 @@ impl LibOS {
     /// Accepts an incoming connection on a TCP socket.
     pub fn accept(&mut self, sockqd: QDesc) -> Result<QToken, Fail> {
         let result: Result<QToken, Fail> = {
-            #[cfg(feature = "profiler")]
             timer!("demikernel::accept");
             match self {
                 LibOS::NetworkLibOS(libos) => libos.accept(sockqd),
@@ -258,7 +251,6 @@ impl LibOS {
     /// Initiates a connection with a remote TCP socket.
     pub fn connect(&mut self, sockqd: QDesc, remote: SocketAddr) -> Result<QToken, Fail> {
         let result: Result<QToken, Fail> = {
-            #[cfg(feature = "profiler")]
             timer!("demikernel::connect");
             match self {
                 LibOS::NetworkLibOS(libos) => libos.connect(sockqd, remote),
@@ -275,7 +267,6 @@ impl LibOS {
     /// async_close() + wait() achieves the same effect as synchronous close.
     pub fn close(&mut self, qd: QDesc) -> Result<(), Fail> {
         let result: Result<(), Fail> = {
-            #[cfg(feature = "profiler")]
             timer!("demikernel::close");
             match self {
                 LibOS::NetworkLibOS(libos) => match libos.async_close(qd) {
@@ -302,7 +293,6 @@ impl LibOS {
 
     pub fn async_close(&mut self, qd: QDesc) -> Result<QToken, Fail> {
         let result: Result<QToken, Fail> = {
-            #[cfg(feature = "profiler")]
             timer!("demikernel::async_close");
             match self {
                 LibOS::NetworkLibOS(libos) => libos.async_close(qd),
@@ -318,7 +308,6 @@ impl LibOS {
     /// Pushes a scatter-gather array to an I/O queue.
     pub fn push(&mut self, qd: QDesc, sga: &demi_sgarray_t) -> Result<QToken, Fail> {
         let result: Result<QToken, Fail> = {
-            #[cfg(feature = "profiler")]
             timer!("demikernel::push");
             match self {
                 LibOS::NetworkLibOS(libos) => libos.push(qd, sga),
@@ -334,7 +323,6 @@ impl LibOS {
     /// Pushes a scatter-gather array to a UDP socket.
     pub fn pushto(&mut self, qd: QDesc, sga: &demi_sgarray_t, to: SocketAddr) -> Result<QToken, Fail> {
         let result: Result<QToken, Fail> = {
-            #[cfg(feature = "profiler")]
             timer!("demikernel::pushto");
             match self {
                 LibOS::NetworkLibOS(libos) => libos.pushto(qd, sga, to),
@@ -350,7 +338,6 @@ impl LibOS {
     /// Pops data from a an I/O queue.
     pub fn pop(&mut self, qd: QDesc, size: Option<usize>) -> Result<QToken, Fail> {
         let result: Result<QToken, Fail> = {
-            #[cfg(feature = "profiler")]
             timer!("demikernel::pop");
 
             // Check if this is a fixed-size pop.
@@ -377,7 +364,6 @@ impl LibOS {
     /// Waits for a pending I/O operation to complete or a timeout to expire.
     /// This is just a single-token convenience wrapper for wait_any().
     pub fn wait(&mut self, qt: QToken, timeout: Option<Duration>) -> Result<demi_qresult_t, Fail> {
-        #[cfg(feature = "profiler")]
         timer!("demikernel::wait");
         match self {
             LibOS::NetworkLibOS(libos) => libos.wait(qt, timeout.unwrap_or(DEFAULT_TIMEOUT)),
@@ -387,7 +373,6 @@ impl LibOS {
 
     /// Waits for any of the given pending I/O operations to complete or a timeout to expire.
     pub fn wait_any(&mut self, qts: &[QToken], timeout: Option<Duration>) -> Result<(usize, demi_qresult_t), Fail> {
-        #[cfg(feature = "profiler")]
         timer!("demikernel::wait_any");
         match self {
             LibOS::NetworkLibOS(libos) => libos.wait_any(qts, timeout.unwrap_or(DEFAULT_TIMEOUT)),
@@ -398,7 +383,6 @@ impl LibOS {
     /// Allocates a scatter-gather array.
     pub fn sgaalloc(&mut self, size: usize) -> Result<demi_sgarray_t, Fail> {
         let result: Result<demi_sgarray_t, Fail> = {
-            #[cfg(feature = "profiler")]
             timer!("demikernel::sgaalloc");
             match self {
                 LibOS::NetworkLibOS(libos) => libos.sgaalloc(size),
@@ -412,7 +396,6 @@ impl LibOS {
     /// Releases a scatter-gather array.
     pub fn sgafree(&mut self, sga: demi_sgarray_t) -> Result<(), Fail> {
         let result: Result<(), Fail> = {
-            #[cfg(feature = "profiler")]
             timer!("demikernel::sgafree");
             match self {
                 LibOS::NetworkLibOS(libos) => libos.sgafree(sga),
@@ -424,7 +407,6 @@ impl LibOS {
     }
 
     fn poll(&mut self) {
-        #[cfg(feature = "profiler")]
         timer!("demikernel::poll");
         match self {
             LibOS::NetworkLibOS(libos) => libos.poll(),

--- a/src/rust/demikernel/libos/network/libos.rs
+++ b/src/rust/demikernel/libos/network/libos.rs
@@ -206,9 +206,10 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
 
         let mut queue: SharedNetworkQueue<T> = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<QToken, Fail> {
-            let task_name: String = format!("NetworkLibOS::accept for qd={:?}", qd);
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().accept_coroutine(qd).fuse());
-            self.runtime.clone().insert_io_coroutine(&task_name, coroutine)
+            self.runtime
+                .clone()
+                .insert_io_coroutine("NetworkLibOS::accept", coroutine)
         };
 
         queue.accept(coroutine_constructor)
@@ -256,9 +257,10 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
         // FIXME: add IPv6 support; https://github.com/microsoft/demikernel/issues/935
         let mut queue: SharedNetworkQueue<T> = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<QToken, Fail> {
-            let task_name: String = format!("NetworkLibOS::connect for qd={:?}", qd);
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().connect_coroutine(qd, remote).fuse());
-            self.runtime.clone().insert_io_coroutine(&task_name, coroutine)
+            self.runtime
+                .clone()
+                .insert_io_coroutine("NetworkLibOS::connect", coroutine)
         };
 
         queue.connect(coroutine_constructor)
@@ -295,9 +297,10 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
 
         let mut queue: SharedNetworkQueue<T> = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<QToken, Fail> {
-            let task_name: String = format!("NetworkLibOS::close for qd={:?}", qd);
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().close_coroutine(qd).fuse());
-            self.runtime.clone().insert_io_coroutine(&task_name, coroutine)
+            self.runtime
+                .clone()
+                .insert_io_coroutine("NetworkLibOS::close", coroutine)
         };
 
         queue.close(coroutine_constructor)
@@ -363,9 +366,10 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
 
         let mut queue: SharedNetworkQueue<T> = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<QToken, Fail> {
-            let task_name: String = format!("NetworkLibOS::push for qd={:?}", qd);
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().push_coroutine(qd, buf).fuse());
-            self.runtime.clone().insert_io_coroutine(&task_name, coroutine)
+            self.runtime
+                .clone()
+                .insert_io_coroutine("NetworkLibOS::push", coroutine)
         };
 
         queue.push(coroutine_constructor)
@@ -405,9 +409,10 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
 
         let mut queue: SharedNetworkQueue<T> = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<QToken, Fail> {
-            let task_name: String = format!("NetworkLibOS::pushto for qd={:?}", qd);
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().pushto_coroutine(qd, buf, remote).fuse());
-            self.runtime.clone().insert_io_coroutine(&task_name, coroutine)
+            self.runtime
+                .clone()
+                .insert_io_coroutine("NetworkLibOS::pushto", coroutine)
         };
 
         queue.push(coroutine_constructor)
@@ -445,9 +450,8 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
 
         let mut queue: SharedNetworkQueue<T> = self.get_shared_queue(&qd)?;
         let coroutine_constructor = || -> Result<QToken, Fail> {
-            let task_name: String = format!("NetworkLibOS::pop for qd={:?}", qd);
             let coroutine: Pin<Box<Operation>> = Box::pin(self.clone().pop_coroutine(qd, size).fuse());
-            self.runtime.clone().insert_io_coroutine(&task_name, coroutine)
+            self.runtime.clone().insert_io_coroutine("NetworkLibOS::pop", coroutine)
         };
 
         queue.pop(coroutine_constructor)

--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -61,7 +61,6 @@ use ::std::{
     },
 };
 
-#[cfg(feature = "profiler")]
 use crate::timer;
 
 //======================================================================================================================
@@ -152,19 +151,16 @@ impl<N: NetworkRuntime> SharedInetStack<N> {
     /// Then ask the runtime to receive new data which we will forward to the engine to parse and
     /// route to the correct protocol.
     pub async fn poll(mut self) {
-        #[cfg(feature = "profiler")]
         timer!("inetstack::poll");
         loop {
             for _ in 0..MAX_RECV_ITERS {
                 let batch = {
-                    #[cfg(feature = "profiler")]
                     timer!("inetstack::poll_bg_work::for::receive");
 
                     self.network.receive()
                 };
 
                 {
-                    #[cfg(feature = "profiler")]
                     timer!("inetstack::poll_bg_work::for::for");
 
                     if batch.is_empty() {

--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -144,8 +144,7 @@ impl<N: NetworkRuntime> SharedInetStack<N> {
             network,
             local_link_addr: local_link_addr,
         }));
-        let background_task: String = format!("inetstack::poll_recv");
-        runtime.insert_background_coroutine(&background_task, Box::pin(me.clone().poll().fuse()))?;
+        runtime.insert_background_coroutine("inetstack::poll_recv", Box::pin(me.clone().poll().fuse()))?;
         Ok(me)
     }
 

--- a/src/rust/inetstack/protocols/udp/peer.rs
+++ b/src/rust/inetstack/protocols/udp/peer.rs
@@ -38,7 +38,6 @@ use ::std::{
     },
 };
 
-#[cfg(feature = "profiler")]
 use crate::timer;
 
 //======================================================================================================================
@@ -158,7 +157,6 @@ impl<N: NetworkRuntime> SharedUdpPeer<N> {
 
     /// Consumes the payload from a buffer.
     pub fn receive(&mut self, ipv4_hdr: Ipv4Header, buf: DemiBuffer) {
-        #[cfg(feature = "profiler")]
         timer!("udp::receive");
         // Parse datagram.
         let (hdr, data): (UdpHeader, DemiBuffer) = match UdpHeader::parse(&ipv4_hdr, buf, self.checksum_offload) {

--- a/src/rust/perftools/profiler/mod.rs
+++ b/src/rust/perftools/profiler/mod.rs
@@ -1,13 +1,24 @@
 // Copyright(c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+//! This module provides a small performance profiler for the Demikernel libOSes.
+
 #[cfg(test)]
 mod tests;
 
+use ::futures::future::FusedFuture;
 use std::{
     cell::RefCell,
+    fmt,
+    fmt::Debug,
+    future::Future,
     io,
+    pin::Pin,
     rc::Rc,
+    task::{
+        Context,
+        Poll,
+    },
     time::{
         Duration,
         SystemTime,
@@ -17,6 +28,7 @@ use std::{
 #[cfg(feature = "auto-calibrate")]
 const SAMPLE_SIZE: usize = 16641;
 
+#[cfg(feature = "profiler")]
 thread_local!(
     /// Global thread-local instance of the profiler.
     pub static PROFILER: RefCell<Profiler> = RefCell::new(Profiler::new())
@@ -51,7 +63,14 @@ thread_local!(
 #[macro_export]
 macro_rules! timer {
     ($name:expr) => {
-        let _guard = $crate::perftools::profiler::PROFILER.with(|p| p.borrow_mut().enter($name));
+        let _guard = $crate::perftools::profiler::PROFILER.with(|p| p.borrow_mut().sync_scope($name));
+    };
+}
+
+#[macro_export]
+macro_rules! async_timer {
+    ($name:expr, $future:expr) => {
+        $crate::perftools::profiler::PROFILER.with(|p| p.borrow_mut().async_scope($name, $future))
     };
 }
 
@@ -167,6 +186,50 @@ impl Scope {
     }
 }
 
+impl Debug for Scope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+/// A scope over an async block that may yield and re-enter several times.
+pub struct AsyncScope<R> {
+    scope: Rc<RefCell<Scope>>,
+    future: Pin<Box<dyn FusedFuture<Output = R>>>,
+}
+
+impl<R> AsyncScope<R> {
+    fn new(future: Pin<Box<dyn FusedFuture<Output = R>>>, scope: Rc<RefCell<Scope>>) -> Pin<Box<Self>> {
+        Box::pin(Self { scope, future })
+    }
+}
+
+impl<R> Future for AsyncScope<R> {
+    type Output = R;
+
+    fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
+        let self_: &mut Self = self.get_mut();
+        trace!("Entering async scope: {:?}", self_.scope);
+        let _guard = PROFILER.with(|p| p.borrow_mut().enter_scope(self_.scope.clone()));
+        match Future::poll(self_.future.as_mut(), ctx) {
+            Poll::Pending => {
+                trace!("Exiting async scope still pending: {:?}", self_.scope);
+                Poll::Pending
+            },
+            Poll::Ready(result) => {
+                trace!("Exiting async scope complete: {:?}", self_.scope);
+                Poll::Ready(result)
+            },
+        }
+    }
+}
+
+impl<R> FusedFuture for AsyncScope<R> {
+    fn is_terminated(&self) -> bool {
+        self.future.is_terminated()
+    }
+}
+
 //==============================================================================
 //
 //==============================================================================
@@ -189,7 +252,7 @@ impl Drop for Guard {
     fn drop(&mut self) {
         let (now, _): (u64, u32) = unsafe { x86::time::rdtscp() };
         let duration: u64 = now - self.enter_time;
-        PROFILER.with(|p| p.borrow_mut().leave(duration));
+        PROFILER.with(|p| p.borrow_mut().leave_scope(duration));
     }
 }
 
@@ -222,17 +285,33 @@ impl Profiler {
         }
     }
 
-    /// Enter a scope. Returns a [`Guard`](struct.Guard.html) that should be
+    /// Create and enter a syncronous scope. Returns a [`Guard`](struct.Guard.html) that should be
     /// dropped upon leaving the scope.
     ///
     /// Usually, this method will be called by the
     /// [`profile`](macro.profile.html) macro, so it does not need to be used
     /// directly.
     #[inline]
-    pub fn enter(&mut self, name: &'static str) -> Guard {
+    pub fn sync_scope(&mut self, name: &'static str) -> Guard {
+        let scope = self.get_scope(name);
+        self.enter_scope(scope)
+    }
+
+    /// Create an asynchronous scope. Returns a wrapped Future that enters the scope when polled.
+    pub fn async_scope<R: 'static>(
+        &mut self,
+        name: &'static str,
+        future: Pin<Box<dyn FusedFuture<Output = R>>>,
+    ) -> Pin<Box<dyn FusedFuture<Output = R>>> {
+        let scope = self.get_scope(name);
+        AsyncScope::new(future, scope)
+    }
+
+    /// Look up the scope using the name.
+    fn get_scope(&mut self, name: &'static str) -> Rc<RefCell<Scope>> {
         // Check if we have already registered `name` at the current point in
         // the tree.
-        let succ = if let Some(current) = self.current.as_ref() {
+        if let Some(current) = self.current.as_ref() {
             // We are currently in some scope.
             let existing_succ = current
                 .borrow()
@@ -264,11 +343,14 @@ impl Profiler {
 
                 succ
             })
-        };
+        }
+    }
 
-        let guard = succ.borrow_mut().enter();
+    /// Actually enter a scope.
+    fn enter_scope(&mut self, scope: Rc<RefCell<Scope>>) -> Guard {
+        let guard = scope.borrow_mut().enter();
 
-        self.current = Some(succ);
+        self.current = Some(scope);
 
         guard
     }
@@ -285,7 +367,7 @@ impl Profiler {
 
     /// Leave the current scope.
     #[inline]
-    fn leave(&mut self, duration: u64) {
+    fn leave_scope(&mut self, duration: u64) {
         self.current = if let Some(current) = self.current.as_ref() {
             cfg_if::cfg_if! {
                 if #[cfg(feature = "auto-calibrate")] {
@@ -346,5 +428,13 @@ impl Profiler {
         }
 
         total / (nsamples as u64)
+    }
+}
+
+impl Drop for Profiler {
+    fn drop(&mut self) {
+        #[cfg(feature = "profiler")]
+        self.write(&mut std::io::stdout(), None)
+            .expect("failed to write to stdout");
     }
 }

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -36,6 +36,7 @@ pub use dpdk_rs as libdpdk;
 //======================================================================================================================
 
 use crate::{
+    async_timer,
     expect_some,
     runtime::{
         fail::Fail,
@@ -86,9 +87,6 @@ use ::std::{
         SystemTime,
     },
 };
-
-#[cfg(feature = "profiler")]
-use crate::async_timer;
 
 //======================================================================================================================
 // Constants
@@ -178,9 +176,7 @@ impl SharedDemiRuntime {
         coroutine: Pin<Box<dyn FusedFuture<Output = R>>>,
     ) -> Result<QToken, Fail> {
         trace!("Inserting coroutine: {:?}", task_name);
-        #[cfg(feature = "profiler")]
-        let coroutine = async_timer!(task_name, coroutine);
-        let task: TaskWithResult<R> = TaskWithResult::<R>::new(task_name, coroutine);
+        let task: TaskWithResult<R> = TaskWithResult::<R>::new(task_name, async_timer!(task_name, coroutine));
         match self.scheduler.insert_task(task) {
             Some(task_id) => Ok(task_id.into()),
             None => {

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -171,7 +171,7 @@ impl SharedDemiRuntime {
         coroutine: Pin<Box<dyn FusedFuture<Output = R>>>,
     ) -> Result<QToken, Fail> {
         trace!("Inserting coroutine: {:?}", task_name);
-        let task: TaskWithResult<R> = TaskWithResult::<R>::new(task_name.to_string(), coroutine);
+        let task: TaskWithResult<R> = TaskWithResult::<R>::new(task_name, coroutine);
         match self.scheduler.insert_task(task) {
             Some(task_id) => Ok(task_id.into()),
             None => {

--- a/src/rust/runtime/scheduler/group.rs
+++ b/src/rust/runtime/scheduler/group.rs
@@ -92,7 +92,7 @@ impl TaskGroup {
 
     /// Insert a new task into our scheduler returning a handle corresponding to it.
     pub fn insert(&mut self, task: Box<dyn Task>) -> Option<TaskId> {
-        let task_name: String = task.get_name();
+        let task_name: &'static str = task.get_name();
         // The pin slab index can be reverse-computed in a page index and an offset within the page.
         let pin_slab_index: usize = self.tasks.insert(task)?;
         let task_id: TaskId = self.ids.insert_with_new_id(pin_slab_index.into());

--- a/src/rust/runtime/scheduler/scheduler.rs
+++ b/src/rust/runtime/scheduler/scheduler.rs
@@ -416,13 +416,13 @@ mod tests {
         let mut scheduler: Scheduler = Scheduler::default();
 
         // Insert a task and make sure the task id is not a simple counter.
-        let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(0).fuse()));
+        let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(0).fuse()));
         let Some(task_id) = scheduler.insert_task(task) else {
             anyhow::bail!("insert() failed")
         };
 
         // Insert another task and make sure the task id is not sequentially after the previous one.
-        let task2: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(0).fuse()));
+        let task2: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(0).fuse()));
         let Some(task_id2) = scheduler.insert_task(task2) else {
             anyhow::bail!("insert() failed")
         };
@@ -437,7 +437,7 @@ mod tests {
         let mut scheduler: Scheduler = Scheduler::default();
 
         // Insert a single future in the scheduler. This future shall complete with a single poll operation.
-        let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(0).fuse()));
+        let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(0).fuse()));
         let Some(task_id) = scheduler.insert_task(task) else {
             anyhow::bail!("insert() failed")
         };
@@ -457,7 +457,7 @@ mod tests {
         let mut scheduler: Scheduler = Scheduler::default();
 
         // Insert a single future in the scheduler. This future shall complete with a single poll operation.
-        let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(0).fuse()));
+        let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(0).fuse()));
         let Some(task_id) = scheduler.insert_task(task) else {
             anyhow::bail!("insert() failed")
         };
@@ -478,7 +478,7 @@ mod tests {
 
         // Insert a single future in the scheduler. This future shall complete
         // with two poll operations.
-        let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(1).fuse()));
+        let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(1).fuse()));
         let Some(task_id) = scheduler.insert_task(task) else {
             anyhow::bail!("insert() failed")
         };
@@ -504,7 +504,7 @@ mod tests {
         let mut scheduler: Scheduler = Scheduler::default();
 
         // Insert a single future in the scheduler. This future shall complete with a single poll operation.
-        let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(0).fuse()));
+        let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(0).fuse()));
         let Some(task_id) = scheduler.insert_task(task) else {
             anyhow::bail!("insert() failed")
         };
@@ -525,7 +525,7 @@ mod tests {
         let mut scheduler: Scheduler = Scheduler::default();
 
         // Create and run a task.
-        let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(0).fuse()));
+        let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(0).fuse()));
         let Some(task_id) = scheduler.insert_task(task) else {
             anyhow::bail!("insert() failed")
         };
@@ -537,7 +537,7 @@ mod tests {
         }
 
         // Create another task.
-        let task2: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(0).fuse()));
+        let task2: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(0).fuse()));
         let Some(task_id2) = scheduler.insert_task(task2) else {
             anyhow::bail!("insert() failed")
         };
@@ -559,7 +559,7 @@ mod tests {
         crate::ensure_eq!(scheduler.num_tasks(), 0);
 
         for val in 0..NUM_TASKS {
-            let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(val).fuse()));
+            let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(val).fuse()));
             let Some(task_id) = scheduler.insert_task(task) else {
                 panic!("insert() failed");
             };
@@ -589,10 +589,7 @@ mod tests {
         let mut scheduler: Scheduler = Scheduler::default();
 
         b.iter(|| {
-            let task: DummyTask = DummyTask::new(
-                String::from("testing"),
-                Box::pin(black_box(DummyCoroutine::default().fuse())),
-            );
+            let task: DummyTask = DummyTask::new("testing", Box::pin(black_box(DummyCoroutine::default().fuse())));
             let task_id: TaskId = expect_some!(scheduler.insert_task(task), "couldn't insert future in scheduler");
             black_box(task_id);
         });
@@ -605,7 +602,7 @@ mod tests {
         let mut task_ids: Vec<TaskId> = Vec::<TaskId>::with_capacity(NUM_TASKS);
 
         for val in 0..NUM_TASKS {
-            let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(val).fuse()));
+            let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(val).fuse()));
             let Some(task_id) = scheduler.insert_task(task) else {
                 panic!("insert() failed");
             };
@@ -624,7 +621,7 @@ mod tests {
         let mut task_ids: Vec<TaskId> = Vec::<TaskId>::with_capacity(NUM_TASKS);
 
         for val in 0..NUM_TASKS {
-            let task: DummyTask = DummyTask::new(String::from("testing"), Box::pin(DummyCoroutine::new(val).fuse()));
+            let task: DummyTask = DummyTask::new("testing", Box::pin(DummyCoroutine::new(val).fuse()));
             let Some(task_id) = scheduler.insert_task(task) else {
                 panic!("insert() failed");
             };

--- a/src/rust/runtime/scheduler/task.rs
+++ b/src/rust/runtime/scheduler/task.rs
@@ -50,7 +50,7 @@ pub struct TaskId(pub u64);
 /// Task runs a single coroutine to completion and stores the result for later. Thus, it implements Future but
 /// never directly returns anything.
 pub trait Task: FusedFuture<Output = ()> + Unpin + Any {
-    fn get_name(&self) -> String;
+    fn get_name(&self) -> &'static str;
     fn as_any(self: Box<Self>) -> Box<dyn Any>;
     fn get_id(&self) -> TaskId;
     fn set_id(&mut self, id: TaskId);
@@ -66,7 +66,7 @@ pub trait TaskWith: TryFrom<Box<dyn Any>> {
 /// A specific instance of Task that returns a particular return type [R].
 pub struct TaskWithResult<R: Unpin + Clone + Any> {
     /// Task name. The libOS should use this to identify the type of task.
-    name: String,
+    name: &'static str,
     /// Task identifier.
     task_id: Option<TaskId>,
     /// Underlying coroutine to run.
@@ -82,7 +82,7 @@ pub struct TaskWithResult<R: Unpin + Clone + Any> {
 /// Associate Functions for TaskWithResults.
 impl<R: Unpin + Clone + Any> TaskWithResult<R> {
     /// Instantiates a new Task.
-    pub fn new(name: String, coroutine: Pin<<Self as TaskWith>::Coroutine>) -> Self {
+    pub fn new(name: &'static str, coroutine: Pin<<Self as TaskWith>::Coroutine>) -> Self {
         Self {
             name,
             task_id: None,
@@ -132,8 +132,8 @@ impl<R: Unpin + Clone + Any> TryFrom<Box<dyn Any>> for TaskWithResult<R> {
 
 impl<R: Unpin + Clone + Any> Task for TaskWithResult<R> {
     // The coroutine type that this task will run.
-    fn get_name(&self) -> String {
-        self.name.clone()
+    fn get_name(&self) -> &'static str {
+        self.name
     }
 
     fn as_any(self: Box<Self>) -> Box<dyn Any> {


### PR DESCRIPTION
This PR adds a feature to our profiler to measure the time spent in async blocks. It only supports fused (non-reentrant) blocks for now. It works by simply wrapping a Future around the existing code that measures when we enter the async block and stops the clock when we exit with either a Pending or Ready status. 

For now, I have annotated all of our coroutines but nothing more detailed. We should add more annotations, especially around the different async workers that all run in a single background coroutine.