### PR TITLE
[testing] Bug Fix: Add proper error checking

### DIFF
--- a/tests/rust/tcp-test/accept/mod.rs
+++ b/tests/rust/tcp-test/accept/mod.rs
@@ -154,12 +154,7 @@ fn accept_connecting_socket(libos: &mut LibOS, remote: &SocketAddr) -> Result<()
     match libos.wait(qt, Some(Duration::from_micros(0))) {
         Err(e) if e.errno == libc::ETIMEDOUT => {},
         // Can only complete with ECONNREFUSED because remote does not exist.
-        Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && qr.qr_ret == libc::ECONNREFUSED as i64 => {
-            connect_finished = true
-        },
-        Ok(qr) if qr.qr_opcode == demi_opcode_t::DEMI_OPC_FAILED && qr.qr_ret == libc::ECONNABORTED as i64 => {
-            connect_finished = true
-        },
+        Ok(qr) if check_for_network_error(&qr) => connect_finished = true,
         Ok(_) => anyhow::bail!("wait() should not succeed"),
         Err(_) => anyhow::bail!("wait() should be cancelled"),
     }


### PR DESCRIPTION
Move all of our error testing on integration tests to check_for_network_error. We introduced the function some time ago but there were still some lingering integration tests that did not use it.