### PR TITLE
[testing] Add multi-core support to TCP echo

### DIFF
--- a/examples/tcp-echo/main.rs
+++ b/examples/tcp-echo/main.rs
@@ -284,7 +284,13 @@ fn main() -> Result<()> {
     let mut threads = vec![];
     match args.peer_type.as_str() {
         "server" => {
-            for _ in 0..args.nthreads.unwrap_or(1) {
+            // Multi-threaded server is only supported by Catnap.
+            // TODO: Check/add support for other libOSes.
+            let nthreads: usize = match libos_name {
+                LibOSName::Catnap => args.nthreads.unwrap_or(1),
+                _ => 1,
+            };
+            for _ in 0..nthreads {
                 if let Ok(handle) = start_server_thread(libos_name, args.addr, args.log_interval) {
                     threads.push(handle)
                 }

--- a/examples/tcp-echo/main.rs
+++ b/examples/tcp-echo/main.rs
@@ -25,6 +25,8 @@ use server::TcpEchoServer;
 use std::{
     net::SocketAddr,
     str::FromStr,
+    thread,
+    thread::JoinHandle,
     time::Duration,
 };
 
@@ -66,6 +68,8 @@ pub struct ProgramArguments {
     nrequests: Option<usize>,
     /// Number of clients.
     nclients: Option<usize>,
+    /// Number of threads.
+    nthreads: Option<usize>,
     /// Log interval.
     log_interval: Option<u64>,
     /// Peer type.
@@ -110,7 +114,15 @@ impl ProgramArguments {
                     .value_parser(clap::value_parser!(usize))
                     .required(false)
                     .value_name("NUMBER")
-                    .help("Sets number of clients"),
+                    .help("Sets number of clients (per thread)"),
+            )
+            .arg(
+                Arg::new("nthreads")
+                    .long("nthreads")
+                    .value_parser(clap::value_parser!(usize))
+                    .required(false)
+                    .value_name("NUMBER")
+                    .help("Sets number of threads"),
             )
             .arg(
                 Arg::new("nrequests")
@@ -151,6 +163,7 @@ impl ProgramArguments {
             bufsize: None,
             nrequests: None,
             nclients: None,
+            nthreads: None,
             log_interval: None,
             peer_type: "server".to_string(),
         };
@@ -181,6 +194,13 @@ impl ProgramArguments {
             }
         }
 
+        // Number of clients.
+        if let Some(nthreads) = matches.get_one::<usize>("nthreads") {
+            if *nthreads > 0 {
+                args.nthreads = Some(*nthreads);
+            }
+        }
+
         // Log interval.
         if let Some(log_interval) = matches.get_one::<u64>("log") {
             if *log_interval > 0 {
@@ -203,6 +223,50 @@ impl ProgramArguments {
     }
 }
 
+fn start_server_thread(
+    libos_name: LibOSName,
+    addr: SocketAddr,
+    log_interval: Option<u64>,
+) -> Result<JoinHandle<Result<()>>> {
+    Ok(thread::spawn(move || -> Result<()> {
+        let libos: LibOS = match LibOS::new(libos_name) {
+            Ok(libos) => libos,
+            Err(e) => anyhow::bail!("failed to initialize libos: {:?}", e.cause),
+        };
+        let mut server: TcpEchoServer = TcpEchoServer::new(libos, addr)?;
+        server.run(log_interval)
+    }))
+}
+
+fn start_client_thread(
+    libos_name: LibOSName,
+    nclients: usize,
+    nrequests: Option<usize>,
+    bufsize: usize,
+    run_mode: &String,
+    addr: SocketAddr,
+    log_interval: Option<u64>,
+) -> Result<JoinHandle<Result<()>>> {
+    match run_mode.as_str() {
+        "sequential" => Ok(thread::spawn(move || -> Result<()> {
+            let libos: LibOS = match LibOS::new(libos_name) {
+                Ok(libos) => libos,
+                Err(e) => anyhow::bail!("failed to initialize libos: {:?}", e.cause),
+            };
+            let mut client: TcpEchoClient = TcpEchoClient::new(libos, bufsize, addr)?;
+            client.run_sequential(log_interval, nclients, nrequests)
+        })),
+        "concurrent" => Ok(thread::spawn(move || -> Result<()> {
+            let libos: LibOS = match LibOS::new(libos_name) {
+                Ok(libos) => libos,
+                Err(e) => anyhow::bail!("failed to initialize libos: {:?}", e.cause),
+            };
+            let mut client: TcpEchoClient = TcpEchoClient::new(libos, bufsize, addr)?;
+            client.run_concurrent(log_interval, nclients, nrequests)
+        })),
+        _ => anyhow::bail!("invalid run mode"),
+    }
+}
 //======================================================================================================================
 
 fn main() -> Result<()> {
@@ -216,31 +280,37 @@ fn main() -> Result<()> {
         Ok(libos_name) => libos_name.into(),
         Err(e) => anyhow::bail!("{:?}", e),
     };
-    let libos: LibOS = match LibOS::new(libos_name) {
-        Ok(libos) => libos,
-        Err(e) => anyhow::bail!("failed to initialize libos: {:?}", e.cause),
-    };
 
+    let run_mode: String = args.run_mode.ok_or(anyhow::anyhow!("missing run mode"))?;
+    let mut threads = vec![];
     match args.peer_type.as_str() {
         "server" => {
-            let mut server: TcpEchoServer = TcpEchoServer::new(libos, args.addr)?;
-            server.run(args.log_interval)?;
+            for _ in 0..args.nthreads.unwrap_or(1) {
+                if let Ok(handle) = start_server_thread(libos_name, args.addr, args.log_interval) {
+                    threads.push(handle)
+                }
+            }
         },
         "client" => {
-            let mut client: TcpEchoClient = TcpEchoClient::new(
-                libos,
-                args.bufsize.ok_or(anyhow::anyhow!("missing buffer size"))?,
-                args.addr,
-            )?;
-            let nclients: usize = args.nclients.ok_or(anyhow::anyhow!("missing number of clients"))?;
-            match args.run_mode.ok_or(anyhow::anyhow!("missing run mode"))?.as_str() {
-                "sequential" => client.run_sequential(args.log_interval, nclients, args.nrequests)?,
-                "concurrent" => client.run_concurrent(args.log_interval, nclients, args.nrequests)?,
-                _ => anyhow::bail!("invalid run mode"),
+            for _ in 0..args.nthreads.unwrap_or(1) {
+                if let Ok(handle) = start_client_thread(
+                    libos_name,
+                    args.nclients.ok_or(anyhow::anyhow!("missing number of clients"))?,
+                    args.nrequests,
+                    args.bufsize.ok_or(anyhow::anyhow!("missing buffer size"))?,
+                    &run_mode,
+                    args.addr,
+                    args.log_interval,
+                ) {
+                    threads.push(handle);
+                }
             }
         },
         _ => todo!(),
     }
 
+    for handle in threads {
+        handle.join().unwrap()?;
+    }
     Ok(())
 }

--- a/examples/tcp-echo/main.rs
+++ b/examples/tcp-echo/main.rs
@@ -281,7 +281,6 @@ fn main() -> Result<()> {
         Err(e) => anyhow::bail!("{:?}", e),
     };
 
-    let run_mode: String = args.run_mode.ok_or(anyhow::anyhow!("missing run mode"))?;
     let mut threads = vec![];
     match args.peer_type.as_str() {
         "server" => {
@@ -292,6 +291,7 @@ fn main() -> Result<()> {
             }
         },
         "client" => {
+            let run_mode: String = args.run_mode.ok_or(anyhow::anyhow!("missing run mode"))?;
             for _ in 0..args.nthreads.unwrap_or(1) {
                 if let Ok(handle) = start_client_thread(
                     libos_name,

--- a/src/rust/catnap/linux/transport.rs
+++ b/src/rust/catnap/linux/transport.rs
@@ -349,7 +349,13 @@ impl NetworkTransport for SharedCatnapTransport {
                 optval_len,
             )
         } < 0
-        {}
+        {
+            let e: i32 = get_libc_err(io::Error::last_os_error());
+            let cause: String = format!("failed to bind socket: {:?}", e);
+            error!("bind(): {}", cause);
+            return Err(Fail::new(e, &cause));
+        }
+
         if let Err(e) = socket.bind(&local.into()) {
             let cause: String = format!("failed to bind socket: {:?}", e);
             error!("bind(): {}", cause);

--- a/src/rust/catnap/linux/transport.rs
+++ b/src/rust/catnap/linux/transport.rs
@@ -294,7 +294,6 @@ impl NetworkTransport for SharedCatnapTransport {
                     error!("new(): {}", cause);
                     return Err(Fail::new(get_libc_err(e), &cause));
                 }
-
                 if let Err(e) = socket.set_nonblocking(true) {
                     let cause: String = format!("cannot set NONBLOCKING option: {:?}", e);
                     socket.shutdown(Shutdown::Both)?;

--- a/src/rust/demikernel/libos/name.rs
+++ b/src/rust/demikernel/libos/name.rs
@@ -12,6 +12,7 @@ use ::std::env;
 // Structures
 //======================================================================================================================
 
+#[derive(Clone, Copy)]
 /// Names of LibOSes.
 pub enum LibOSName {
     Catpowder,

--- a/tools/ci/config/ci_map.yaml
+++ b/tools/ci/config/ci_map.yaml
@@ -87,41 +87,61 @@ catnap:
       nclients: 1
       nrequests: 128
       run_mode: sequential
+      nthreads: 1
     - scenario1:
       bufsize: 64
       nclients: 1
       nrequests: 1024
       run_mode: sequential
+      nthreads: 1
     - scenario2:
       bufsize: 1024
       nclients: 1
       nrequests: 128
       run_mode: sequential
+      nthreads: 1
     - scenario3:
       bufsize: 1024
       nclients: 1
       nrequests: 1024
       run_mode: sequential
+      nthreads: 1
     - scenario4:
       bufsize: 64
       nclients: 32
       nrequests: 128
       run_mode: concurrent
+      nthreads: 1
     - scenario5:
       bufsize: 64
       nclients: 32
       nrequests: 1024
       run_mode: concurrent
+      nthreads: 1
     - scenario6:
       bufsize: 1024
       nclients: 32
       nrequests: 128
       run_mode: concurrent
+      nthreads: 1
     - scenario7:
       bufsize: 1024
       nclients: 32
       nrequests: 1024
       run_mode: concurrent
+      nthreads: 1
+    - scenario8:
+      bufsize: 64
+      nclients: 32
+      nrequests: 1024
+      run_mode: concurrent
+      nthreads: 2
+    - scenario9:
+      bufsize: 64
+      nclients: 32
+      nrequests: 1024
+      run_mode: concurrent
+      nthreads: 4
   tcp_ping_pong: {}
   tcp_push_pop: {}
   tcp_wait:

--- a/tools/ci/job/linux.py
+++ b/tools/ci/job/linux.py
@@ -206,11 +206,11 @@ class TcpCloseTest(SystemTestJobOnLinux):
 
 
 class TcpEchoTest(SystemTestJobOnLinux):
-    def __init__(self, config: dict, run_mode: str, nclients: int, bufsize: int, nrequests: int):
+    def __init__(self, config: dict, run_mode: str, nclients: int, bufsize: int, nrequests: int, nthreads: int):
         config["test_name"] = "tcp-echo"
-        config["test_alias"] = f"tcp-echo-{run_mode}-{nclients}-{bufsize}-{nrequests}"
+        config["test_alias"] = f"tcp-echo-{run_mode}-{nclients}-{bufsize}-{nrequests}-{nthreads}"
         config["all_pass"] = True
-        config["server_args"] = f"--peer server --address {config['server_addr']}:12345"
+        config["server_args"] = f"--peer server --address {config['server_addr']}:12345 --nthreads {nthreads}"
         config["client_args"] = f"--peer client --address {config['server_addr']}:12345 --nclients {nclients} --nrequests {nrequests} --bufsize {bufsize} --run-mode {run_mode}"
         super().__init__(config)
 

--- a/tools/demikernel_ci.py
+++ b/tools/demikernel_ci.py
@@ -125,8 +125,12 @@ def run_pipeline(
                 status["pipe-push-pop"] = PipePushPopTest(config).execute()
             if 'tcp_echo' in ci_map[libos] and (test_system == "tcp-echo" or test_system == "all"):
                 for scenario in ci_map[libos]['tcp_echo']:
-                    status["tcp_echo"] = TcpEchoTest(
-                        config, scenario['run_mode'], scenario['nclients'], scenario['bufsize'], scenario['nrequests']).execute()
+                    if libos == "catnap":
+                        status["tcp_echo"] = TcpEchoTest(
+                            config, scenario['run_mode'], scenario['nclients'], scenario['bufsize'], scenario['nrequests'], scenario['nthreads']).execute()
+                    else:
+                        status["tcp_echo"] = TcpEchoTest(
+                            config, scenario['run_mode'], scenario['nclients'], scenario['bufsize'], scenario['nrequests'], 1).execute()
             if 'tcp_close' in ci_map[libos] and (test_system == "tcp-close" or test_system == "all"):
                 for scenario in ci_map[libos]['tcp_close']:
                     status["tcp_close"] = TcpCloseTest(


### PR DESCRIPTION
This PR add support for multicore execution to our tcp-echo benchmark as an example of how we will handle basic multi-core architectures with RSS support. It currently only works with Catnap because there is more configuration that needs to be done for DPDK support. Since it has a share nothing architecture, it should work fine with Catloop and Catmem but is not currently supported.