### PR TITLE
[runtime] Workaround: Adjust TIMER resolutions to fix perf regression

### DIFF
--- a/src/rust/runtime/mod.rs
+++ b/src/rust/runtime/mod.rs
@@ -90,8 +90,8 @@ use std::pin::Pin;
 
 // TODO: Make this more accurate using rdtsc.
 // FIXME: https://github.com/microsoft/demikernel/issues/1226
-const TIMER_RESOLUTION: usize = 1024;
-const TIMER_FINER_RESOLUTION: usize = 16;
+const TIMER_RESOLUTION: usize = 64;
+const TIMER_FINER_RESOLUTION: usize = 2;
 
 //======================================================================================================================
 // Structures


### PR DESCRIPTION
Bing observed performance regression between Demikernel builds. The TIMER resolution changes that were introduced between the build were the root cause. So, tuning these values manually to work around this issue for now. Refer to attached files for more details.

[RCA.pdf](https://github.com/microsoft/demikernel/files/15339187/RCA.pdf)
[TestWorkaround.pdf](https://github.com/microsoft/demikernel/files/15339194/TestWorkaround.pdf)

