### PR TITLE
[catnap] Enhancement: Yield to kernel 

### DIFF
--- a/src/rust/catnap/linux/transport.rs
+++ b/src/rust/catnap/linux/transport.rs
@@ -14,9 +14,12 @@ mod socket;
 //======================================================================================================================
 
 use crate::{
-    catnap::transport::socket::{
-        SharedSocketData,
-        SocketData,
+    catnap::{
+        transport::socket::{
+            SharedSocketData,
+            SocketData,
+        },
+        YIELD_TIMEOUT_MS,
     },
     demikernel::config::Config,
     expect_ok,
@@ -173,7 +176,7 @@ impl SharedCatnapTransport {
                     self.epoll_fd,
                     events.as_mut_ptr() as *mut libc::epoll_event,
                     EPOLL_BATCH_SIZE as i32,
-                    0,
+                    YIELD_TIMEOUT_MS as i32,
                 )
             } {
                 result if result >= 0 => {

--- a/src/rust/catnap/mod.rs
+++ b/src/rust/catnap/mod.rs
@@ -4,3 +4,5 @@
 #[cfg_attr(target_os = "linux", path = "linux/transport.rs")]
 #[cfg_attr(target_os = "windows", path = "win/transport.rs")]
 pub mod transport;
+
+const YIELD_TIMEOUT_MS: u32 = 1;

--- a/src/rust/catnap/win/overlapped.rs
+++ b/src/rust/catnap/win/overlapped.rs
@@ -31,7 +31,10 @@ use windows::Win32::{
 };
 
 use crate::{
-    catnap::transport::error::translate_ntstatus,
+    catnap::{
+        transport::error::translate_ntstatus,
+        YIELD_TIMEOUT_MS,
+    },
     collections::pin_slab::PinSlab,
     expect_some,
     runtime::{
@@ -245,7 +248,15 @@ impl<S: Unpin> IoCompletionPort<S> {
 
         loop {
             let mut dequeued: u32 = 0;
-            match unsafe { GetQueuedCompletionStatusEx(self.iocp, entries.as_mut_slice(), &mut dequeued, 0, FALSE) } {
+            match unsafe {
+                GetQueuedCompletionStatusEx(
+                    self.iocp,
+                    entries.as_mut_slice(),
+                    &mut dequeued,
+                    YIELD_TIMEOUT_MS,
+                    FALSE,
+                )
+            } {
                 Ok(()) => {
                     for i in 0..dequeued {
                         self.process_overlapped(&entries[i as usize]);


### PR DESCRIPTION
This PR adds a yield to Catnap into the kernel for a configurable amount of time, currently set to 1 milliseconds. This ensures that we do not continuously poll and run the CPU at 100%, while still occasionally returning to Demikernel, every second. This is safe in Catnap because there are no background coroutines, however, it does mean that every poll takes at least 1 milliseconds to complete. 