### PR TITLE
[build] Bug Fix: Use -O0 instead of -O3 when in debug mode

### DIFF
--- a/linux.mk
+++ b/linux.mk
@@ -45,7 +45,7 @@ export CARGO_FLAGS += --profile $(BUILD)
 # C
 export CFLAGS := -I $(INCDIR)
 ifeq ($(DEBUG),yes)
-export CFLAGS += -O3
+export CFLAGS += -O0
 endif
 
 #=======================================================================================================================


### PR DESCRIPTION
When in debug mode compile without optimizations in C.