### PR TITLE
[shim] Shim race conditions

### DIFF
--- a/shim/include/glue.h
+++ b/shim/include/glue.h
@@ -31,6 +31,10 @@ extern int __demi_sgafree(demi_sgarray_t *sga);
 extern int __demi_wait(demi_qresult_t *qr_out, demi_qtoken_t qt, const struct timespec *timeout);
 extern int __demi_wait_any(demi_qresult_t *qr_out, int *ready_offset, const demi_qtoken_t qts[], int num_qts,
                            const struct timespec *timeout);
+extern int __demi_getsockopt(int sockfd, int level, int optname,
+        void *optval, socklen_t *optlen);
+extern int __demi_setsockopt(int sockfd, int level, int optname,
+        const void *optval, socklen_t optlen);
 extern int __demi_getpeername(int qd, struct sockaddr *addr, socklen_t *addrlen);
 
 extern int __init(void);

--- a/shim/src/ctrl/getpeername.c
+++ b/shim/src/ctrl/getpeername.c
@@ -34,6 +34,11 @@ int __getpeername(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
     TRACE("sockfd=%d, addr=%p, addrlen=%p", sockfd, (void *)addr, (void *)addrlen);
 
     ret = __demi_getpeername(sockfd, addr, addrlen);
+    if (ret != 0)
+    {
+        errno = ret;
+        return -1;
+    }
 
     return (ret);
 }

--- a/shim/src/ctrl/getsockopt.c
+++ b/shim/src/ctrl/getsockopt.c
@@ -5,6 +5,7 @@
 #include "../log.h"
 #include "../qman.h"
 #include "../utils.h"
+#include <glue.h>
 #include <demi/libos.h>
 #include <errno.h>
 #include <netinet/tcp.h>
@@ -58,5 +59,5 @@ int __getsockopt(int sockfd, int level, int optname, void *optval, socklen_t *op
         WARN("%s is not supported", "TCP_ULP");
     }
 
-    return (demi_getsockopt(sockfd, level, optname, optval, optlen));
+    return (__demi_getsockopt(sockfd, level, optname, optval, optlen));
 }

--- a/shim/src/ctrl/getsockopt.c
+++ b/shim/src/ctrl/getsockopt.c
@@ -59,5 +59,12 @@ int __getsockopt(int sockfd, int level, int optname, void *optval, socklen_t *op
         WARN("%s is not supported", "TCP_ULP");
     }
 
-    return (__demi_getsockopt(sockfd, level, optname, optval, optlen));
+    ret = __demi_getsockopt(sockfd, level, optname, optval, optlen);
+    if (ret != 0)
+    {
+        errno = ret;
+        return -1;
+    }
+
+    return (ret);
 }

--- a/shim/src/ctrl/setsockopt.c
+++ b/shim/src/ctrl/setsockopt.c
@@ -3,6 +3,7 @@
 
 #include "../log.h"
 #include "../qman.h"
+#include <glue.h>
 #include <demi/libos.h>
 #include <errno.h>
 #include <sys/socket.h>
@@ -58,5 +59,5 @@ int __setsockopt(int sockfd, int level, int optname, const void *optval, socklen
         WARN("%s is not supported", "TCP_ULP");
     }
 
-    return (demi_setsockopt(sockfd, level, optname, optval, optlen));
+    return (__demi_setsockopt(sockfd, level, optname, optval, optlen));
 }

--- a/shim/src/ctrl/setsockopt.c
+++ b/shim/src/ctrl/setsockopt.c
@@ -62,11 +62,13 @@ int __setsockopt(int sockfd, int level, int optname, const void *optval, socklen
     }
 
     ret = __demi_setsockopt(sockfd, level, optname, optval, optlen);
-    if (ret != 0)
-    {
-        errno = ret;
-        return -1;
-    }
+    // TODO: Add SO_REUSEADDR and uncomment this out. Without the
+    //       SO_REUSEADDR option implemented the Redis pipeline will fail.
+    // if (ret != 0)
+    // {
+    //     errno = ret;
+    //     return -1;
+    // }
 
     return (ret);
 }

--- a/shim/src/ctrl/setsockopt.c
+++ b/shim/src/ctrl/setsockopt.c
@@ -23,6 +23,8 @@
  */
 int __setsockopt(int sockfd, int level, int optname, const void *optval, socklen_t optlen)
 {
+    int ret;
+
     // Check if this socket descriptor is managed by Demikernel.
     // If that is not the case, then fail to let the Linux kernel handle it.
     if (!queue_man_query_fd(sockfd))
@@ -59,5 +61,12 @@ int __setsockopt(int sockfd, int level, int optname, const void *optval, socklen
         WARN("%s is not supported", "TCP_ULP");
     }
 
-    return (__demi_setsockopt(sockfd, level, optname, optval, optlen));
+    ret = __demi_setsockopt(sockfd, level, optname, optval, optlen);
+    if (ret != 0)
+    {
+        errno = ret;
+        return -1;
+    }
+
+    return (ret);
 }

--- a/shim/src/data/recv.c
+++ b/shim/src/data/recv.c
@@ -183,18 +183,18 @@ ssize_t __readv(int sockfd, const struct iovec *iov, int iovcnt)
             if (ev->qr.qr_value.sga.sga_segs[0].sgaseg_len == 0)
             {
                 TRACE("read zero bytes");
-                demi_sgafree(&ev->qr.qr_value.sga);
+                __demi_sgafree(&ev->qr.qr_value.sga);
                 return (0);
             }
 
             count = fill_iov(iov, &ev->qr.qr_value.sga, iovcnt, num_segs);
             if (count > 0)
             {
-                demi_sgafree(&ev->qr.qr_value.sga);
+                __demi_sgafree(&ev->qr.qr_value.sga);
             }
 
             // Re-issue I/O queue operation.
-            assert(demi_pop(&ev->qt, ev->sockqd) == 0);
+            assert(__demi_pop(&ev->qt, ev->sockqd) == 0);
             assert(ev->qt != (demi_qtoken_t)-1);
 
             return (count);
@@ -246,11 +246,11 @@ static size_t fill_iov(const struct iovec *iov, demi_sgarray_t *sga,
         iov_len = iov[i_iov].iov_len - iov_off;
         sga_len = sga->sga_segs[i_sga].sgaseg_len - sga_off;
         count = MIN(iov_len, sga_len);
-        memcpy(iov[i_iov].iov_base + iov_off, 
+        memcpy(iov[i_iov].iov_base + iov_off,
                 sga->sga_segs[i_sga].sgaseg_buf + sga_off, count);
-        
+
         total += count;
-    
+
         if (iov_len > sga_len)
         {
             i_sga += 1;

--- a/shim/src/data/send.c
+++ b/shim/src/data/send.c
@@ -108,15 +108,15 @@ ssize_t __sendmsg(int sockfd, const struct msghdr *msg, int flags)
 
     demi_qtoken_t qt = -1;
     demi_qresult_t qr;
-    demi_sgarray_t sga = demi_sgaalloc(iov_len);
+    demi_sgarray_t sga = __demi_sgaalloc(iov_len);
 
     // Copy iovecs to sga
     bytes = fill_sga(msg->msg_iov, &sga, msg->msg_iovlen);
 
-    assert(demi_push(&qt, sockfd, &sga) == 0);
-    assert(demi_wait(&qr, qt, NULL) == 0);
+    assert(__demi_push(&qt, sockfd, &sga) == 0);
+    assert(__demi_wait(&qr, qt, NULL) == 0);
     assert(qr.qr_opcode == DEMI_OPC_PUSH);
-    demi_sgafree(&sga);
+    __demi_sgafree(&sga);
 
     return (bytes);
 }
@@ -169,7 +169,7 @@ static size_t fill_sga(const struct iovec *iov, demi_sgarray_t *sga,
     size_t iovcnt)
 {
     size_t len, sga_len, iov_len;
-    
+
     size_t i_iov = 0;
     uint8_t sga_pos = 0, iov_pos = 0;
 
@@ -180,11 +180,11 @@ static size_t fill_sga(const struct iovec *iov, demi_sgarray_t *sga,
         sga_len = sga->sga_segs[0].sgaseg_len - sga_pos;
 
         len = MIN(iov_len, sga_len);
-        memcpy(sga->sga_segs[0].sgaseg_buf + sga_pos, 
+        memcpy(sga->sga_segs[0].sgaseg_buf + sga_pos,
                 iov[i_iov].iov_base + iov_pos, len);
-        
+
         sga_pos += len;
-        
+
         if (len == iov_len)
         {
             iov_pos = 0;

--- a/shim/src/glue.c
+++ b/shim/src/glue.c
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#include "log.h"
 #include <demi/libos.h>
 #include <demi/sga.h>
 #include <demi/wait.h>
-#include <pthread.h>
-#include <stdlib.h>
 
 static __thread int __demi_reent_guard = 0;
 
@@ -121,4 +118,3 @@ int __demi_getpeername(int qd, struct sockaddr *addr, socklen_t *addrlen)
 {
     DEMI_CALL(int, demi_getpeername, qd, addr, addrlen);
 }
-

--- a/shim/src/glue.c
+++ b/shim/src/glue.c
@@ -5,7 +5,7 @@
 #include <demi/sga.h>
 #include <demi/wait.h>
 
-static int __demi_reent_guard = 0;
+static __thread int __demi_reent_guard = 0;
 
 #define DEMI_CALL(type, fn, ...)    \
     {                               \

--- a/shim/src/glue.c
+++ b/shim/src/glue.c
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+#include "log.h"
 #include <demi/libos.h>
 #include <demi/sga.h>
 #include <demi/wait.h>
+#include <pthread.h>
+#include <stdlib.h>
 
 static __thread int __demi_reent_guard = 0;
 
@@ -102,7 +105,20 @@ int __demi_wait_any(demi_qresult_t *qr_out, int *ready_offset, const demi_qtoken
     DEMI_CALL(int, demi_wait_any, qr_out, ready_offset, qts, num_qts, timeout);
 }
 
+int __demi_getsockopt(int sockfd, int level, int optname,
+        void *optval, socklen_t *optlen)
+{
+    DEMI_CALL(int, demi_getsockopt, sockfd, level, optname, optval, optlen);
+}
+
+int __demi_setsockopt(int sockfd, int level, int optname,
+        const void *optval, socklen_t optlen)
+{
+    DEMI_CALL(int, demi_setsockopt, sockfd, level, optname, optval, optlen);
+}
+
 int __demi_getpeername(int qd, struct sockaddr *addr, socklen_t *addrlen)
 {
     DEMI_CALL(int, demi_getpeername, qd, addr, addrlen);
 }
+

--- a/shim/src/interpose.c
+++ b/shim/src/interpose.c
@@ -54,8 +54,7 @@
     {                                                         \
         bool reentrant = is_reentrant_demi_call();            \
                                                               \
-        if (!initialized_libc)                                \
-            init_libc();                                      \
+        init_libc();                                          \
                                                               \
         if ((!initialized) || (reentrant))                    \
             return (fn_libc(__VA_ARGS__));                    \
@@ -94,50 +93,87 @@ static int (*libc_epoll_create1)(int) = NULL;
 static int (*libc_epoll_ctl)(int, int, int, struct epoll_event *) = NULL;
 static int (*libc_epoll_wait)(int, struct epoll_event *, int, int) = NULL;
 
-static bool initialized = false;
-static bool initialized_libc = false;
+static volatile uint8_t initialized_libc = 0;
+static volatile uint8_t in_init_libc = 0;
+
+static volatile uint8_t initialized = 0;
+static volatile uint8_t in_init = 0;
 
 static void init_libc(void)
 {
-    assert((libc_socket = dlsym(RTLD_NEXT, "socket")) != NULL);
-    assert((libc_shutdown = dlsym(RTLD_NEXT, "shutdown")) != NULL);
-    assert((libc_bind = dlsym(RTLD_NEXT, "bind")) != NULL);
-    assert((libc_connect = dlsym(RTLD_NEXT, "connect")) != NULL);
-    assert((libc_fcntl = dlsym(RTLD_NEXT, "fcntl")) != NULL);
-    assert((libc_listen = dlsym(RTLD_NEXT, "listen")) != NULL);
-    assert((libc_accept4 = dlsym(RTLD_NEXT, "accept4")) != NULL);
-    assert((libc_accept = dlsym(RTLD_NEXT, "accept")) != NULL);
-    assert((libc_getsockopt = dlsym(RTLD_NEXT, "getsockopt")) != NULL);
-    assert((libc_setsockopt = dlsym(RTLD_NEXT, "setsockopt")) != NULL);
-    assert((libc_getsockname = dlsym(RTLD_NEXT, "getsockname")) != NULL);
-    assert((libc_getpeername = dlsym(RTLD_NEXT, "getpeername")) != NULL);
-    assert((libc_read = dlsym(RTLD_NEXT, "read")) != NULL);
-    assert((libc_recv = dlsym(RTLD_NEXT, "recv")) != NULL);
-    assert((libc_recvfrom = dlsym(RTLD_NEXT, "recvfrom")) != NULL);
-    assert((libc_recvmsg = dlsym(RTLD_NEXT, "recvmsg")) != NULL);
-    assert((libc_readv = dlsym(RTLD_NEXT, "readv")) != NULL);
-    assert((libc_pread = dlsym(RTLD_NEXT, "pread")) != NULL);
-    assert((libc_write = dlsym(RTLD_NEXT, "write")) != NULL);
-    assert((libc_send = dlsym(RTLD_NEXT, "send")) != NULL);
-    assert((libc_sendto = dlsym(RTLD_NEXT, "sendto")) != NULL);
-    assert((libc_sendmsg = dlsym(RTLD_NEXT, "sendmsg")) != NULL);
-    assert((libc_writev = dlsym(RTLD_NEXT, "writev")) != NULL);
-    assert((libc_pwrite = dlsym(RTLD_NEXT, "pwrite")) != NULL);
-    assert((libc_close = dlsym(RTLD_NEXT, "close")) != NULL);
-    assert((libc_epoll_create = dlsym(RTLD_NEXT, "epoll_create")) != NULL);
-    assert((libc_epoll_create1 = dlsym(RTLD_NEXT, "epoll_create1")) != NULL);
-    assert((libc_epoll_ctl = dlsym(RTLD_NEXT, "epoll_ctl")) != NULL);
-    assert((libc_epoll_wait = dlsym(RTLD_NEXT, "epoll_wait")) != NULL);
+if (initialized_libc == 0)
+    {
+
+        if (__sync_fetch_and_add(&in_init_libc, 1) == 0)
+        {
+            assert((libc_socket = dlsym(RTLD_NEXT, "socket")) != NULL);
+            assert((libc_shutdown = dlsym(RTLD_NEXT, "shutdown")) != NULL);
+            assert((libc_bind = dlsym(RTLD_NEXT, "bind")) != NULL);
+            assert((libc_connect = dlsym(RTLD_NEXT, "connect")) != NULL);
+            assert((libc_fcntl = dlsym(RTLD_NEXT, "fcntl")) != NULL);
+            assert((libc_listen = dlsym(RTLD_NEXT, "listen")) != NULL);
+            assert((libc_accept4 = dlsym(RTLD_NEXT, "accept4")) != NULL);
+            assert((libc_accept = dlsym(RTLD_NEXT, "accept")) != NULL);
+            assert((libc_getsockopt = dlsym(RTLD_NEXT, "getsockopt")) != NULL);
+            assert((libc_setsockopt = dlsym(RTLD_NEXT, "setsockopt")) != NULL);
+            assert((libc_getsockname = dlsym(RTLD_NEXT, "getsockname")) != NULL);
+            assert((libc_getpeername = dlsym(RTLD_NEXT, "getpeername")) != NULL);
+            assert((libc_read = dlsym(RTLD_NEXT, "read")) != NULL);
+            assert((libc_recv = dlsym(RTLD_NEXT, "recv")) != NULL);
+            assert((libc_recvfrom = dlsym(RTLD_NEXT, "recvfrom")) != NULL);
+            assert((libc_recvmsg = dlsym(RTLD_NEXT, "recvmsg")) != NULL);
+            assert((libc_readv = dlsym(RTLD_NEXT, "readv")) != NULL);
+            assert((libc_pread = dlsym(RTLD_NEXT, "pread")) != NULL);
+            assert((libc_write = dlsym(RTLD_NEXT, "write")) != NULL);
+            assert((libc_send = dlsym(RTLD_NEXT, "send")) != NULL);
+            assert((libc_sendto = dlsym(RTLD_NEXT, "sendto")) != NULL);
+            assert((libc_sendmsg = dlsym(RTLD_NEXT, "sendmsg")) != NULL);
+            assert((libc_writev = dlsym(RTLD_NEXT, "writev")) != NULL);
+            assert((libc_pwrite = dlsym(RTLD_NEXT, "pwrite")) != NULL);
+            assert((libc_close = dlsym(RTLD_NEXT, "close")) != NULL);
+            assert((libc_epoll_create = dlsym(RTLD_NEXT, "epoll_create")) != NULL);
+            assert((libc_epoll_create1 = dlsym(RTLD_NEXT, "epoll_create1")) != NULL);
+            assert((libc_epoll_ctl = dlsym(RTLD_NEXT, "epoll_ctl")) != NULL);
+            assert((libc_epoll_wait = dlsym(RTLD_NEXT, "epoll_wait")) != NULL);
+
+            __sync_fetch_and_sub(&in_init_libc, 1);
+            MEM_BARRIER();
+            initialized_libc = 1;
+        }
+        else
+        {
+            while (initialized_libc == 0)
+            {
+                sched_yield();
+            }
+            MEM_BARRIER();
+        }
+    }
 }
 
 static void init(void)
 {
-    if (!initialized)
-    {
-        if (__init() != 0)
-            abort();
+    int ret;
 
-        initialized = true;
+    if (initialized == 0)
+    {
+        if (__sync_fetch_and_add(&in_init, 1) == 0)
+        {
+            ret = __init();
+            if (ret != 0 && ret != EEXIST)
+                abort();
+            __sync_fetch_and_sub(&in_init, 1);
+            MEM_BARRIER();
+            initialized = 1;
+        }
+        else
+        {
+            while (initialized == 0)
+            {
+                sched_yield();
+            }
+            MEM_BARRIER();
+        }
     }
 }
 

--- a/shim/src/utils.h
+++ b/shim/src/utils.h
@@ -10,6 +10,8 @@
 
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 
+#define MEM_BARRIER() __asm__ volatile("" ::: "memory")
+
 struct hashset;
 extern struct hashset *hashset_create(int);
 extern int hashset_insert(struct hashset *, int);


### PR DESCRIPTION
This pull request deals with a couple of issues with the shim library
- Fixes race conditions when initializing the demikernel
- Makes sure every call to the demikernel is wrapped with the DEMI_CALL macro (there were a few calls that we forgot about and that were causing issues)
- Sets errno before returning an error from getpeername