### PR TITLE
[runtime] Enhancement: Add new 'wait_next_n' binding and add type annotations to bindings

### DIFF
--- a/include/demi/libos.h
+++ b/include/demi/libos.h
@@ -29,8 +29,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_init(_In_ int argc, _In_reads_(argc) _Deref_pre_z_ char *const argv[])
-        ATTR_NONNULL(1);
+    ATTR_NONNULL(1)
+    extern int demi_init(_In_ int argc, _In_reads_(argc) _Deref_pre_z_ char *const argv[]);
 
 
     /**
@@ -41,8 +41,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_create_pipe(_Out_ int *memqd_out, _In_z_ const char *name)
-        ATTR_NONNULL(0, 1);
+    ATTR_NONNULL(0, 1)
+    extern int demi_create_pipe(_Out_ int *memqd_out, _In_z_ const char *name);
 
     /**
      * @brief Opens an existing memory I/O queue.
@@ -52,8 +52,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_open_pipe(_Out_ int *memqd_out, _In_z_ const char *name)
-        ATTR_NONNULL(0, 1);
+    ATTR_NONNULL(0, 1)
+    extern int demi_open_pipe(_Out_ int *memqd_out, _In_z_ const char *name);
 
     /**
      * @brief Creates a socket I/O queue.
@@ -65,8 +65,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_socket(_Out_ int *sockqd_out, _In_ int domain, _In_ int type, _In_ int protocol)
-        ATTR_NONNULL(0);
+    ATTR_NONNULL(0)
+    extern int demi_socket(_Out_ int *sockqd_out, _In_ int domain, _In_ int type, _In_ int protocol);
 
     /**
      * @brief Sets as passive a socket I/O queue.
@@ -87,8 +87,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_bind(_In_ int sockqd, _In_reads_bytes_(size) const struct sockaddr *addr, _In_ socklen_t size)
-        ATTR_NONNULL(1);
+    ATTR_NONNULL(1)
+    extern int demi_bind(_In_ int sockqd, _In_reads_bytes_(size) const struct sockaddr *addr, _In_ socklen_t size);
 
     /**
      * @brief Asynchronously accepts a connection request on a socket I/O queue.
@@ -98,8 +98,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_accept(_Out_ demi_qtoken_t *qt_out, _In_ int sockqd)
-        ATTR_NONNULL(0);
+    ATTR_NONNULL(0)
+    extern int demi_accept(_Out_ demi_qtoken_t *qt_out, _In_ int sockqd);
 
     /**
      * @brief Asynchronously initiates a connection on a socket I/O queue.
@@ -111,9 +111,9 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
+    ATTR_NONNULL(0, 2)
     extern int demi_connect(_Out_ demi_qtoken_t *qt_out, _In_ int sockqd,
-                            _In_reads_bytes_(size) const struct sockaddr *addr, _In_ socklen_t size)
-        ATTR_NONNULL(0, 2);
+                            _In_reads_bytes_(size) const struct sockaddr *addr, _In_ socklen_t size);
 
 
     /**
@@ -134,8 +134,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_push(_Out_ demi_qtoken_t *qt_out, _In_ int qd, _In_ const demi_sgarray_t *sga)
-        ATTR_NONNULL(0, 2);
+    ATTR_NONNULL(0, 2)
+    extern int demi_push(_Out_ demi_qtoken_t *qt_out, _In_ int qd, _In_ const demi_sgarray_t *sga);
 
     /**
      * @brief Asynchronously pushes a scatter-gather array to a socket I/O queue.
@@ -148,9 +148,9 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
+    ATTR_NONNULL(0, 2, 3)
     extern int demi_pushto(_Out_ demi_qtoken_t *qt_out, _In_ int sockqd, _In_ const demi_sgarray_t *sga,
-                           _In_reads_bytes_(size) const struct sockaddr *dest_addr, _In_ socklen_t size)
-        ATTR_NONNULL(0, 2, 3);
+                           _In_reads_bytes_(size) const struct sockaddr *dest_addr, _In_ socklen_t size);
 
     /**
      * @brief Asynchronously pops a scatter-gather array from an I/O queue.
@@ -160,8 +160,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_pop(_Out_ demi_qtoken_t *qt_out, _In_ int qd)
-        ATTR_NONNULL(0);
+    ATTR_NONNULL(0)
+    extern int demi_pop(_Out_ demi_qtoken_t *qt_out, _In_ int qd);
 
 #ifdef __cplusplus
 }

--- a/include/demi/libos.h
+++ b/include/demi/libos.h
@@ -29,7 +29,7 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    ATTR_NONNULL(1)
+    ATTR_NONNULL(2)
     extern int demi_init(_In_ int argc, _In_reads_(argc) _Deref_pre_z_ char *const argv[]);
 
 
@@ -41,7 +41,7 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    ATTR_NONNULL(0, 1)
+    ATTR_NONNULL(1, 2)
     extern int demi_create_pipe(_Out_ int *memqd_out, _In_z_ const char *name);
 
     /**
@@ -52,7 +52,7 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    ATTR_NONNULL(0, 1)
+    ATTR_NONNULL(1, 2)
     extern int demi_open_pipe(_Out_ int *memqd_out, _In_z_ const char *name);
 
     /**
@@ -65,7 +65,7 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    ATTR_NONNULL(0)
+    ATTR_NONNULL(1)
     extern int demi_socket(_Out_ int *sockqd_out, _In_ int domain, _In_ int type, _In_ int protocol);
 
     /**
@@ -87,7 +87,7 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    ATTR_NONNULL(1)
+    ATTR_NONNULL(2)
     extern int demi_bind(_In_ int sockqd, _In_reads_bytes_(size) const struct sockaddr *addr, _In_ socklen_t size);
 
     /**
@@ -98,7 +98,7 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    ATTR_NONNULL(0)
+    ATTR_NONNULL(1)
     extern int demi_accept(_Out_ demi_qtoken_t *qt_out, _In_ int sockqd);
 
     /**
@@ -111,7 +111,7 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    ATTR_NONNULL(0, 2)
+    ATTR_NONNULL(1, 3)
     extern int demi_connect(_Out_ demi_qtoken_t *qt_out, _In_ int sockqd,
                             _In_reads_bytes_(size) const struct sockaddr *addr, _In_ socklen_t size);
 
@@ -134,7 +134,7 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    ATTR_NONNULL(0, 2)
+    ATTR_NONNULL(1, 3)
     extern int demi_push(_Out_ demi_qtoken_t *qt_out, _In_ int qd, _In_ const demi_sgarray_t *sga);
 
     /**
@@ -148,7 +148,7 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    ATTR_NONNULL(0, 2, 3)
+    ATTR_NONNULL(1, 3, 4)
     extern int demi_pushto(_Out_ demi_qtoken_t *qt_out, _In_ int sockqd, _In_ const demi_sgarray_t *sga,
                            _In_reads_bytes_(size) const struct sockaddr *dest_addr, _In_ socklen_t size);
 
@@ -160,7 +160,7 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    ATTR_NONNULL(0)
+    ATTR_NONNULL(1)
     extern int demi_pop(_Out_ demi_qtoken_t *qt_out, _In_ int qd);
 
 #ifdef __cplusplus

--- a/include/demi/libos.h
+++ b/include/demi/libos.h
@@ -29,7 +29,9 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_init(int argc, char *const argv[]);
+    extern int demi_init(_In_ int argc, _In_reads_(argc) _Deref_pre_z_ char *const argv[])
+        ATTR_NONNULL(1);
+
 
     /**
      * @brief Creates a new memory I/O queue.
@@ -39,7 +41,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_create_pipe(int *memqd_out, const char *name);
+    extern int demi_create_pipe(_Out_ int *memqd_out, _In_z_ const char *name)
+        ATTR_NONNULL(0, 1);
 
     /**
      * @brief Opens an existing memory I/O queue.
@@ -49,7 +52,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_open_pipe(int *memqd_out, const char *name);
+    extern int demi_open_pipe(_Out_ int *memqd_out, _In_z_ const char *name)
+        ATTR_NONNULL(0, 1);
 
     /**
      * @brief Creates a socket I/O queue.
@@ -61,7 +65,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_socket(int *sockqd_out, int domain, int type, int protocol);
+    extern int demi_socket(_Out_ int *sockqd_out, _In_ int domain, _In_ int type, _In_ int protocol)
+        ATTR_NONNULL(0);
 
     /**
      * @brief Sets as passive a socket I/O queue.
@@ -71,7 +76,7 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_listen(int sockqd, int backlog);
+    extern int demi_listen(_In_ int sockqd, _In_ int backlog);
 
     /**
      * @brief Binds an address to a socket I/O queue.
@@ -82,7 +87,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_bind(int sockqd, const struct sockaddr *addr, socklen_t size);
+    extern int demi_bind(_In_ int sockqd, _In_reads_bytes_(size) const struct sockaddr *addr, _In_ socklen_t size)
+        ATTR_NONNULL(1);
 
     /**
      * @brief Asynchronously accepts a connection request on a socket I/O queue.
@@ -92,7 +98,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_accept(demi_qtoken_t *qt_out, int sockqd);
+    extern int demi_accept(_Out_ demi_qtoken_t *qt_out, _In_ int sockqd)
+        ATTR_NONNULL(0);
 
     /**
      * @brief Asynchronously initiates a connection on a socket I/O queue.
@@ -104,7 +111,10 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_connect(demi_qtoken_t *qt_out, int sockqd, const struct sockaddr *addr, socklen_t size);
+    extern int demi_connect(_Out_ demi_qtoken_t *qt_out, _In_ int sockqd,
+                            _In_reads_bytes_(size) const struct sockaddr *addr, _In_ socklen_t size)
+        ATTR_NONNULL(0, 2);
+
 
     /**
      * @brief Closes an I/O queue descriptor.
@@ -113,7 +123,7 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_close(int qd);
+    extern int demi_close(_In_ int qd);
 
     /**
      * @brief Asynchronously pushes a scatter-gather array to an I/O queue.
@@ -124,7 +134,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_push(demi_qtoken_t *qt_out, int qd, const demi_sgarray_t *sga);
+    extern int demi_push(_Out_ demi_qtoken_t *qt_out, _In_ int qd, _In_ const demi_sgarray_t *sga)
+        ATTR_NONNULL(0, 2);
 
     /**
      * @brief Asynchronously pushes a scatter-gather array to a socket I/O queue.
@@ -137,8 +148,9 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_pushto(demi_qtoken_t *qt_out, int sockqd, const demi_sgarray_t *sga,
-                           const struct sockaddr *dest_addr, socklen_t size);
+    extern int demi_pushto(_Out_ demi_qtoken_t *qt_out, _In_ int sockqd, _In_ const demi_sgarray_t *sga,
+                           _In_reads_bytes_(size) const struct sockaddr *dest_addr, _In_ socklen_t size)
+        ATTR_NONNULL(0, 2, 3);
 
     /**
      * @brief Asynchronously pops a scatter-gather array from an I/O queue.
@@ -148,7 +160,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_pop(demi_qtoken_t *qt_out, int qd);
+    extern int demi_pop(_Out_ demi_qtoken_t *qt_out, _In_ int qd)
+        ATTR_NONNULL(0);
 
 #ifdef __cplusplus
 }

--- a/include/demi/sga.h
+++ b/include/demi/sga.h
@@ -20,7 +20,8 @@ extern "C"
      * @return On successful completion, the allocated scatter-gather array is returned. On error, a null scatter-gather
      * array is returned instead.
      */
-    extern demi_sgarray_t demi_sgaalloc(size_t size);
+    ATTR_NODISCARD
+    extern demi_sgarray_t demi_sgaalloc(_In_ size_t size);
 
     /**
      * @brief Releases a scatter-gather array.
@@ -29,7 +30,7 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_sgafree(demi_sgarray_t *sga);
+    extern int demi_sgafree(_In_ demi_sgarray_t *sga);
 
 #ifdef __cplusplus
 }

--- a/include/demi/types.h
+++ b/include/demi/types.h
@@ -21,13 +21,13 @@ extern "C"
 {
 #endif
 
-#ifndef __has_include
-#define __has_include(x) false
-#endif
-
+#ifdef __has_include
 #if __has_include(<sal.h>)
 #  include <sal.h>
-#elif defined(_MSC_VER)
+#endif
+#endif
+
+#if !defined(_SAL_VERSION) && defined(_MSC_VER)
 #  include <sal.h>
 #else
 #  define _In_
@@ -41,11 +41,14 @@ extern "C"
 #endif
 
 #ifdef __has_c_attribute
-#  define FUNC_NONNULL(...) [[gnu::nonnull(__VA_ARGS__)]]
+#  define ATTR_NONNULL(...) [[gnu::nonnull(__VA_ARGS__)]]
+#  define ATTR_NODISCARD [[nodiscard]]
 #elif defined(__GNUC__)
-#  define FUNC_NONNULL(...) __attribute__((nonnull(__VA_ARGS__)))
-#else
-#  define FUNC_NONNULL(...)
+#  define ATTR_NONNULL(...) __attribute__((nonnull(__VA_ARGS__)))
+#  define ATTR_NODISCARD __attribute__((warn_unused_result))
+#elif defined(_MSC_VER)
+#  define ATTR_NONNULL(...)
+#  define ATTR_NODISCARD _Check_return_
 #endif
 
 /**

--- a/include/demi/types.h
+++ b/include/demi/types.h
@@ -40,13 +40,18 @@ extern "C"
 #  define _Deref_pre_z_
 #endif
 
-#ifdef __has_c_attribute
-#  define ATTR_NONNULL(...) [[gnu::nonnull(__VA_ARGS__)]]
-#  define ATTR_NODISCARD [[nodiscard]]
-#elif defined(__GNUC__)
+#if defined(__GNUC__)
+// GCC and clang both support __attribute__((nonnull(...)))
+// Indices are one-based.
+// Note that while clang support _Nonnull and _Nullable, they have different positional syntax
+// w.r.t. SAL, so supporting both is complex.
 #  define ATTR_NONNULL(...) __attribute__((nonnull(__VA_ARGS__)))
 #  define ATTR_NODISCARD __attribute__((warn_unused_result))
 #elif defined(_MSC_VER)
+// MSVC uses SAL; NONNULL is supported via _In_/_Out_/etc.
+#  define ATTR_NONNULL(...)
+#  define ATTR_NODISCARD _Check_return_
+#else
 #  define ATTR_NONNULL(...)
 #  define ATTR_NODISCARD _Check_return_
 #endif

--- a/include/demi/types.h
+++ b/include/demi/types.h
@@ -21,6 +21,33 @@ extern "C"
 {
 #endif
 
+#ifndef __has_include
+#define __has_include(x) false
+#endif
+
+#if __has_include(<sal.h>)
+#  include <sal.h>
+#elif defined(_MSC_VER)
+#  include <sal.h>
+#else
+#  define _In_
+#  define _In_z_
+#  define _In_opt_
+#  define _In_reads_(s)
+#  define _In_reads_bytes_(b)
+#  define _Out_
+#  define _Out_writes_to_(s,c)
+#  define _Deref_pre_z_
+#endif
+
+#ifdef __has_c_attribute
+#  define FUNC_NONNULL(...) [[gnu::nonnull(__VA_ARGS__)]]
+#elif defined(__GNUC__)
+#  define FUNC_NONNULL(...) __attribute__((nonnull(__VA_ARGS__)))
+#else
+#  define FUNC_NONNULL(...)
+#endif
+
 /**
  * @brief Maximum number of segments in a scatter-gather array.
  */

--- a/include/demi/wait.h
+++ b/include/demi/wait.h
@@ -21,8 +21,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_wait(_Out_ demi_qresult_t *qr_out, _In_ demi_qtoken_t qt, _In_opt_ const struct timespec *timeout)
-        ATTR_NONNULL(1);
+    ATTR_NONNULL(1)
+    extern int demi_wait(_Out_ demi_qresult_t *qr_out, _In_ demi_qtoken_t qt, _In_opt_ const struct timespec *timeout);
 
     /**
      * @brief Waits for the first asynchronous I/O operation in a list to complete.
@@ -35,10 +35,10 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
+    ATTR_NONNULL(1, 2, 3)
     extern int demi_wait_any(_Out_ demi_qresult_t *qr_out, _Out_ int *ready_offset,
                              _In_reads_(num_qts) const demi_qtoken_t qts[], _In_ int num_qts,
-                             _In_opt_ const struct timespec *timeout)
-        ATTR_NONNULL(1, 2, 3);
+                             _In_opt_ const struct timespec *timeout);
 
     /**
      * @brief Waits for the next n asynchronous I/O operations to complete.
@@ -51,9 +51,9 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_wait_any(_Out_writes_to_(num_qrs, *ready_offset) demi_qresult_t *qr_out, _In_ int num_qrs,
-                             _Out_ int *ready_offset, _In_opt_ const struct timespec *timeout)
-        ATTR_NONNULL(1, 3);
+    ATTR_NONNULL(1, 3)
+    extern int demi_wait_next_n(_Out_writes_to_(num_qrs, *ready_offset) demi_qresult_t *qr_out, _In_ int num_qrs,
+                                _Out_ int *ready_offset, _In_opt_ const struct timespec *timeout);
 
 #ifdef __cplusplus
 }

--- a/include/demi/wait.h
+++ b/include/demi/wait.h
@@ -21,7 +21,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_wait(demi_qresult_t *qr_out, demi_qtoken_t qt, const struct timespec *timeout);
+    extern int demi_wait(_Out_ demi_qresult_t *qr_out, _In_ demi_qtoken_t qt, _In_opt_ const struct timespec *timeout)
+        ATTR_NONNULL(1);
 
     /**
      * @brief Waits for the first asynchronous I/O operation in a list to complete.
@@ -34,8 +35,25 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_wait_any(demi_qresult_t *qr_out, int *ready_offset, const demi_qtoken_t qts[], int num_qts,
-                             const struct timespec *timeout);
+    extern int demi_wait_any(_Out_ demi_qresult_t *qr_out, _Out_ int *ready_offset,
+                             _In_reads_(num_qts) const demi_qtoken_t qts[], _In_ int num_qts,
+                             _In_opt_ const struct timespec *timeout)
+        ATTR_NONNULL(1, 2, 3);
+
+    /**
+     * @brief Waits for the next n asynchronous I/O operations to complete.
+     *
+     * @param qr_out       Store location for the result of the completed I/O operation.
+     * @param ready_offset Store location for the offset in the list of I/O queue tokens of the completed I/O operation.
+     * @param qts          List of I/O queue tokens to wait for completion.
+     * @param num_qts      Length of the list of I/O queue tokens to wait for completion.
+     * @param timeout      Timeout interval in seconds and nanoseconds.
+     *
+     * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
+     */
+    extern int demi_wait_any(_Out_writes_to_(num_qrs, *ready_offset) demi_qresult_t *qr_out, _In_ int num_qrs,
+                             _Out_ int *ready_offset, _In_opt_ const struct timespec *timeout)
+        ATTR_NONNULL(1, 3);
 
 #ifdef __cplusplus
 }

--- a/src/rust/catmem/mod.rs
+++ b/src/rust/catmem/mod.rs
@@ -214,6 +214,19 @@ impl SharedCatmemLibOS {
         Ok((offset, self.create_result(result, qd, qt)))
     }
 
+    /// Waits in a loop until the next task is complete, passing the result to `acceptor`. This process continues until
+    /// either the acceptor returns false (in which case the method returns Ok), or the timeout has expired (in which
+    /// the method returns an `Err` indicating timeout).
+    pub fn wait_next_n<Acceptor: FnMut(demi_qresult_t) -> bool>(
+        &mut self,
+        mut acceptor: Acceptor,
+        timeout: Duration
+    ) -> Result<(), Fail>
+    {
+        self.runtime.clone().wait_next_n(
+            |qt, qd, result| acceptor(self.create_result(result, qd, qt)), timeout)
+    }
+
     /// Waits for any operation in an I/O queue.
     pub fn poll(&mut self) {
         self.runtime.poll()

--- a/src/rust/demikernel/libos/memory.rs
+++ b/src/rust/demikernel/libos/memory.rs
@@ -116,13 +116,13 @@ impl MemoryLibOS {
     /// either the acceptor returns false (in which case the method returns Ok), or the timeout has expired (in which
     /// the method returns an `Err` indicating timeout).
     #[allow(unreachable_patterns, unused_variables)]
-    pub fn wait_next_n<Acceptor: FnMut(QToken, QDesc, demi_qresult_t) -> bool>(
+    pub fn wait_next_n<Acceptor: FnMut(demi_qresult_t) -> bool>(
         &mut self,
         acceptor: Acceptor,
         timeout: Duration
     ) -> Result<(), Fail>
     {
-        trace!("wait_next_n(): acceptor={:?}, timeout={:?}", acceptor, timeout);
+        trace!("wait_next_n(): acceptor, timeout={:?}", timeout);
         match self {
             #[cfg(feature = "catmem-libos")]
             MemoryLibOS::Catmem(libos) => libos.wait_next_n(acceptor, timeout),

--- a/src/rust/demikernel/libos/memory.rs
+++ b/src/rust/demikernel/libos/memory.rs
@@ -101,7 +101,6 @@ impl MemoryLibOS {
         Ok(qr)
     }
 
-    #[allow(unreachable_patterns, unused_variables)]
     /// Waits for any of the given pending I/O operations to complete or a timeout to expire.
     #[allow(unreachable_patterns, unused_variables)]
     pub fn wait_any(&mut self, qts: &[QToken], timeout: Duration) -> Result<(usize, demi_qresult_t), Fail> {
@@ -112,6 +111,25 @@ impl MemoryLibOS {
             _ => unreachable!("unknown memory libos"),
         }
     }
+
+    /// Waits in a loop until the next task is complete, passing the result to `acceptor`. This process continues until
+    /// either the acceptor returns false (in which case the method returns Ok), or the timeout has expired (in which
+    /// the method returns an `Err` indicating timeout).
+    #[allow(unreachable_patterns, unused_variables)]
+    pub fn wait_next_n<Acceptor: FnMut(QToken, QDesc, demi_qresult_t) -> bool>(
+        &mut self,
+        acceptor: Acceptor,
+        timeout: Duration
+    ) -> Result<(), Fail>
+    {
+        trace!("wait_next_n(): acceptor={:?}, timeout={:?}", acceptor, timeout);
+        match self {
+            #[cfg(feature = "catmem-libos")]
+            MemoryLibOS::Catmem(libos) => libos.wait_next_n(acceptor, timeout),
+            _ => unreachable!("unknown memory libos"),
+        }
+    }
+
 
     /// Allocates a scatter-gather array.
     #[allow(unreachable_patterns, unused_variables)]

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -505,6 +505,30 @@ impl LibOS {
         }
     }
 
+    /// Waits in a loop until the next task is complete, passing the result to `acceptor`. This process continues until
+    /// either the acceptor returns false (in which case the method returns Ok), or the timeout has expired (in which
+    /// the method returns an `Err` indicating timeout).
+    #[allow(unreachable_patterns, unused_variables)]
+    pub fn wait_next_n<Acceptor: FnMut(demi_qresult_t) -> bool>(
+        &mut self,
+        acceptor: Acceptor,
+        timeout: Option<Duration>
+    ) -> Result<(), Fail>
+    {
+        timer!("demikernel::wait_next_n");
+        match self {
+            #[cfg(any(
+                feature = "catnap-libos",
+                feature = "catnip-libos",
+                feature = "catpowder-libos",
+                feature = "catloop-libos"
+            ))]
+            LibOS::NetworkLibOS(libos) => libos.wait_next_n(acceptor, timeout.unwrap_or(DEFAULT_TIMEOUT)),
+            #[cfg(feature = "catmem-libos")]
+            LibOS::MemoryLibOS(libos) => libos.wait_any(qts, timeout.unwrap_or(DEFAULT_TIMEOUT)),
+        }
+    }
+
     /// Allocates a scatter-gather array.
     pub fn sgaalloc(&mut self, size: usize) -> Result<demi_sgarray_t, Fail> {
         let result: Result<demi_sgarray_t, Fail> = {
@@ -545,7 +569,7 @@ impl LibOS {
         result
     }
 
-    fn poll(&mut self) {
+    pub fn poll(&mut self) {
         timer!("demikernel::poll");
         match self {
             #[cfg(any(

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -525,7 +525,7 @@ impl LibOS {
             ))]
             LibOS::NetworkLibOS(libos) => libos.wait_next_n(acceptor, timeout.unwrap_or(DEFAULT_TIMEOUT)),
             #[cfg(feature = "catmem-libos")]
-            LibOS::MemoryLibOS(libos) => libos.wait_any(qts, timeout.unwrap_or(DEFAULT_TIMEOUT)),
+            LibOS::MemoryLibOS(libos) => libos.wait_next_n(acceptor, timeout.unwrap_or(DEFAULT_TIMEOUT)),
         }
     }
 

--- a/src/rust/demikernel/libos/network/libos.rs
+++ b/src/rust/demikernel/libos/network/libos.rs
@@ -47,7 +47,6 @@ use ::socket2::{
     Protocol,
     Type,
 };
-use std::mem::MaybeUninit;
 use ::std::{
     mem,
     net::{

--- a/src/rust/demikernel/libos/network/mod.rs
+++ b/src/rust/demikernel/libos/network/mod.rs
@@ -25,7 +25,6 @@ use crate::{
         QToken,
     },
 };
-use std::mem::MaybeUninit;
 use ::std::{
     net::SocketAddr,
     time::Duration,

--- a/src/rust/lib.rs
+++ b/src/rust/lib.rs
@@ -8,6 +8,7 @@
 #![feature(strict_provenance)]
 #![cfg_attr(target_os = "windows", feature(maybe_uninit_uninit_array))]
 #![feature(noop_waker)]
+#![feature(hash_extract_if)]
 
 mod collections;
 mod pal;

--- a/tests/c/syscalls.c
+++ b/tests/c/syscalls.c
@@ -16,6 +16,9 @@
  * System Calls in demi/libos.h                                                                                      *
  *===================================================================================================================*/
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnonnull"
+
 /**
  * @brief Issues an invalid call to demi_socket().
  */
@@ -177,6 +180,8 @@ static bool inval_wait_any(void)
 
     return (demi_wait_any(qr, ready_offset, qts, num_qts, timeout) != 0);
 }
+
+#pragma GCC diagnostic pop
 
 /*===================================================================================================================*
  * main()                                                                                                            *


### PR DESCRIPTION
This PR adds a new binding API to batch-deque completed operations from the libOS. The semantics are similar to `wait_any` except that the returned QTokens are not filtered, and the method may retrieve multiple results in a single call.

Also added GCC- and MSVC-specific correctness annotations to the C headers.