### PR TITLE
[runtime] Enhancement: add new demi_wait_next_n runtime binding

### DIFF
--- a/include/demi/cc.h
+++ b/include/demi/cc.h
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#ifndef DEMI_CC_H
+#define DEMI_CC_H
+
+#ifdef _MSC_VER
+#include <sal.h>
+#else
+#define _In_
+#define _In_z_
+#define _In_opt_
+#define _In_reads_(s)
+#define _In_reads_bytes_(b)
+#define _Out_
+#define _Out_writes_to_(s, c)
+#define _Deref_pre_z_
+#endif
+
+#if defined(__GNUC__)
+// GCC and clang both support __attribute__((nonnull(...)))
+// Indices are one-based.
+// Note that while clang support _Nonnull and _Nullable, they have different positional syntax
+// w.r.t. SAL, so supporting both is complex.
+#define ATTR_NONNULL(...) __attribute__((nonnull(__VA_ARGS__)))
+#define ATTR_NODISCARD __attribute__((warn_unused_result))
+#elif defined(_MSC_VER)
+// MSVC uses SAL; NONNULL is supported via _In_/_Out_/etc.
+#define ATTR_NONNULL(...)
+#define ATTR_NODISCARD _Check_return_
+#else
+#define ATTR_NONNULL(...)
+#define ATTR_NODISCARD _Check_return_
+#endif
+
+#endif /* DEMI_CC_H_ */

--- a/include/demi/libos.h
+++ b/include/demi/libos.h
@@ -6,6 +6,7 @@
 
 #include <demi/types.h>
 #include <stddef.h>
+#include <demi/cc.h>
 
 #ifdef __linux__
 #include <sys/socket.h>
@@ -29,7 +30,9 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_init(int argc, char *const argv[]);
+    ATTR_NONNULL(2)
+    extern int demi_init(_In_ int argc, _In_reads_(argc) _Deref_pre_z_ char *const argv[]);
+
 
     /**
      * @brief Creates a new memory I/O queue.
@@ -39,7 +42,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_create_pipe(int *memqd_out, const char *name);
+    ATTR_NONNULL(1, 2)
+    extern int demi_create_pipe(_Out_ int *memqd_out, _In_z_ const char *name);
 
     /**
      * @brief Opens an existing memory I/O queue.
@@ -49,7 +53,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_open_pipe(int *memqd_out, const char *name);
+    ATTR_NONNULL(1, 2)
+    extern int demi_open_pipe(_Out_ int *memqd_out, _In_z_ const char *name);
 
     /**
      * @brief Creates a socket I/O queue.
@@ -61,7 +66,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_socket(int *sockqd_out, int domain, int type, int protocol);
+    ATTR_NONNULL(1)
+    extern int demi_socket(_Out_ int *sockqd_out, _In_ int domain, _In_ int type, _In_ int protocol);
 
     /**
      * @brief Sets as passive a socket I/O queue.
@@ -71,7 +77,7 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_listen(int sockqd, int backlog);
+    extern int demi_listen(_In_ int sockqd, _In_ int backlog);
 
     /**
      * @brief Binds an address to a socket I/O queue.
@@ -82,7 +88,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_bind(int sockqd, const struct sockaddr *addr, socklen_t size);
+    ATTR_NONNULL(2)
+    extern int demi_bind(_In_ int sockqd, _In_reads_bytes_(size) const struct sockaddr *addr, _In_ socklen_t size);
 
     /**
      * @brief Asynchronously accepts a connection request on a socket I/O queue.
@@ -92,7 +99,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_accept(demi_qtoken_t *qt_out, int sockqd);
+    ATTR_NONNULL(1)
+    extern int demi_accept(_Out_ demi_qtoken_t *qt_out, _In_ int sockqd);
 
     /**
      * @brief Asynchronously initiates a connection on a socket I/O queue.
@@ -104,7 +112,10 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_connect(demi_qtoken_t *qt_out, int sockqd, const struct sockaddr *addr, socklen_t size);
+    ATTR_NONNULL(1, 3)
+    extern int demi_connect(_Out_ demi_qtoken_t *qt_out, _In_ int sockqd,
+                            _In_reads_bytes_(size) const struct sockaddr *addr, _In_ socklen_t size);
+
 
     /**
      * @brief Closes an I/O queue descriptor.
@@ -113,7 +124,7 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_close(int qd);
+    extern int demi_close(_In_ int qd);
 
     /**
      * @brief Asynchronously pushes a scatter-gather array to an I/O queue.
@@ -124,7 +135,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_push(demi_qtoken_t *qt_out, int qd, const demi_sgarray_t *sga);
+    ATTR_NONNULL(1, 3)
+    extern int demi_push(_Out_ demi_qtoken_t *qt_out, _In_ int qd, _In_ const demi_sgarray_t *sga);
 
     /**
      * @brief Asynchronously pushes a scatter-gather array to a socket I/O queue.
@@ -137,8 +149,9 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_pushto(demi_qtoken_t *qt_out, int sockqd, const demi_sgarray_t *sga,
-                           const struct sockaddr *dest_addr, socklen_t size);
+    ATTR_NONNULL(1, 3, 4)
+    extern int demi_pushto(_Out_ demi_qtoken_t *qt_out, _In_ int sockqd, _In_ const demi_sgarray_t *sga,
+                           _In_reads_bytes_(size) const struct sockaddr *dest_addr, _In_ socklen_t size);
 
     /**
      * @brief Asynchronously pops a scatter-gather array from an I/O queue.
@@ -148,7 +161,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_pop(demi_qtoken_t *qt_out, int qd);
+    ATTR_NONNULL(1)
+    extern int demi_pop(_Out_ demi_qtoken_t *qt_out, _In_ int qd);
 
 #ifdef __cplusplus
 }

--- a/include/demi/sga.h
+++ b/include/demi/sga.h
@@ -5,6 +5,7 @@
 #define DEMI_SGA_H_IS_INCLUDED
 
 #include <demi/types.h>
+#include <demi/cc.h>
 #include <stddef.h>
 
 #ifdef __cplusplus
@@ -20,7 +21,8 @@ extern "C"
      * @return On successful completion, the allocated scatter-gather array is returned. On error, a null scatter-gather
      * array is returned instead.
      */
-    extern demi_sgarray_t demi_sgaalloc(size_t size);
+    ATTR_NODISCARD
+    extern demi_sgarray_t demi_sgaalloc(_In_ size_t size);
 
     /**
      * @brief Releases a scatter-gather array.
@@ -29,7 +31,7 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_sgafree(demi_sgarray_t *sga);
+    extern int demi_sgafree(_In_ demi_sgarray_t *sga);
 
 #ifdef __cplusplus
 }

--- a/include/demi/types.h
+++ b/include/demi/types.h
@@ -6,6 +6,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <demi/cc.h>
 
 #ifdef __linux__
 #include <netinet/in.h>

--- a/include/demi/wait.h
+++ b/include/demi/wait.h
@@ -5,6 +5,7 @@
 #define DEMI_WAIT_H_IS_INCLUDED
 
 #include <demi/types.h>
+#include <demi/cc.h>
 #include <time.h>
 
 #ifdef __cplusplus
@@ -21,7 +22,8 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_wait(demi_qresult_t *qr_out, demi_qtoken_t qt, const struct timespec *timeout);
+    ATTR_NONNULL(1)
+    extern int demi_wait(_Out_ demi_qresult_t *qr_out, _In_ demi_qtoken_t qt, _In_opt_ const struct timespec *timeout);
 
     /**
      * @brief Waits for the first asynchronous I/O operation in a list to complete.
@@ -34,8 +36,26 @@ extern "C"
      *
      * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
      */
-    extern int demi_wait_any(demi_qresult_t *qr_out, int *ready_offset, const demi_qtoken_t qts[], int num_qts,
-                             const struct timespec *timeout);
+    ATTR_NONNULL(1, 2, 3)
+    extern int demi_wait_any(_Out_ demi_qresult_t *qr_out, _Out_ int *ready_offset,
+                             _In_reads_(num_qts) const demi_qtoken_t qts[], _In_ int num_qts,
+                             _In_opt_ const struct timespec *timeout);
+
+    /**
+     * @brief Waits for the next n asynchronous I/O operations to complete.
+     *
+     * @param qr_out       Store location for the results of the completed I/O operation.
+     * @param num_qrs      The size of the array poitned to by qr_out; i.e., the number of demi_qresult_t entries
+     *                     pointed to by qr_out.
+     * @param num_qrs_out  The number of valid demi_qresult_t entries returned from the method call 
+     *                     (qr_out[0..num_qrs_out-1] will be valid when the method returns successfully).
+     * @param timeout      Timeout interval in seconds and nanoseconds.
+     *
+     * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
+     */
+    ATTR_NONNULL(1, 3)
+    extern int demi_wait_next_n(_Out_writes_to_(num_qrs, *ready_offset) demi_qresult_t *qr_out, _In_ int num_qrs,
+                                _Out_ int *num_qrs_out, _In_opt_ const struct timespec *timeout);
 
 #ifdef __cplusplus
 }

--- a/src/rust/catmem/mod.rs
+++ b/src/rust/catmem/mod.rs
@@ -214,6 +214,19 @@ impl SharedCatmemLibOS {
         Ok((offset, self.create_result(result, qd, qt)))
     }
 
+    /// Waits in a loop until the next task is complete, passing the result to `acceptor`. This process continues until
+    /// either the acceptor returns false (in which case the method returns Ok), or the timeout has expired (in which
+    /// the method returns an `Err` indicating timeout).
+    pub fn wait_next_n<Acceptor: FnMut(demi_qresult_t) -> bool>(
+        &mut self,
+        mut acceptor: Acceptor,
+        timeout: Duration
+    ) -> Result<(), Fail>
+    {
+        self.runtime.clone().wait_next_n(
+            |qt, qd, result| acceptor(self.create_result(result, qd, qt)), timeout)
+    }
+
     /// Waits for any operation in an I/O queue.
     pub fn poll(&mut self) {
         self.runtime.poll()

--- a/src/rust/demikernel/bindings.rs
+++ b/src/rust/demikernel/bindings.rs
@@ -45,7 +45,10 @@ use ::socket2::SockAddr;
 use ::std::{
     cell::RefCell,
     ffi::CStr,
-    mem,
+    mem::{
+        self,
+        MaybeUninit
+    },
     net::SocketAddr,
     ptr,
     slice,
@@ -622,6 +625,72 @@ pub extern "C" fn demi_wait_any(
     }
 }
 
+//======================================================================================================================
+// wait_next_n
+//======================================================================================================================
+
+#[no_mangle]
+pub extern "C" fn demi_wait_next_n(
+    qr_out: *mut demi_qresult_t,
+    qr_out_size: c_int,
+    qr_written: *mut c_int,
+    timeout: *const libc::timespec,
+) -> c_int {
+    trace!(
+        "demi_wait_next_n() {:?} {:?} {:?}",
+        qr_out,
+        qr_out_size,
+        timeout
+    );
+
+    // Check for invalid storage location for queue result.
+    if qr_out.is_null() {
+        warn!("qr_out is a null pointer");
+        return libc::EINVAL;
+    }
+
+    // Check arguments.
+    if qr_out_size <= 0 {
+        return libc::EINVAL;
+    }
+
+    if qr_written.is_null() {
+        warn!("qr_written is a null pointer");
+        return libc::EINVAL;
+    }
+
+    // Convert timespec to Duration.
+    let duration: Option<Duration> = if timeout.is_null() {
+        None
+    } else {
+        // Safety: We have to trust that our user is providing a valid timeout pointer for us to dereference.
+        Some(unsafe { Duration::new((*timeout).tv_sec as u64, (*timeout).tv_nsec as u32) })
+    };
+
+    let out_slice: &mut [MaybeUninit<demi_qresult_t>] = unsafe { slice::from_raw_parts_mut(qr_out.cast(), qr_out_size as usize) };
+    let mut result_idx: c_int = 0;
+    let wait_callback = |result: demi_qresult_t| -> bool {
+        out_slice[result_idx as usize] = MaybeUninit::new(result);
+        result_idx += 1;
+        result_idx < qr_out_size
+    };
+
+    // Issue wait_any operation.
+    let ret: Result<i32, Fail> = do_syscall(|libos| match libos.wait_next_n(wait_callback, duration) {
+        Ok(()) => 0,
+        Err(e) => {
+            trace!("demi_wait_any() failed: {:?}", e);
+            e.errno
+        },
+    });
+
+    unsafe { *qr_written = result_idx };
+
+    match ret {
+        Ok(ret) => ret,
+        Err(e) => e.errno,
+    }
+}
 //======================================================================================================================
 // sgaalloc
 //======================================================================================================================

--- a/src/rust/demikernel/libos/memory.rs
+++ b/src/rust/demikernel/libos/memory.rs
@@ -101,7 +101,6 @@ impl MemoryLibOS {
         Ok(qr)
     }
 
-    #[allow(unreachable_patterns, unused_variables)]
     /// Waits for any of the given pending I/O operations to complete or a timeout to expire.
     #[allow(unreachable_patterns, unused_variables)]
     pub fn wait_any(&mut self, qts: &[QToken], timeout: Duration) -> Result<(usize, demi_qresult_t), Fail> {
@@ -112,6 +111,25 @@ impl MemoryLibOS {
             _ => unreachable!("unknown memory libos"),
         }
     }
+
+    /// Waits in a loop until the next task is complete, passing the result to `acceptor`. This process continues until
+    /// either the acceptor returns false (in which case the method returns Ok), or the timeout has expired (in which
+    /// the method returns an `Err` indicating timeout).
+    #[allow(unreachable_patterns, unused_variables)]
+    pub fn wait_next_n<Acceptor: FnMut(demi_qresult_t) -> bool>(
+        &mut self,
+        acceptor: Acceptor,
+        timeout: Duration
+    ) -> Result<(), Fail>
+    {
+        trace!("wait_next_n(): acceptor, timeout={:?}", timeout);
+        match self {
+            #[cfg(feature = "catmem-libos")]
+            MemoryLibOS::Catmem(libos) => libos.wait_next_n(acceptor, timeout),
+            _ => unreachable!("unknown memory libos"),
+        }
+    }
+
 
     /// Allocates a scatter-gather array.
     #[allow(unreachable_patterns, unused_variables)]

--- a/src/rust/demikernel/libos/network/libos.rs
+++ b/src/rust/demikernel/libos/network/libos.rs
@@ -502,6 +502,19 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
         Ok((offset, self.create_result(result, qd, qt)))
     }
 
+    /// Waits in a loop until the next task is complete, passing the result to `acceptor`. This process continues until
+    /// either the acceptor returns false (in which case the method returns Ok), or the timeout has expired (in which
+    /// the method returns an `Err` indicating timeout).
+    pub fn wait_next_n<Acceptor: FnMut(demi_qresult_t) -> bool>(
+        &mut self,
+        mut acceptor: Acceptor,
+        timeout: Duration
+    ) -> Result<(), Fail>
+    {
+        self.runtime.clone().wait_next_n(
+            |qt, qd, result| acceptor(self.create_result(result, qd, qt)), timeout)
+    }
+
     pub fn create_result(&self, result: OperationResult, qd: QDesc, qt: QToken) -> demi_qresult_t {
         match result {
             OperationResult::Connect => demi_qresult_t {

--- a/src/rust/demikernel/libos/network/mod.rs
+++ b/src/rust/demikernel/libos/network/mod.rs
@@ -238,6 +238,28 @@ impl NetworkLibOSWrapper {
         }
     }
 
+    /// Waits in a loop until the next task is complete, passing the result to `acceptor`. This process continues until
+    /// either the acceptor returns false (in which case the method returns Ok), or the timeout has expired (in which
+    /// the method returns an `Err` indicating timeout).
+    pub fn wait_next_n<Acceptor: FnMut(demi_qresult_t) -> bool>(
+        &mut self,
+        acceptor: Acceptor,
+        timeout: Duration
+    ) -> Result<(), Fail>
+    {
+        match self {
+            #[cfg(feature = "catpowder-libos")]
+            NetworkLibOSWrapper::Catpowder(libos) => libos.wait_next_n(acceptor, timeout),
+            #[cfg(all(feature = "catnap-libos"))]
+            NetworkLibOSWrapper::Catnap(libos) => libos.wait_next_n(acceptor, timeout),
+            #[cfg(feature = "catnip-libos")]
+            NetworkLibOSWrapper::Catnip(libos) => libos.wait_next_n(acceptor, timeout),
+            #[cfg(feature = "catloop-libos")]
+            NetworkLibOSWrapper::Catloop(libos) => libos.wait_next_n(acceptor, timeout),
+        }
+    }
+
+
     /// Waits for any operation in an I/O queue.
     pub fn poll(&mut self) {
         match self {

--- a/src/rust/lib.rs
+++ b/src/rust/lib.rs
@@ -8,6 +8,7 @@
 #![feature(strict_provenance)]
 #![cfg_attr(target_os = "windows", feature(maybe_uninit_uninit_array))]
 #![feature(noop_waker)]
+#![feature(hash_extract_if)]
 
 mod collections;
 mod pal;

--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -286,8 +286,63 @@ impl SharedDemiRuntime {
         self.completed_tasks.remove(qt)
     }
 
-    /// Runs the scheduler for one [TIMER_RESOLUTION] quanta. Importantly does not modify the clock.
+    /// Waits until the next task is complete, passing the result to `acceptor`. The acceptor may return true to
+    /// continue waiting or false to exit the wait. The method will return when either the acceptor returns false
+    /// (returning Ok) or the timeout has expired (returning a Fail indicating timeout).
+    pub fn wait_next_n<Acceptor: FnMut(QToken, QDesc, OperationResult) -> bool>(
+        &mut self,
+        mut acceptor: Acceptor,
+        timeout: Duration,
+    ) -> Result<(), Fail> {
+        // 1. Check if any tasks are completed.
+        for (qt, (qd, result)) in self.completed_tasks.extract_if(|_, _| { true }) {
+            if acceptor(qt, qd, result) == false {
+                return Ok(());
+            }
+        }
+
+        // 2. None of the tasks have already completed, so start a timer and move the clock.
+        self.advance_clock_to_now();
+        let start: Instant = self.get_now();
+
+        // 3. Invoke the scheduler and run some tasks.
+        loop {
+            // Run for one quanta and if one of our queue tokens completed, then return.
+            if let Some((qt, qd, result)) = self.run_next() {
+                if acceptor(qt, qd, result) == false {
+                    return Ok(());
+                }
+            }
+            // Otherwise, move time forward.
+            self.advance_clock_to_now();
+            let now: Instant = self.get_now();
+            if now >= start + timeout {
+                return Err(Fail::new(libc::ETIMEDOUT, "wait timed out"));
+            }
+        }
+    }
+
+    /// Runs the scheduler for one [TIMER_RESOLUTION] quanta, returning any task in `qts`. Importantly does not modify
+    /// the clock.
     pub fn run_any(&mut self, qts: &[QToken]) -> Option<(usize, QDesc, OperationResult)> {
+        if let Some((qt, qd, result)) = self.run_next() {
+            // Check whether it matches any of the queue tokens that we are waiting on.
+            for i in 0..qts.len() {
+                if qts[i] == qt {
+                    return Some((i, qd, result));
+                }
+            }
+
+            // If not a queue token that we are waiting on, then insert into our list of completed tasks.
+            self.completed_tasks.insert(qt, (qd, result));
+        }
+
+        None
+    }
+
+    /// Runs the scheduler for one [TIMER_RESOLUTION] quanta, returning any ready task. Importantly does not modify
+    /// the clock.
+    fn run_next(&mut self) -> Option<(QToken, QDesc, OperationResult)> {
         if let Some(boxed_task) = self.scheduler.get_next_completed_task(TIMER_RESOLUTION) {
             // Perform bookkeeping for the completed and removed task.
             trace!("Removing coroutine: {:?}", boxed_task.get_name());
@@ -298,17 +353,10 @@ impl SharedDemiRuntime {
                 let (qd, result): (QDesc, OperationResult) =
                     expect_some!(operation_task.get_result(), "coroutine not finished");
 
-                // Check whether it matches any of the queue tokens that we are waiting on.
-                for i in 0..qts.len() {
-                    if qts[i] == qt {
-                        return Some((i, qd, result));
-                    }
-                }
-
-                // If not a queue token that we are waiting on, then insert into our list of completed tasks.
-                self.completed_tasks.insert(qt, (qd, result));
+                return Some((qt, qd, result));
             }
         }
+
         None
     }
 

--- a/tests/c/syscalls.c
+++ b/tests/c/syscalls.c
@@ -16,6 +16,9 @@
  * System Calls in demi/libos.h                                                                                      *
  *===================================================================================================================*/
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnonnull"
+
 /**
  * @brief Issues an invalid call to demi_socket().
  */
@@ -177,6 +180,8 @@ static bool inval_wait_any(void)
 
     return (demi_wait_any(qr, ready_offset, qts, num_qts, timeout) != 0);
 }
+
+#pragma GCC diagnostic pop
 
 /*===================================================================================================================*
  * main()                                                                                                            *


### PR DESCRIPTION
This PR adds a new binding to get the next (n) completed operation(s). I also added some annotations to the bindings to engage some correctness checking on the behalf of GCC/clang/MSVC.