### PR TITLE
[ci] Run Workflows Only On PRs

### DIFF
--- a/.github/workflows/catloop.yml
+++ b/.github/workflows/catloop.yml
@@ -2,21 +2,14 @@
 # Licensed under the MIT license.
 
 name: Main Catloop
+
 concurrency:
   group: catloop
   cancel-in-progress: false
 
 on:
-  push:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - main
-  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
 
 env:
   LIBOS: catloop
@@ -53,7 +46,7 @@ jobs:
           --server $SERVER \
           --client $CLIENT \
           --repository demikernel \
-          --branch origin/${{ github.ref_name }} \
+          --branch origin/${{ github.head_ref }} \
           --libos $LIBOS \
           --debug \
           --test-unit --test-system all --delay 2 --enable-nfs \
@@ -95,7 +88,7 @@ jobs:
           --server $SERVER \
           --client $CLIENT \
           --repository demikernel \
-          --branch origin/${{ github.ref_name }} \
+          --branch origin/${{ github.head_ref }} \
           --libos $LIBOS \
           --test-unit --test-system all --delay 2 --enable-nfs \
           --server-addr $SERVER_ADDR \

--- a/.github/workflows/catmem.yml
+++ b/.github/workflows/catmem.yml
@@ -2,21 +2,14 @@
 # Licensed under the MIT license.
 
 name: Main Catmem
+
 concurrency:
   group: catmem
   cancel-in-progress: false
 
 on:
-  push:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - main
-  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
 
 env:
   LIBOS: catmem
@@ -53,7 +46,7 @@ jobs:
           --server $SERVER \
           --client $CLIENT \
           --repository demikernel \
-          --branch origin/${{ github.ref_name }} \
+          --branch origin/${{ github.head_ref }} \
           --libos $LIBOS \
           --debug \
           --test-unit --test-system all --delay 2 --enable-nfs \
@@ -95,7 +88,7 @@ jobs:
           --server $SERVER \
           --client $CLIENT \
           --repository demikernel \
-          --branch origin/${{ github.ref_name }} \
+          --branch origin/${{ github.head_ref }} \
           --libos $LIBOS \
           --test-unit --test-system all --delay 2 --enable-nfs \
           --server-addr $SERVER_ADDR \

--- a/.github/workflows/catnap.yml
+++ b/.github/workflows/catnap.yml
@@ -2,21 +2,14 @@
 # Licensed under the MIT license.
 
 name: Main Catnap
+
 concurrency:
   group: catnap
   cancel-in-progress: false
 
 on:
-  push:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - main
-  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
 
 env:
   LIBOS: catnap
@@ -53,7 +46,7 @@ jobs:
           --server $SERVER \
           --client $CLIENT \
           --repository demikernel \
-          --branch origin/${{ github.ref_name }} \
+          --branch origin/${{ github.head_ref }} \
           --libos $LIBOS \
           --debug \
           --test-unit --test-system all --delay 2 \
@@ -95,7 +88,7 @@ jobs:
           --server $SERVER \
           --client $CLIENT \
           --repository demikernel \
-          --branch origin/${{ github.ref_name }} \
+          --branch origin/${{ github.head_ref }} \
           --libos $LIBOS \
           --test-unit --test-system all --delay 2 \
           --server-addr $SERVER_ADDR \

--- a/.github/workflows/catnapw.yml
+++ b/.github/workflows/catnapw.yml
@@ -2,21 +2,14 @@
 # Licensed under the MIT license.
 
 name: Main Catnapw
+
 concurrency:
   group: catnapw
   cancel-in-progress: false
 
 on:
-  push:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
-  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
 
 env:
   LIBOS: catnapw
@@ -54,7 +47,7 @@ jobs:
           --client $CLIENT \
           --repository 'c:\demikernel' \
           --config-path 'c:\config.yaml' \
-          --branch origin/${{ github.ref_name }} \
+          --branch origin/${{ github.head_ref }} \
           --libos $LIBOS \
           --debug \
           --server-addr $SERVER_ADDR \
@@ -96,7 +89,7 @@ jobs:
           --client $CLIENT \
           --repository 'c:\demikernel' \
           --config-path 'c:\config.yaml' \
-          --branch origin/${{ github.ref_name }} \
+          --branch origin/${{ github.head_ref }} \
           --libos $LIBOS \
           --server-addr $SERVER_ADDR \
           --client-addr $CLIENT_ADDR \

--- a/.github/workflows/catnip.yml
+++ b/.github/workflows/catnip.yml
@@ -2,21 +2,14 @@
 # Licensed under the MIT license.
 
 name: Main Catnip
+
 concurrency:
   group: catnip
   cancel-in-progress: false
 
 on:
-  push:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - main
-  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
 
 env:
   LIBOS: catnip
@@ -53,7 +46,7 @@ jobs:
           --server $SERVER \
           --client $CLIENT \
           --repository demikernel \
-          --branch origin/${{ github.ref_name }} \
+          --branch origin/${{ github.head_ref }} \
           --debug \
           --libos $LIBOS \
           --test-unit --test-system all --delay 2 \
@@ -95,7 +88,7 @@ jobs:
           --server $SERVER \
           --client $CLIENT \
           --repository demikernel \
-          --branch origin/${{ github.ref_name }} \
+          --branch origin/${{ github.head_ref }} \
           --libos $LIBOS \
           --test-unit --test-system all --delay 2 \
           --server-addr $SERVER_ADDR \

--- a/.github/workflows/catpowder.yml
+++ b/.github/workflows/catpowder.yml
@@ -2,21 +2,14 @@
 # Licensed under the MIT license.
 
 name: Main Catpowder
+
 concurrency:
   group: catpowder
   cancel-in-progress: false
 
 on:
-  push:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - main
-  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
 
 env:
   LIBOS: catpowder
@@ -53,7 +46,7 @@ jobs:
           --server $SERVER \
           --client $CLIENT \
           --repository demikernel \
-          --branch origin/${{ github.ref_name }} \
+          --branch origin/${{ github.head_ref }} \
           --debug \
           --libos $LIBOS \
           --test-unit --test-system all --delay 2 \
@@ -96,7 +89,7 @@ jobs:
           --server $SERVER \
           --client $CLIENT \
           --repository demikernel \
-          --branch origin/${{ github.ref_name }} \
+          --branch origin/${{ github.head_ref }} \
           --libos $LIBOS \
           --test-unit --test-system all --delay 2 \
           --server-addr $SERVER_ADDR \


### PR DESCRIPTION
## Description

This PR changes the triggering strategy for our CI.

Previously, we would trigger workflows on every push made to a matching branch. With changes introduced in this PR, workflow runs now trigger only when a PR is opened or updated.

## What has changed?

- Workflow runs are now triggered only when opening or updating PRs

## Why is this change required?

The motivation for this change is twofold:

- Enable access to PRs context API. This is required to leverage further automation CI (ie. post comments on PRs with performance numbers).
- Enable workflows to run on PRs made by external contributors (upon approval).