### PR TITLE
[testing] Turn timer tests back on

### DIFF
--- a/src/rust/runtime/timer.rs
+++ b/src/rust/runtime/timer.rs
@@ -166,9 +166,9 @@ pub async fn wait_until(expiry: Instant) {
     .await
 }
 
-//==============================================================================
+//======================================================================================================================
 // Trait Implementations
-//==============================================================================
+//======================================================================================================================
 
 impl Default for SharedTimer {
     fn default() -> Self {
@@ -254,95 +254,84 @@ impl Drop for YieldPoint {
     }
 }
 
-//==============================================================================
+//======================================================================================================================
 // Unit Tests
-//==============================================================================
+//======================================================================================================================
 
-// FIXME: Turning these off because they do not use the scheduler.
+#[cfg(test)]
+mod tests {
+    use crate::runtime::timer::{
+        global_advance_clock,
+        wait,
+    };
+    use ::anyhow::Result;
+    use futures::task::noop_waker_ref;
+    use std::{
+        future::Future,
+        pin::Pin,
+        task::Context,
+        time::{
+            Duration,
+            Instant,
+        },
+    };
 
-// #[cfg(test)]
-// mod tests {
-//     use super::{
-//         SharedConditionVariable,
-//         SharedTimer,
-//     };
-//     use ::anyhow::Result;
-//     use futures::task::noop_waker_ref;
-//     use std::{
-//         future::Future,
-//         pin::Pin,
-//         task::Context,
-//         time::{
-//             Duration,
-//             Instant,
-//         },
-//     };
+    #[test]
+    fn test_timer() -> Result<()> {
+        let mut ctx = Context::from_waker(noop_waker_ref());
+        let mut now = Instant::now();
 
-//     #[test]
-//     fn test_timer() -> Result<()> {
-//         let mut ctx = Context::from_waker(noop_waker_ref());
-//         let mut now = Instant::now();
+        // Add a single time out at start of test + 2 seconds.
+        let wait_future1 = wait(Duration::from_secs(2));
+        futures::pin_mut!(wait_future1);
 
-//         // Add a single time out at start of test + 2 seconds.
-//         let mut timer: SharedTimer = SharedTimer::new(now);
-//         let cond_var: SharedConditionVariable = SharedConditionVariable::default();
-//         let wait_future1 = timer.clone().wait(Duration::from_secs(2), cond_var);
-//         futures::pin_mut!(wait_future1);
+        // Check that the time out has not triggered.
+        crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future1), &mut ctx).is_ready(), false);
 
-//         // Check that the time out has not triggered.
-//         crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future1), &mut ctx).is_ready(), false);
+        // Move time to start of test + 0.5 seconds.
+        now += Duration::from_millis(500);
+        global_advance_clock(now);
 
-//         // Move time to start of test + 0.5 seconds.
-//         now += Duration::from_millis(500);
-//         timer.advance_clock(now);
+        // Check that the first time out has not triggered.
+        crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future1), &mut ctx).is_ready(), false);
 
-//         // Check that the first time out has not triggered.
-//         crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future1), &mut ctx).is_ready(), false);
+        // Create second time out at start of test + 1.5 seconds.
+        let wait_future2 = wait(Duration::from_secs(1));
+        futures::pin_mut!(wait_future2);
 
-//         // Create second time out at start of test + 1.5 seconds.
-//         let cond_var2: SharedConditionVariable = SharedConditionVariable::default();
-//         let wait_future2 = timer.clone().wait(Duration::from_secs(1), cond_var2);
-//         futures::pin_mut!(wait_future2);
+        // Check that both have not triggered.
+        crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future1), &mut ctx).is_ready(), false);
+        crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future2), &mut ctx).is_ready(), false);
 
-//         // Check that both have not triggered.
-//         crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future1), &mut ctx).is_ready(), false);
-//         crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future2), &mut ctx).is_ready(), false);
+        // Move time to start of test + 1 second.
+        now += Duration::from_millis(500);
+        global_advance_clock(now);
 
-//         // Move time to start of test + 1 second.
-//         now += Duration::from_millis(500);
-//         timer.advance_clock(now);
+        // Check that both time outs have not triggered
+        crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future1), &mut ctx).is_ready(), false);
+        crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future2), &mut ctx).is_ready(), false);
 
-//         // Check that both time outs have not triggered
-//         crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future1), &mut ctx).is_ready(), false);
-//         crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future2), &mut ctx).is_ready(), false);
+        // Create a new timeout for start of test + 5 seconds.
+        let wait_future3 = wait(Duration::from_secs(4));
+        futures::pin_mut!(wait_future3);
 
-//         // Create a new timeout for start of test + 5 seconds.
-//         let mut cond_var3: SharedConditionVariable = SharedConditionVariable::default();
-//         let wait_future3 = timer.clone().wait(Duration::from_secs(4), cond_var3.clone());
-//         futures::pin_mut!(wait_future3);
+        // Move time to start of test + 1.5 seconds.
+        now += Duration::from_millis(500);
+        global_advance_clock(now);
 
-//         // Move time to start of test + 1.5 seconds.
-//         now += Duration::from_millis(500);
-//         timer.advance_clock(now);
+        // Check that timer2 has triggered but not timer1.
+        crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future1), &mut ctx).is_ready(), false);
+        crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future2), &mut ctx).is_ready(), true);
+        crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future3), &mut ctx).is_ready(), false);
 
-//         // Check that timer2 has triggered but not timer1.
-//         crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future1), &mut ctx).is_ready(), false);
-//         crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future2), &mut ctx).is_ready(), true);
-//         crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future3), &mut ctx).is_ready(), false);
+        // Move time to start of test + 2.15 seconds.
+        now += Duration::from_millis(750);
+        global_advance_clock(now);
 
-//         // Move time to start of test + 2.15 seconds.
-//         now += Duration::from_millis(750);
-//         timer.advance_clock(now);
+        // Check that timer1 has triggered.
+        crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future1), &mut ctx).is_ready(), true);
+        crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future3), &mut ctx).is_ready(), false);
 
-//         // Check that timer1 has triggered.
-//         crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future1), &mut ctx).is_ready(), true);
-//         crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future3), &mut ctx).is_ready(), false);
-
-//         // Cancel the condition variable waiters and ensure that the timer does not fire.
-//         cond_var3.cancel();
-//         now += Duration::from_millis(10000);
-//         crate::ensure_eq!(Future::poll(Pin::new(&mut wait_future3), &mut ctx).is_ready(), false);
-
-//         Ok(())
-//     }
-// }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Turn the timer unit tests back on now that we are not using a global scheduler any more