### PR TITLE
[compile] Bug Fix: Enable profiler compile

### DIFF
--- a/linux.mk
+++ b/linux.mk
@@ -62,7 +62,7 @@ CARGO_FEATURES += --features=$(DRIVER)
 endif
 
 # Switch for profiler.
-export PROFILER=no
+export PROFILER ?= no
 ifeq ($(PROFILER),yes)
 CARGO_FEATURES += --features=profiler
 endif


### PR DESCRIPTION
Previously, we always compiled without the profiler feature flag through the Make file. Now if the feature flag is set to yes, then we will compile the profiler.