### PR TITLE
[runtime] Enhancement: Increase timer resolution

### DIFF
--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -88,7 +88,9 @@ use std::pin::Pin;
 // Constants
 //======================================================================================================================
 
-const TIMER_RESOLUTION: usize = 64;
+// TODO: Make this more accurate using rdtsc.
+// FIXME: https://github.com/microsoft/demikernel/issues/1226
+const TIMER_RESOLUTION: usize = 1024;
 
 //======================================================================================================================
 // Structures

--- a/tests/rust/tcp-test/connect/mod.rs
+++ b/tests/rust/tcp-test/connect/mod.rs
@@ -87,9 +87,7 @@ fn connect_unbound_socket(libos: &mut LibOS, remote: &SocketAddr) -> Result<()> 
     match libos.wait(qt, Some(Duration::from_micros(0))) {
         Err(e) if e.errno == libc::ETIMEDOUT => {},
         // Can only complete with ECONNREFUSED because remote does not exist.
-        Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && qr.qr_ret == libc::ECONNREFUSED as i64 => {
-            connect_finished = true
-        },
+        Ok(qr) if check_for_network_error(&qr) => connect_finished = true,
         // If completes successfully, something has gone wrong.
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CONNECT && qr.qr_ret == 0 => {
             anyhow::bail!("connect() should not succeed because remote does not exist")
@@ -175,9 +173,7 @@ fn connect_bound_socket(libos: &mut LibOS, local: &SocketAddr, remote: &SocketAd
     match libos.wait(qt, Some(Duration::from_micros(0))) {
         Err(e) if e.errno == libc::ETIMEDOUT => {},
         // Can only complete with ECONNREFUSED because remote does not exist.
-        Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && qr.qr_ret == libc::ECONNREFUSED as i64 => {
-            connect_finished = true
-        },
+        Ok(qr) if check_for_network_error(&qr) => connect_finished = true,
         // If completes successfully, something has gone wrong.
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CONNECT && qr.qr_ret == 0 => {
             anyhow::bail!("connect() should not succeed because remote does not exist")
@@ -242,9 +238,7 @@ fn connect_connecting_socket(libos: &mut LibOS, remote: &SocketAddr) -> Result<(
     match libos.wait(qt, Some(Duration::from_micros(0))) {
         Err(e) if e.errno == libc::ETIMEDOUT => {},
         // Can only complete with ECONNREFUSED because remote does not exist.
-        Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && qr.qr_ret == libc::ECONNREFUSED as i64 => {
-            connect_finished = true
-        },
+        Ok(qr) if check_for_network_error(&qr) => connect_finished = true,
         // If completes successfully, something has gone wrong.
         Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_CONNECT && qr.qr_ret == 0 => {
             anyhow::bail!("connect() should not succeed because remote does not exist")


### PR DESCRIPTION
Currently our timer resolution is 64 scheduler tasks. Assuming each task runs for roughly 100ns, we are checking the clock every 6.4us, which is too frequently to make a sys call. Thus, this PR increases the timer resolution to 1024, which is roughly once every 100us. This should reduce the sys call overhead, while still providing a reasonable timer granularity. 