### PR TITLE
[catnap] Bug Fix: Check if socket is already nonblocking

### DIFF
--- a/src/rust/catnap/linux/transport.rs
+++ b/src/rust/catnap/linux/transport.rs
@@ -297,7 +297,7 @@ impl NetworkTransport for SharedCatnapTransport {
 
                 let socket_fd = socket.as_raw_fd();
                 let flags = unsafe { libc::fcntl(socket_fd, libc::F_GETFL) };
-                if flags & libc::O_NONBLOCK != 0 {
+                if flags & libc::O_NONBLOCK == 0 {
                     if let Err(e) = socket.set_nonblocking(true) {
                         let cause: String = format!("cannot set NONBLOCKING option: {:?}", e);
                         socket.shutdown(Shutdown::Both)?;


### PR DESCRIPTION
Currently, if the socket is set to non-blocking when created, set_nonblocking will return an error. Therefore, check if the socket is nonblocking before calling set_nonblocking.