### PR TITLE
[pdpix] `getpeername()`

### DIFF
--- a/include/demi/libos.h
+++ b/include/demi/libos.h
@@ -190,6 +190,17 @@ extern "C"
     ATTR_NONNULL(4)
     extern int demi_getsockopt(_In_ int qd, _In_ int level, _In_ int optname, _Out_writes_to_(optlen, *optlen) void *optval, _In_ socklen_t *optlen);
 
+    /**
+     * @brief Returns the address of the peer connected to qd.
+     *
+     * @param addr    Peer address is returned in this parameter.
+     * @param addrlen Indicates the amount of space pointed to by addr
+     *
+     * @return On success, zero is returned. On failure, a possitive error code is returned.
+     */
+    ATTR_NONNULL(2, 3)
+    extern int demi_getpeername(_In_ int qd, _Out_ struct sockaddr *addr, _Out_ socklen_t *addrlen);
+
 #ifdef __cplusplus
 }
 #endif

--- a/man/demi_getpeername.md
+++ b/man/demi_getpeername.md
@@ -1,0 +1,48 @@
+# `demi_getpeername()`
+
+## Name
+
+`demi_getpeername` - Gets address of peer connected to this socket.
+
+## Synopsis
+
+```c
+#include <demi/libos.h>
+#include <sys/socket.h> /* For struct sockaddr and socklen_t. */
+
+int demi_getpeername(int qd, struct sockaddr *addr, socklent_t addrlen);
+```
+
+## Description
+
+`demi_getpeername()` returns the address of the peer connected to the socket qd.
+
+The `addrlen` argument should be initialized to indicated the amount of space
+pointed to by `addr`. On return `addrlen` contains the size of the `addr`
+returned (in bytes). The addr is truncated if the buffer provided is too small.
+
+## Return Value
+
+On success, zero is returned. On error, a positive error code is returned.
+
+## Errors
+
+On error, one of the following positive error codes is returned:
+
+- `EBADF` - Invalid file descriptor.
+- `EINVAL` - `addrlen` is invalid.
+- `EINVAL` - `addr` points to invalid memory.
+- `ENOTCONN` - The socket is not connected
+
+## Conforming To
+
+The socket address structure, the socket length type and error codes are conformant to
+[POSIX.1-2017](https://pubs.opengroup.org/onlinepubs/9699919799/nframe.html).
+
+## Bugs
+
+Demikernel may fail with error codes that are not listed in this manual page.
+
+## Disclaimer
+
+Any behavior that is not documented in this manual page is unintentional and should be reported.

--- a/shim/include/glue.h
+++ b/shim/include/glue.h
@@ -31,6 +31,7 @@ extern int __demi_sgafree(demi_sgarray_t *sga);
 extern int __demi_wait(demi_qresult_t *qr_out, demi_qtoken_t qt, const struct timespec *timeout);
 extern int __demi_wait_any(demi_qresult_t *qr_out, int *ready_offset, const demi_qtoken_t qts[], int num_qts,
                            const struct timespec *timeout);
+extern int __demi_getpeername(int qd, struct sockaddr *addr, socklen_t *addrlen);
 
 extern int __init(void);
 extern int __socket(int domain, int type, int protocol);

--- a/shim/src/ctrl/getpeername.c
+++ b/shim/src/ctrl/getpeername.c
@@ -4,6 +4,7 @@
 #include "../log.h"
 #include "../qman.h"
 #include "../utils.h"
+#include <glue.h>
 #include <demi/libos.h>
 #include <errno.h>
 #include <sys/socket.h>
@@ -32,10 +33,7 @@ int __getpeername(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 
     TRACE("sockfd=%d, addr=%p, addrlen=%p", sockfd, (void *)addr, (void *)addrlen);
 
-    // TODO: Hook in demi_getpeername().
-    UNUSED(addr);
-    UNUSED(addrlen);
-    ret = ENOSYS;
+    ret = __demi_getpeername(sockfd, addr, addrlen);
 
     return (ret);
 }

--- a/shim/src/glue.c
+++ b/shim/src/glue.c
@@ -101,3 +101,8 @@ int __demi_wait_any(demi_qresult_t *qr_out, int *ready_offset, const demi_qtoken
 {
     DEMI_CALL(int, demi_wait_any, qr_out, ready_offset, qts, num_qts, timeout);
 }
+
+int __demi_getpeername(int qd, struct sockaddr *addr, socklen_t *addrlen)
+{
+    DEMI_CALL(int, demi_getpeername, qd, addr, addrlen);
+}

--- a/src/rust/catloop/socket.rs
+++ b/src/rust/catloop/socket.rs
@@ -137,6 +137,19 @@ impl SharedMemorySocket {
         }
     }
 
+    /// Gets address of peer connected to socket.
+    pub fn getpeername(&mut self) -> Result<SocketAddrV4, Fail> {
+        match self.remote {
+            Some(addr) => Ok(addr),
+            None => {
+                let cause: String = format!("socket is not connected");
+                error!("getpeername(): {:?}", &cause);
+                Err(Fail::new(libc::ENOTCONN, &cause))
+            }
+
+        }
+    }
+
     /// Binds the target socket to `local` address.
     /// TODO: Should probably move the create of the duplex pipe to listen.
     pub fn bind(&mut self, local: SocketAddrV4, catmem: &mut SharedCatmemLibOS) -> Result<(), Fail> {

--- a/src/rust/catloop/transport.rs
+++ b/src/rust/catloop/transport.rs
@@ -96,6 +96,14 @@ impl NetworkTransport for SharedCatloopTransport {
         sd.get_socket_option(option)
     }
 
+    /// Gets the address of the peer connected to this socket.
+    fn getpeername(
+        &mut self,
+        sd: &mut Self::SocketDescriptor
+    ) -> Result<SocketAddrV4, Fail> {
+        sd.getpeername()
+    }
+
     /// Binds a socket to a local endpoint. This function contains the libOS-level functionality needed to bind a
     /// SharedCatloopQueue to a local address.
     fn bind(&mut self, sd: &mut Self::SocketDescriptor, local: SocketAddr) -> Result<(), Fail> {

--- a/src/rust/catnap/win/socket.rs
+++ b/src/rust/catnap/win/socket.rs
@@ -217,6 +217,12 @@ impl Socket {
         }
     }
 
+    /// Get address of peer connected to socket
+    pub fn getpeername(&self) -> Result<SocketAddrV4, Fail> {
+        let addr: Result<SocketAddrV4, Fail> = WinsockRuntime::getpeername(self.s);
+        addr
+    }
+
     /// Set TCP keepalive socket options.
     fn set_tcp_keepalive(&self, keepalive_params: &tcp_keepalive) -> Result<(), Fail> {
         unsafe { WinsockRuntime::do_setsockopt(self.s, SOL_SOCKET, SO_KEEPALIVE, Some(&keepalive_params.onoff)) }?;

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -55,7 +55,10 @@ use crate::{
 };
 use ::std::{
     env,
-    net::SocketAddr,
+    net::{
+        SocketAddr,
+        SocketAddrV4,
+    },
     time::Duration,
 };
 
@@ -293,6 +296,30 @@ impl LibOS {
                 LibOS::MemoryLibOS(_) => {
                     let cause: String = format!("Socket options are not supported on memory liboses");
                     error!("get_socket_option(): {}", cause);
+                    Err(Fail::new(libc::ENOTSUP, &cause))
+                },
+            }
+        };
+
+        self.poll();
+
+        result
+    }
+
+    pub fn getpeername(&mut self, sockqd: QDesc) -> Result<SocketAddrV4, Fail> {
+        let result: Result<SocketAddrV4, Fail> = {
+            match self {
+                #[cfg(any(
+                    feature = "catnap-libos",
+                    feature = "catnip-libos",
+                    feature = "catpowder-libos",
+                    feature = "catloop-libos"
+                ))]
+                LibOS::NetworkLibOS(libos) => libos.getpeername(sockqd),
+                #[cfg(feature = "catmem-libos")]
+                LibOS::MemoryLibOS(_) => {
+                    let cause: String = format!("Peername is not supported on memory liboses");
+                    error!("getpeername(): {}", cause);
                     Err(Fail::new(libc::ENOTSUP, &cause))
                 },
             }

--- a/src/rust/demikernel/libos/network/libos.rs
+++ b/src/rust/demikernel/libos/network/libos.rs
@@ -143,6 +143,14 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
         self.get_shared_queue(&qd)?.get_socket_option(option)
     }
 
+    /// Gets the peer address connected to the scoket.
+    pub fn getpeername(&mut self, qd: QDesc) -> Result<SocketAddrV4, Fail> {
+        trace!("getpeername() qd={:?}", qd);
+
+        // Issue operation.
+        self.get_shared_queue(&qd)?.getpeername()
+    }
+
     /// Binds a socket to a local endpoint. This function contains the libOS-level functionality needed to bind a
     /// SharedNetworkQueue to a local address.
     pub fn bind(&mut self, qd: QDesc, mut local: SocketAddr) -> Result<(), Fail> {

--- a/src/rust/demikernel/libos/network/mod.rs
+++ b/src/rust/demikernel/libos/network/mod.rs
@@ -27,7 +27,10 @@ use crate::{
     },
 };
 use ::std::{
-    net::SocketAddr,
+    net::{
+        SocketAddr,
+        SocketAddrV4,
+    },
     time::Duration,
 };
 
@@ -109,6 +112,20 @@ impl NetworkLibOSWrapper {
             NetworkLibOSWrapper::Catnip(libos) => libos.get_socket_option(sockqd, option),
             #[cfg(feature = "catloop-libos")]
             NetworkLibOSWrapper::Catloop(libos) => libos.get_socket_option(sockqd, option),
+        }
+    }
+
+    /// Gets the address of the peer connected to the socket.
+    pub fn getpeername(&mut self, sockqd: QDesc) -> Result<SocketAddrV4, Fail> {
+        match self {
+            #[cfg(feature = "catpowder-libos")]
+            NetworkLibOSWrapper::Catpowder(libos) => libos.getpeername(sockqd),
+            #[cfg(all(feature = "catnap-libos"))]
+            NetworkLibOSWrapper::Catnap(libos) => libos.getpeername(sockqd),
+            #[cfg(feature = "catnip-libos")]
+            NetworkLibOSWrapper::Catnip(libos) => libos.getpeername(sockqd),
+            #[cfg(feature = "catloop-libos")]
+            NetworkLibOSWrapper::Catloop(libos) => libos.getpeername(sockqd),
         }
     }
 

--- a/src/rust/demikernel/libos/network/queue.rs
+++ b/src/rust/demikernel/libos/network/queue.rs
@@ -35,7 +35,10 @@ use ::socket2::{
 };
 use ::std::{
     any::Any,
-    net::SocketAddr,
+    net::{
+        SocketAddr,
+        SocketAddrV4,
+    },
     ops::{
         Deref,
         DerefMut,
@@ -114,6 +117,11 @@ impl<T: NetworkTransport> SharedNetworkQueue<T> {
     /// Sets a SO_* option on the socket referenced by [sockqd].
     pub fn get_socket_option(&mut self, option: SocketOption) -> Result<SocketOption, Fail> {
         self.transport.clone().get_socket_option(&mut self.socket, option)
+    }
+
+    /// Gets the peer address connected to the socket.
+    pub fn getpeername(&mut self) -> Result<SocketAddrV4, Fail> {
+        self.transport.clone().getpeername(&mut self.socket)
     }
 
     /// Binds the target queue to `local` address.

--- a/src/rust/inetstack/mod.rs
+++ b/src/rust/inetstack/mod.rs
@@ -316,6 +316,20 @@ impl<N: NetworkRuntime> NetworkTransport for SharedInetStack<N> {
         }
     }
 
+    fn getpeername(
+        &mut self,
+        sd: &mut Self::SocketDescriptor,
+    ) -> Result<SocketAddrV4, Fail> {
+        match sd {
+            Socket::Tcp(socket) => self.ipv4.tcp.getpeername(socket),
+            Socket::Udp(_) => {
+                let cause: String = format!("Getting peer address is not supported on UDP sockets");
+                error!("getpeername(): {}", cause);
+                Err(Fail::new(libc::ENOTSUP, &cause))
+            }
+        }
+    }
+
     ///
     /// **Brief**
     ///

--- a/src/rust/inetstack/protocols/tcp/peer.rs
+++ b/src/rust/inetstack/protocols/tcp/peer.rs
@@ -130,6 +130,14 @@ impl<N: NetworkRuntime> SharedTcpPeer<N> {
         socket.get_socket_option(option)
     }
 
+    /// Gets a peer address on a TCP socket.
+    pub fn getpeername(
+        &mut self,
+        socket: &mut SharedTcpSocket<N>,
+    ) -> Result<SocketAddrV4, Fail> {
+        socket.getpeername()
+    }
+
     /// Binds a socket to a local address supplied by [local].
     pub fn bind(&mut self, socket: &mut SharedTcpSocket<N>, local: SocketAddrV4) -> Result<(), Fail> {
         // All other checks should have been done already.

--- a/src/rust/inetstack/protocols/tcp/socket.rs
+++ b/src/rust/inetstack/protocols/tcp/socket.rs
@@ -150,6 +150,21 @@ impl<N: NetworkRuntime> SharedTcpSocket<N> {
         }
     }
 
+    /// Gets the peer address of the socket.
+    pub fn getpeername(&mut self) -> Result<SocketAddrV4, Fail> {
+        match self.state {
+            SocketState::Established(ref mut socket) => {
+                let (_, remote_endpoint): (SocketAddrV4, SocketAddrV4) = socket.endpoints();
+                return Ok(remote_endpoint);
+            },
+            _ => {
+                let cause: String = format!("socket is not in established state");
+                error!("getpeername(): {}", &cause);
+                Err(Fail::new(libc::ENOTCONN, &cause))
+            },
+        }
+    }
+
     /// Binds the target queue to `local` address.
     pub fn bind(&mut self, local: SocketAddrV4) -> Result<(), Fail> {
         self.state = SocketState::Bound(local);

--- a/src/rust/pal/functions.rs
+++ b/src/rust/pal/functions.rs
@@ -22,3 +22,25 @@ pub fn socketaddrv4_to_sockaddr(addr: &SocketAddrV4) -> SOCKADDR {
     let sockaddr: SOCKADDR = unsafe { std::mem::transmute(sockaddr_in) };
     sockaddr
 }
+
+#[cfg(target_os = "linux")]
+use std::net::SocketAddrV4;
+
+#[cfg(target_os = "linux")]
+use libc::sockaddr;
+
+#[cfg(target_os = "linux")]
+use libc::sockaddr_in;
+
+#[cfg(target_os = "linux")]
+use crate::pal::constants::AF_INET;
+
+#[cfg(target_os = "linux")]
+pub fn socketaddrv4_to_sockaddr(addr: &SocketAddrV4) -> sockaddr {
+    let mut sockaddr_in: sockaddr_in = unsafe { std::mem::zeroed() };
+    sockaddr_in.sin_family = AF_INET;
+    sockaddr_in.sin_port = addr.port().to_be();
+    sockaddr_in.sin_addr.s_addr = u32::from_be_bytes(addr.ip().octets()).to_be();
+    let sockaddr: sockaddr = unsafe { std::mem::transmute(sockaddr_in) };
+    sockaddr
+}

--- a/src/rust/runtime/network/transport.rs
+++ b/src/rust/runtime/network/transport.rs
@@ -20,7 +20,10 @@ use ::socket2::{
 };
 use ::std::{
     fmt::Debug,
-    net::SocketAddr,
+    net::{
+        SocketAddr,
+        SocketAddrV4,
+    },
 };
 
 //======================================================================================================================
@@ -45,6 +48,8 @@ pub trait NetworkTransport: Clone + 'static + MemoryRuntime {
         sd: &mut Self::SocketDescriptor,
         option: SocketOption,
     ) -> Result<SocketOption, Fail>;
+
+    fn getpeername(&mut self, sd: &mut Self::SocketDescriptor) -> Result<SocketAddrV4, Fail>;
 
     /// Bind an address to the socket.
     fn bind(&mut self, sd: &mut Self::SocketDescriptor, local: SocketAddr) -> Result<(), Fail>;

--- a/tests/c/syscalls.c
+++ b/tests/c/syscalls.c
@@ -154,6 +154,16 @@ static bool inval_getsockopt(void)
     return (demi_getsockopt(qd, level, optname, optval, optlen) != 0);
 }
 
+/*
+* @brief Issues an invalid call to getpeername().
+*/
+static bool inval_getpeername(void)
+{
+    int qd = -1;
+
+    return (demi_getpeername(qd, NULL, NULL) != 0);
+}
+
 /*===================================================================================================================*
  * System Calls in demi/sga.h                                                                                        *
  *===================================================================================================================*/
@@ -227,7 +237,12 @@ struct test
 /**
  * @brief Tests for system calls in demi/libos.h
  */
-static struct test tests_libos[] = {{inval_socket, "invalid demi_socket()"}, {inval_accept, "invalid demi_accept()"}, {inval_bind, "invalid demi_bind()"}, {inval_close, "invalid_demi_close()"}, {inval_connect, "invalid demi_connect()"}, {inval_listen, "invalid demi_listen()"}, {inval_pop, "invalid demi_pop()"}, {inval_push, "invalid demi_push()"}, {inval_pushto, "invalid demi_pushto()"}, {inval_setsockopt, "invalid demi_setsockopt()"}, {inval_getsockopt, "invalid demi_getsockopt()}"}};
+static struct test tests_libos[] = {{inval_socket, "invalid demi_socket()"},   {inval_accept, "invalid demi_accept()"},
+                                    {inval_bind, "invalid demi_bind()"},       {inval_close, "invalid_demi_close()"},
+                                    {inval_connect, "invalid demi_connect()"}, {inval_listen, "invalid demi_listen()"},
+                                    {inval_pop, "invalid demi_pop()"},         {inval_push, "invalid demi_push()"},
+                                    {inval_pushto, "invalid demi_pushto()"},   {inval_getpeername, "invalid demi_getpeername()"},
+                                    {inval_setsockopt, "invalid demi_setsockopt()"}, {inval_getsockopt, "invalid demi_getsockopt()}"}};
 
 /**
  * @brief Tests for system calls in demi/sga.h


### PR DESCRIPTION
Adding a getpeername call to the demikernel, so that we can interpose libc getpeername calls.