### PR TITLE
[demikernel] Bug Fix: Don't leak libos when calling init more than once

### DIFF
--- a/man/demi_init.md
+++ b/man/demi_init.md
@@ -48,6 +48,7 @@ On error, one of the following positive error codes is returned:
 
 - `EINVAL` - The `argc` argument is less than or equal to zero.
 - `EINVAL` - The `argv` argument is `NULL`.
+- `EEXIST` - The LibOS has already been initialized.
 
 ## Conforming To
 

--- a/src/rust/demikernel/bindings.rs
+++ b/src/rust/demikernel/bindings.rs
@@ -85,6 +85,15 @@ pub extern "C" fn demi_init(argc: c_int, argv: *mut *mut c_char) -> c_int {
         Err(e) => panic!("{:?}", e),
     };
 
+    // Check if demikernel has already been initialized and return
+    match unsafe { DEMIKERNEL.try_borrow() } {
+        Ok(libos) => match *libos {
+            Some(_) => return libc::EEXIST,
+            None => (),
+        },
+        Err(e) => panic!("{:?}", e),
+    }
+
     // TODO: Pass arguments to the underlying libOS.
     let libos: LibOS = match LibOS::new(libos_name) {
         Ok(libos) => libos,


### PR DESCRIPTION
Multiple calls to demi_init would create a new libOS and the old one would leak. This change makes it so that a call to demi_init immediately returns if there is a libOS already initialized.