### PR TITLE
[catpowder] Close Raw Socket

### DIFF
--- a/src/rust/catpowder/runtime/mod.rs
+++ b/src/rust/catpowder/runtime/mod.rs
@@ -26,6 +26,7 @@ use crate::{
             types::MacAddress,
         },
         Runtime,
+        SharedObject,
     },
 };
 use ::std::{
@@ -49,7 +50,7 @@ pub struct LinuxRuntime {
     link_addr: MacAddress,
     ipv4_addr: Ipv4Addr,
     ifindex: i32,
-    socket: RawSocket,
+    socket: SharedObject<RawSocket>,
 }
 
 //==============================================================================
@@ -85,7 +86,7 @@ impl LinuxRuntime {
             link_addr: config.local_link_addr(),
             ipv4_addr: config.local_ipv4_addr(),
             ifindex,
-            socket,
+            socket: SharedObject::<RawSocket>::new(socket),
         }
     }
 

--- a/src/rust/catpowder/runtime/rawsocket/rawsocket.rs
+++ b/src/rust/catpowder/runtime/rawsocket/rawsocket.rs
@@ -24,7 +24,6 @@ use ::std::{
 //======================================================================================================================
 
 /// Raw socket.
-#[derive(Clone)]
 pub struct RawSocket(libc::c_int);
 
 //======================================================================================================================
@@ -44,7 +43,7 @@ impl RawSocket {
         if sockfd == -1 {
             return Err(Fail::new(libc::EAGAIN, "failed to create raw socket"));
         }
-
+        trace!("Creating raw socket with fd={:?}", sockfd);
         Ok(RawSocket(sockfd))
     }
 
@@ -106,5 +105,21 @@ impl RawSocket {
         }
 
         Ok((nbytes as usize, rawaddr))
+    }
+}
+
+//======================================================================================================================
+// Trait Implementations
+//======================================================================================================================
+
+/// Closes the raw socket.
+impl Drop for RawSocket {
+    fn drop(&mut self) {
+        if unsafe { libc::close(self.0) } < 0 {
+            let errno: libc::c_int = unsafe { *libc::__errno_location() };
+            warn!("could not close raw socket (fd={:?}): {:?}", self.0, errno);
+        } else {
+            trace!("Closing raw socket fd={:?}", self.0)
+        }
     }
 }


### PR DESCRIPTION
Currently, we do not close the raw socket on exit, which possibly causes a lingering socket in Linux when we crash. Closes #671 