### PR TITLE
[demikernel] Fixing ``'unknown libos'`` message

### DIFF
--- a/src/rust/demikernel/libos/name.rs
+++ b/src/rust/demikernel/libos/name.rs
@@ -49,7 +49,7 @@ impl From<String> for LibOSName {
             "catnip" => LibOSName::Catnip,
             "catmem" => LibOSName::Catmem,
             "catloop" => LibOSName::Catloop,
-            _ => panic!("unkown libos"),
+            _ => panic!("unknown libos"),
         }
     }
 }


### PR DESCRIPTION
_src/rust/demikernel/libos/name.rs_

Fixed

```rs
_ => panic!("unknown libos"),
```