### PR TITLE
[pdpix] Expose System Calls for Setting / Getting Socket Options

### DIFF
--- a/include/demi/libos.h
+++ b/include/demi/libos.h
@@ -33,7 +33,6 @@ extern "C"
     ATTR_NONNULL(2)
     extern int demi_init(_In_ int argc, _In_reads_(argc) _Deref_pre_z_ char *const argv[]);
 
-
     /**
      * @brief Creates a new memory I/O queue.
      *
@@ -115,7 +114,6 @@ extern "C"
     ATTR_NONNULL(1, 3)
     extern int demi_connect(_Out_ demi_qtoken_t *qt_out, _In_ int sockqd,
                             _In_reads_bytes_(size) const struct sockaddr *addr, _In_ socklen_t size);
-
 
     /**
      * @brief Closes an I/O queue descriptor.

--- a/include/demi/libos.h
+++ b/include/demi/libos.h
@@ -162,6 +162,34 @@ extern "C"
     ATTR_NONNULL(1)
     extern int demi_pop(_Out_ demi_qtoken_t *qt_out, _In_ int qd);
 
+    /**
+     * @brief Sets socket options.
+     *
+     * @param qd     Target I/O queue descriptor.
+     * @param level  Protocol level at which the option resides.
+     * @param optname Socket option for which the value is to be set.
+     * @param optval Pointer to the buffer containing the option value.
+     * @param optlen Size of the buffer containing the option value.
+     *
+     * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
+     */
+    ATTR_NONNULL(4)
+    extern int demi_setsockopt(_In_ int qd, _In_ int level, _In_ int optname, _In_reads_bytes_(optlen) const void *optval, _In_ socklen_t optlen);
+
+    /**
+     * @brief Gets socket options.
+     *
+     * @param qd     Target I/O queue descriptor.
+     * @param level  Protocol level at which the option resides.
+     * @param optname Socket option for which the value is to be retrieved.
+     * @param optval Pointer to the buffer containing the option value.
+     * @param optlen Size of the buffer containing the option value.
+     *
+     * @return On successful completion, zero is returned. On failure, a positive error code is returned instead.
+     */
+    ATTR_NONNULL(4)
+    extern int demi_getsockopt(_In_ int qd, _In_ int level, _In_ int optname, _Out_writes_to_(optlen, *optlen) void *optval, _In_ socklen_t *optlen);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/c/syscalls.c
+++ b/tests/c/syscalls.c
@@ -126,6 +126,34 @@ static bool inval_pop(void)
     return (demi_pop(qt, qd) != 0);
 }
 
+/**
+ * @brief Issues an invalid call to demi_setsockopt().
+ */
+static bool inval_setsockopt(void)
+{
+    int qd = -1;
+    int level = -1;
+    int optname = -1;
+    const void *optval = NULL;
+    socklen_t optlen = 0;
+
+    return (demi_setsockopt(qd, level, optname, optval, optlen) != 0);
+}
+
+/**
+ * @brief Issues an invalid call to demi_getsockopt().
+ */
+static bool inval_getsockopt(void)
+{
+    int qd = -1;
+    int level = -1;
+    int optname = -1;
+    void *optval = NULL;
+    socklen_t *optlen = NULL;
+
+    return (demi_getsockopt(qd, level, optname, optval, optlen) != 0);
+}
+
 /*===================================================================================================================*
  * System Calls in demi/sga.h                                                                                        *
  *===================================================================================================================*/
@@ -199,11 +227,7 @@ struct test
 /**
  * @brief Tests for system calls in demi/libos.h
  */
-static struct test tests_libos[] = {{inval_socket, "invalid demi_socket()"},   {inval_accept, "invalid demi_accept()"},
-                                    {inval_bind, "invalid demi_bind()"},       {inval_close, "invalid_demi_close()"},
-                                    {inval_connect, "invalid demi_connect()"}, {inval_listen, "invalid demi_listen()"},
-                                    {inval_pop, "invalid demi_pop()"},         {inval_push, "invalid demi_push()"},
-                                    {inval_pushto, "invalid demi_pushto()"}};
+static struct test tests_libos[] = {{inval_socket, "invalid demi_socket()"}, {inval_accept, "invalid demi_accept()"}, {inval_bind, "invalid demi_bind()"}, {inval_close, "invalid_demi_close()"}, {inval_connect, "invalid demi_connect()"}, {inval_listen, "invalid demi_listen()"}, {inval_pop, "invalid demi_pop()"}, {inval_push, "invalid demi_push()"}, {inval_pushto, "invalid demi_pushto()"}, {inval_setsockopt, "invalid demi_setsockopt()"}, {inval_getsockopt, "invalid demi_getsockopt()}"}};
 
 /**
  * @brief Tests for system calls in demi/sga.h


### PR DESCRIPTION
## Description

- This PR closes #73 
- This PR closes #74 

This PR introduces a C unit tests for `demi_getsockopt()` and `demi_setsockopt()`.

## Related PRs

https://github.com/microsoft/demikernel/pull/1257