### PR TITLE
[runtime] Enhancement: Move background coroutines to own group

### DIFF
--- a/src/rust/catmem/mod.rs
+++ b/src/rust/catmem/mod.rs
@@ -220,16 +220,16 @@ impl SharedCatmemLibOS {
     pub fn wait_next_n<Acceptor: FnMut(demi_qresult_t) -> bool>(
         &mut self,
         mut acceptor: Acceptor,
-        timeout: Duration
-    ) -> Result<(), Fail>
-    {
-        self.runtime.clone().wait_next_n(
-            |qt, qd, result| acceptor(self.create_result(result, qd, qt)), timeout)
+        timeout: Duration,
+    ) -> Result<(), Fail> {
+        self.runtime
+            .clone()
+            .wait_next_n(|qt, qd, result| acceptor(self.create_result(result, qd, qt)), timeout)
     }
 
     /// Waits for any operation in an I/O queue.
-    pub fn poll(&mut self) {
-        self.runtime.poll()
+    pub fn poll_task(&mut self, qt: QToken) {
+        self.runtime.poll_task(qt)
     }
 
     pub fn create_result(&self, result: OperationResult, qd: QDesc, qt: QToken) -> demi_qresult_t {

--- a/src/rust/catnap/win/overlapped.rs
+++ b/src/rust/catnap/win/overlapped.rs
@@ -689,7 +689,7 @@ mod tests {
 
         let result: OperationResult = loop {
             iocp.get_mut().process_events()?;
-            runtime.poll();
+            runtime.poll_task(server_task);
             if let Some((_, result)) = runtime.get_completed_task(&server_task) {
                 break result;
             }

--- a/src/rust/demikernel/libos/memory.rs
+++ b/src/rust/demikernel/libos/memory.rs
@@ -119,9 +119,8 @@ impl MemoryLibOS {
     pub fn wait_next_n<Acceptor: FnMut(demi_qresult_t) -> bool>(
         &mut self,
         acceptor: Acceptor,
-        timeout: Duration
-    ) -> Result<(), Fail>
-    {
+        timeout: Duration,
+    ) -> Result<(), Fail> {
         trace!("wait_next_n(): acceptor, timeout={:?}", timeout);
         match self {
             #[cfg(feature = "catmem-libos")]
@@ -129,7 +128,6 @@ impl MemoryLibOS {
             _ => unreachable!("unknown memory libos"),
         }
     }
-
 
     /// Allocates a scatter-gather array.
     #[allow(unreachable_patterns, unused_variables)]
@@ -153,10 +151,10 @@ impl MemoryLibOS {
 
     /// Waits for any operation in an I/O queue.
     #[allow(unreachable_patterns, unused_variables)]
-    pub fn poll(&mut self) {
+    pub fn poll_task(&mut self, qt: QToken) {
         match self {
             #[cfg(feature = "catmem-libos")]
-            MemoryLibOS::Catmem(libos) => libos.poll(),
+            MemoryLibOS::Catmem(libos) => libos.poll_task(qt),
             _ => unreachable!("unknown memory libos"),
         }
     }

--- a/src/rust/demikernel/libos/mod.rs
+++ b/src/rust/demikernel/libos/mod.rs
@@ -182,53 +182,41 @@ impl LibOS {
     /// Creates a new memory queue and connect to consumer end.
     #[allow(unused_variables)]
     pub fn create_pipe(&mut self, name: &str) -> Result<QDesc, Fail> {
-        let result: Result<QDesc, Fail> = {
-            timer!("demikernel::create_pipe");
-            match self {
-                #[cfg(any(
-                    feature = "catnap-libos",
-                    feature = "catnip-libos",
-                    feature = "catpowder-libos",
-                    feature = "catloop-libos"
-                ))]
-                LibOS::NetworkLibOS(_) => Err(Fail::new(
-                    libc::ENOTSUP,
-                    "create_pipe() is not supported on network liboses",
-                )),
-                #[cfg(feature = "catmem-libos")]
-                LibOS::MemoryLibOS(libos) => libos.create_pipe(name),
-            }
-        };
-
-        self.poll();
-
-        result
+        timer!("demikernel::create_pipe");
+        match self {
+            #[cfg(any(
+                feature = "catnap-libos",
+                feature = "catnip-libos",
+                feature = "catpowder-libos",
+                feature = "catloop-libos"
+            ))]
+            LibOS::NetworkLibOS(_) => Err(Fail::new(
+                libc::ENOTSUP,
+                "create_pipe() is not supported on network liboses",
+            )),
+            #[cfg(feature = "catmem-libos")]
+            LibOS::MemoryLibOS(libos) => libos.create_pipe(name),
+        }
     }
 
     /// Opens an existing memory queue and connects to producer end.
     #[allow(unused_variables)]
     pub fn open_pipe(&mut self, name: &str) -> Result<QDesc, Fail> {
-        let result: Result<QDesc, Fail> = {
-            timer!("demikernel::open_pipe");
-            match self {
-                #[cfg(any(
-                    feature = "catnap-libos",
-                    feature = "catnip-libos",
-                    feature = "catpowder-libos",
-                    feature = "catloop-libos"
-                ))]
-                LibOS::NetworkLibOS(_) => Err(Fail::new(
-                    libc::ENOTSUP,
-                    "open_pipe() is not supported on network liboses",
-                )),
-                #[cfg(feature = "catmem-libos")]
-                LibOS::MemoryLibOS(libos) => libos.open_pipe(name),
-            }
-        };
-
-        self.poll();
-
-        result
+        timer!("demikernel::open_pipe");
+        match self {
+            #[cfg(any(
+                feature = "catnap-libos",
+                feature = "catnip-libos",
+                feature = "catpowder-libos",
+                feature = "catloop-libos"
+            ))]
+            LibOS::NetworkLibOS(_) => Err(Fail::new(
+                libc::ENOTSUP,
+                "open_pipe() is not supported on network liboses",
+            )),
+            #[cfg(feature = "catmem-libos")]
+            LibOS::MemoryLibOS(libos) => libos.open_pipe(name),
+        }
     }
 
     /// Creates a socket.
@@ -239,150 +227,114 @@ impl LibOS {
         socket_type: libc::c_int,
         protocol: libc::c_int,
     ) -> Result<QDesc, Fail> {
-        let result: Result<QDesc, Fail> = {
-            timer!("demikernel::socket");
-            match self {
-                #[cfg(any(
-                    feature = "catnap-libos",
-                    feature = "catnip-libos",
-                    feature = "catpowder-libos",
-                    feature = "catloop-libos"
-                ))]
-                LibOS::NetworkLibOS(libos) => libos.socket(domain, socket_type, protocol),
-                #[cfg(feature = "catmem-libos")]
-                LibOS::MemoryLibOS(_) => Err(Fail::new(libc::ENOTSUP, "socket() is not supported on memory liboses")),
-            }
-        };
-
-        self.poll();
-
-        result
+        timer!("demikernel::socket");
+        match self {
+            #[cfg(any(
+                feature = "catnap-libos",
+                feature = "catnip-libos",
+                feature = "catpowder-libos",
+                feature = "catloop-libos"
+            ))]
+            LibOS::NetworkLibOS(libos) => libos.socket(domain, socket_type, protocol),
+            #[cfg(feature = "catmem-libos")]
+            LibOS::MemoryLibOS(_) => Err(Fail::new(libc::ENOTSUP, "socket() is not supported on memory liboses")),
+        }
     }
 
     /// Sets an SO_* option on the socket referenced by [sockqd].
     pub fn set_socket_option(&mut self, sockqd: QDesc, option: SocketOption) -> Result<(), Fail> {
-        let result: Result<(), Fail> = {
-            match self {
-                #[cfg(any(
-                    feature = "catnap-libos",
-                    feature = "catnip-libos",
-                    feature = "catpowder-libos",
-                    feature = "catloop-libos"
-                ))]
-                LibOS::NetworkLibOS(libos) => libos.set_socket_option(sockqd, option),
-                #[cfg(feature = "catmem-libos")]
-                LibOS::MemoryLibOS(_) => {
-                    let cause: String = format!("Socket options are not supported on memory liboses");
-                    error!("get_socket_option(): {}", cause);
-                    Err(Fail::new(libc::ENOTSUP, &cause))
-                },
-            }
-        };
-
-        self.poll();
-
-        result
+        match self {
+            #[cfg(any(
+                feature = "catnap-libos",
+                feature = "catnip-libos",
+                feature = "catpowder-libos",
+                feature = "catloop-libos"
+            ))]
+            LibOS::NetworkLibOS(libos) => libos.set_socket_option(sockqd, option),
+            #[cfg(feature = "catmem-libos")]
+            LibOS::MemoryLibOS(_) => {
+                let cause: String = format!("Socket options are not supported on memory liboses");
+                error!("get_socket_option(): {}", cause);
+                Err(Fail::new(libc::ENOTSUP, &cause))
+            },
+        }
     }
 
     /// Gets a SO_* option on the socket referenced by [sockqd].
     pub fn get_socket_option(&mut self, sockqd: QDesc, option: SocketOption) -> Result<SocketOption, Fail> {
-        let result: Result<SocketOption, Fail> = {
-            match self {
-                #[cfg(any(
-                    feature = "catnap-libos",
-                    feature = "catnip-libos",
-                    feature = "catpowder-libos",
-                    feature = "catloop-libos"
-                ))]
-                LibOS::NetworkLibOS(libos) => libos.get_socket_option(sockqd, option),
-                #[cfg(feature = "catmem-libos")]
-                LibOS::MemoryLibOS(_) => {
-                    let cause: String = format!("Socket options are not supported on memory liboses");
-                    error!("get_socket_option(): {}", cause);
-                    Err(Fail::new(libc::ENOTSUP, &cause))
-                },
-            }
-        };
-
-        self.poll();
-
-        result
+        match self {
+            #[cfg(any(
+                feature = "catnap-libos",
+                feature = "catnip-libos",
+                feature = "catpowder-libos",
+                feature = "catloop-libos"
+            ))]
+            LibOS::NetworkLibOS(libos) => libos.get_socket_option(sockqd, option),
+            #[cfg(feature = "catmem-libos")]
+            LibOS::MemoryLibOS(_) => {
+                let cause: String = format!("Socket options are not supported on memory liboses");
+                error!("get_socket_option(): {}", cause);
+                Err(Fail::new(libc::ENOTSUP, &cause))
+            },
+        }
     }
 
     pub fn getpeername(&mut self, sockqd: QDesc) -> Result<SocketAddrV4, Fail> {
-        let result: Result<SocketAddrV4, Fail> = {
-            match self {
-                #[cfg(any(
-                    feature = "catnap-libos",
-                    feature = "catnip-libos",
-                    feature = "catpowder-libos",
-                    feature = "catloop-libos"
-                ))]
-                LibOS::NetworkLibOS(libos) => libos.getpeername(sockqd),
-                #[cfg(feature = "catmem-libos")]
-                LibOS::MemoryLibOS(_) => {
-                    let cause: String = format!("Peername is not supported on memory liboses");
-                    error!("getpeername(): {}", cause);
-                    Err(Fail::new(libc::ENOTSUP, &cause))
-                },
-            }
-        };
-
-        self.poll();
-
-        result
+        match self {
+            #[cfg(any(
+                feature = "catnap-libos",
+                feature = "catnip-libos",
+                feature = "catpowder-libos",
+                feature = "catloop-libos"
+            ))]
+            LibOS::NetworkLibOS(libos) => libos.getpeername(sockqd),
+            #[cfg(feature = "catmem-libos")]
+            LibOS::MemoryLibOS(_) => {
+                let cause: String = format!("Peername is not supported on memory liboses");
+                error!("getpeername(): {}", cause);
+                Err(Fail::new(libc::ENOTSUP, &cause))
+            },
+        }
     }
 
     /// Binds a socket to a local address.
     #[allow(unused_variables)]
     pub fn bind(&mut self, sockqd: QDesc, local: SocketAddr) -> Result<(), Fail> {
-        let result: Result<(), Fail> = {
-            timer!("demikernel::bind");
-            match self {
-                #[cfg(any(
-                    feature = "catnap-libos",
-                    feature = "catnip-libos",
-                    feature = "catpowder-libos",
-                    feature = "catloop-libos"
-                ))]
-                LibOS::NetworkLibOS(libos) => libos.bind(sockqd, local),
-                #[cfg(feature = "catmem-libos")]
-                LibOS::MemoryLibOS(_) => Err(Fail::new(libc::ENOTSUP, "bind() is not supported on memory liboses")),
-            }
-        };
-
-        self.poll();
-
-        result
+        timer!("demikernel::bind");
+        match self {
+            #[cfg(any(
+                feature = "catnap-libos",
+                feature = "catnip-libos",
+                feature = "catpowder-libos",
+                feature = "catloop-libos"
+            ))]
+            LibOS::NetworkLibOS(libos) => libos.bind(sockqd, local),
+            #[cfg(feature = "catmem-libos")]
+            LibOS::MemoryLibOS(_) => Err(Fail::new(libc::ENOTSUP, "bind() is not supported on memory liboses")),
+        }
     }
 
     /// Marks a socket as a passive one.
     #[allow(unused_variables)]
     pub fn listen(&mut self, sockqd: QDesc, backlog: usize) -> Result<(), Fail> {
-        let result: Result<(), Fail> = {
-            timer!("demikernel::listen");
-            match self {
-                #[cfg(any(
-                    feature = "catnap-libos",
-                    feature = "catnip-libos",
-                    feature = "catpowder-libos",
-                    feature = "catloop-libos"
-                ))]
-                LibOS::NetworkLibOS(libos) => libos.listen(sockqd, backlog),
-                #[cfg(feature = "catmem-libos")]
-                LibOS::MemoryLibOS(_) => Err(Fail::new(libc::ENOTSUP, "listen() is not supported on memory liboses")),
-            }
-        };
-
-        self.poll();
-
-        result
+        timer!("demikernel::listen");
+        match self {
+            #[cfg(any(
+                feature = "catnap-libos",
+                feature = "catnip-libos",
+                feature = "catpowder-libos",
+                feature = "catloop-libos"
+            ))]
+            LibOS::NetworkLibOS(libos) => libos.listen(sockqd, backlog),
+            #[cfg(feature = "catmem-libos")]
+            LibOS::MemoryLibOS(_) => Err(Fail::new(libc::ENOTSUP, "listen() is not supported on memory liboses")),
+        }
     }
 
     /// Accepts an incoming connection on a TCP socket.
     #[allow(unused_variables)]
     pub fn accept(&mut self, sockqd: QDesc) -> Result<QToken, Fail> {
-        let result: Result<QToken, Fail> = {
+        let qt: QToken = {
             timer!("demikernel::accept");
             match self {
                 #[cfg(any(
@@ -395,17 +347,17 @@ impl LibOS {
                 #[cfg(feature = "catmem-libos")]
                 LibOS::MemoryLibOS(_) => Err(Fail::new(libc::ENOTSUP, "accept() is not supported on memory liboses")),
             }
-        };
+        }?;
 
-        self.poll();
+        self.poll_task(qt);
 
-        result
+        Ok(qt)
     }
 
     /// Initiates a connection with a remote TCP socket.
     #[allow(unused_variables)]
     pub fn connect(&mut self, sockqd: QDesc, remote: SocketAddr) -> Result<QToken, Fail> {
-        let result: Result<QToken, Fail> = {
+        let qt: QToken = {
             timer!("demikernel::connect");
             match self {
                 #[cfg(any(
@@ -418,50 +370,44 @@ impl LibOS {
                 #[cfg(feature = "catmem-libos")]
                 LibOS::MemoryLibOS(_) => Err(Fail::new(libc::ENOTSUP, "connect() is not supported on memory liboses")),
             }
-        };
+        }?;
 
-        self.poll();
+        self.poll_task(qt);
 
-        result
+        Ok(qt)
     }
 
     /// Closes an I/O queue.
     /// async_close() + wait() achieves the same effect as synchronous close.
     pub fn close(&mut self, qd: QDesc) -> Result<(), Fail> {
-        let result: Result<(), Fail> = {
-            timer!("demikernel::close");
-            match self {
-                #[cfg(any(
-                    feature = "catnap-libos",
-                    feature = "catnip-libos",
-                    feature = "catpowder-libos",
-                    feature = "catloop-libos"
-                ))]
-                LibOS::NetworkLibOS(libos) => match libos.async_close(qd) {
-                    Ok(qt) => match self.wait(qt, None) {
-                        Ok(_) => Ok(()),
-                        Err(e) => Err(e),
-                    },
+        timer!("demikernel::close");
+        match self {
+            #[cfg(any(
+                feature = "catnap-libos",
+                feature = "catnip-libos",
+                feature = "catpowder-libos",
+                feature = "catloop-libos"
+            ))]
+            LibOS::NetworkLibOS(libos) => match libos.async_close(qd) {
+                Ok(qt) => match self.wait(qt, None) {
+                    Ok(_) => Ok(()),
                     Err(e) => Err(e),
                 },
-                #[cfg(feature = "catmem-libos")]
-                LibOS::MemoryLibOS(libos) => match libos.async_close(qd) {
-                    Ok(qt) => match self.wait(qt, None) {
-                        Ok(_) => Ok(()),
-                        Err(e) => Err(e),
-                    },
+                Err(e) => Err(e),
+            },
+            #[cfg(feature = "catmem-libos")]
+            LibOS::MemoryLibOS(libos) => match libos.async_close(qd) {
+                Ok(qt) => match self.wait(qt, None) {
+                    Ok(_) => Ok(()),
                     Err(e) => Err(e),
                 },
-            }
-        };
-
-        self.poll();
-
-        result
+                Err(e) => Err(e),
+            },
+        }
     }
 
     pub fn async_close(&mut self, qd: QDesc) -> Result<QToken, Fail> {
-        let result: Result<QToken, Fail> = {
+        let qt: QToken = {
             timer!("demikernel::async_close");
             match self {
                 #[cfg(any(
@@ -474,16 +420,16 @@ impl LibOS {
                 #[cfg(feature = "catmem-libos")]
                 LibOS::MemoryLibOS(libos) => libos.async_close(qd),
             }
-        };
+        }?;
 
-        self.poll();
+        self.poll_task(qt);
 
-        result
+        Ok(qt)
     }
 
     /// Pushes a scatter-gather array to an I/O queue.
     pub fn push(&mut self, qd: QDesc, sga: &demi_sgarray_t) -> Result<QToken, Fail> {
-        let result: Result<QToken, Fail> = {
+        let qt: QToken = {
             timer!("demikernel::push");
             match self {
                 #[cfg(any(
@@ -496,41 +442,40 @@ impl LibOS {
                 #[cfg(feature = "catmem-libos")]
                 LibOS::MemoryLibOS(libos) => libos.push(qd, sga),
             }
-        };
+        }?;
 
-        self.poll();
+        self.poll_task(qt);
 
-        result
+        Ok(qt)
     }
 
     /// Pushes a scatter-gather array to a UDP socket.
     #[allow(unused_variables)]
     pub fn pushto(&mut self, qd: QDesc, sga: &demi_sgarray_t, to: SocketAddr) -> Result<QToken, Fail> {
-        let result: Result<QToken, Fail> = {
-            timer!("demikernel::pushto");
-            match self {
-                #[cfg(any(
-                    feature = "catnap-libos",
-                    feature = "catnip-libos",
-                    feature = "catpowder-libos",
-                    feature = "catloop-libos"
-                ))]
-                LibOS::NetworkLibOS(libos) => libos.pushto(qd, sga, to),
-                #[cfg(feature = "catmem-libos")]
-                LibOS::MemoryLibOS(_) => Err(Fail::new(libc::ENOTSUP, "pushto() is not supported on memory liboses")),
-            }
+        timer!("demikernel::pushto");
+        let qt: QToken = match self {
+            #[cfg(any(
+                feature = "catnap-libos",
+                feature = "catnip-libos",
+                feature = "catpowder-libos",
+                feature = "catloop-libos"
+            ))]
+            LibOS::NetworkLibOS(libos) => libos.pushto(qd, sga, to)?,
+            #[cfg(feature = "catmem-libos")]
+            LibOS::MemoryLibOS(_) => {
+                return Err(Fail::new(libc::ENOTSUP, "pushto() is not supported on memory liboses"))
+            },
         };
 
-        self.poll();
+        self.poll_task(qt);
 
-        result
+        Ok(qt)
     }
 
     /// Pops data from a an I/O queue.
     pub fn pop(&mut self, qd: QDesc, size: Option<usize>) -> Result<QToken, Fail> {
-        let result: Result<QToken, Fail> = {
-            timer!("demikernel::pop");
-
+        timer!("demikernel::pop");
+        let qt: QToken = {
             // Check if this is a fixed-size pop.
             if let Some(size) = size {
                 // Check if size is valid.
@@ -552,11 +497,11 @@ impl LibOS {
                 #[cfg(feature = "catmem-libos")]
                 LibOS::MemoryLibOS(libos) => libos.pop(qd, size),
             }
-        };
+        }?;
 
-        self.poll();
+        self.poll_task(qt);
 
-        result
+        Ok(qt)
     }
 
     /// Waits for a pending I/O operation to complete or a timeout to expire.
@@ -655,7 +600,7 @@ impl LibOS {
         result
     }
 
-    pub fn poll(&mut self) {
+    pub fn poll_task(&mut self, qt: QToken) {
         timer!("demikernel::poll");
         match self {
             #[cfg(any(
@@ -664,9 +609,9 @@ impl LibOS {
                 feature = "catpowder-libos",
                 feature = "catloop-libos"
             ))]
-            LibOS::NetworkLibOS(libos) => libos.poll(),
+            LibOS::NetworkLibOS(libos) => libos.poll_task(qt),
             #[cfg(feature = "catmem-libos")]
-            LibOS::MemoryLibOS(libos) => libos.poll(),
+            LibOS::MemoryLibOS(libos) => libos.poll_task(qt),
         }
     }
 }

--- a/src/rust/demikernel/libos/network/libos.rs
+++ b/src/rust/demikernel/libos/network/libos.rs
@@ -638,8 +638,8 @@ impl<T: NetworkTransport> SharedNetworkLibOS<T> {
     }
 
     /// Runs all runnable coroutines.
-    pub fn poll(&mut self) {
-        self.runtime.poll()
+    pub fn poll_task(&mut self, qt: QToken) {
+        self.runtime.poll_task(qt)
     }
 
     /// Releases a scatter-gather array.

--- a/src/rust/demikernel/libos/network/mod.rs
+++ b/src/rust/demikernel/libos/network/mod.rs
@@ -305,16 +305,16 @@ impl NetworkLibOSWrapper {
     }
 
     /// Waits for any operation in an I/O queue.
-    pub fn poll(&mut self) {
+    pub fn poll_task(&mut self, qt: QToken) {
         match self {
             #[cfg(feature = "catpowder-libos")]
-            NetworkLibOSWrapper::Catpowder(libos) => libos.poll(),
+            NetworkLibOSWrapper::Catpowder(libos) => libos.poll_task(qt),
             #[cfg(all(feature = "catnap-libos"))]
-            NetworkLibOSWrapper::Catnap(libos) => libos.poll(),
+            NetworkLibOSWrapper::Catnap(libos) => libos.poll_task(qt),
             #[cfg(feature = "catnip-libos")]
-            NetworkLibOSWrapper::Catnip(libos) => libos.poll(),
+            NetworkLibOSWrapper::Catnip(libos) => libos.poll_task(qt),
             #[cfg(feature = "catloop-libos")]
-            NetworkLibOSWrapper::Catloop(libos) => libos.poll(),
+            NetworkLibOSWrapper::Catloop(libos) => libos.poll_task(qt),
         }
     }
 

--- a/src/rust/inetstack/protocols/udp/tests.rs
+++ b/src/rust/inetstack/protocols/udp/tests.rs
@@ -204,7 +204,7 @@ fn udp_ping_pong() -> Result<()> {
     // Receive data from Bob.
     carrie.receive(bob.pop_frame()).unwrap();
     let carrie_qt: QToken = carrie.udp_pop(carrie_fd)?;
-    carrie.poll();
+    carrie.poll_task(carrie_qt);
 
     let (remote_addr, received_buf_a): (Option<SocketAddrV4>, DemiBuffer) =
         match carrie.wait(carrie_qt, DEFAULT_TIMEOUT)? {
@@ -223,7 +223,7 @@ fn udp_ping_pong() -> Result<()> {
         (_, OperationResult::Push) => {},
         _ => anyhow::bail!("Push failed"),
     };
-    carrie.poll();
+    carrie.poll_background();
     now += Duration::from_micros(1);
 
     // Receive data from Carrie.
@@ -331,7 +331,7 @@ fn udp_loop2_push_pop() -> Result<()> {
             (_, OperationResult::Push) => {},
             _ => anyhow::bail!("Push failed"),
         };
-        bob.poll();
+        bob.poll_background();
 
         now += Duration::from_micros(1);
 
@@ -395,7 +395,7 @@ fn udp_loop2_ping_pong() -> Result<()> {
             (_, OperationResult::Push) => {},
             _ => anyhow::bail!("Push failed"),
         };
-        bob.poll();
+        bob.poll_background();
 
         now += Duration::from_micros(1);
 
@@ -546,7 +546,7 @@ fn udp_pop_not_bound() -> Result<()> {
         (_, OperationResult::Push) => {},
         _ => anyhow::bail!("Push failed"),
     };
-    bob.poll();
+    bob.poll_background();
 
     now += Duration::from_micros(1);
 

--- a/src/rust/inetstack/test_helpers/engine.rs
+++ b/src/rust/inetstack/test_helpers/engine.rs
@@ -49,7 +49,7 @@ use ::std::{
 };
 
 /// A default amount of time to wait on an operation to complete. This was chosen arbitrarily.
-pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(120);
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(20);
 
 #[derive(Clone)]
 pub struct SharedEngine(SharedNetworkLibOS<SharedInetStack<SharedTestRuntime>>);
@@ -87,8 +87,8 @@ impl SharedEngine {
         // We no longer do processing in this function, so we will not know if the packet is dropped or not.
         self.get_transport().receive(bytes)?;
         // So poll the scheduler to do the processing.
-        self.get_runtime().poll();
-        self.get_runtime().poll();
+        self.get_runtime().poll_background();
+        self.get_runtime().poll_background();
 
         Ok(())
     }
@@ -163,8 +163,16 @@ impl SharedEngine {
         self.get_transport().export_arp_cache()
     }
 
-    pub fn poll(&self) {
-        self.get_runtime().poll()
+    pub fn poll_io(&self) {
+        self.get_runtime().poll_io()
+    }
+
+    pub fn poll_background(&self) {
+        self.get_runtime().poll_background()
+    }
+
+    pub fn poll_task(&self, qt: QToken) {
+        self.get_runtime().poll_task(qt)
     }
 
     pub fn wait(&self, qt: QToken, timeout: Duration) -> Result<(QDesc, OperationResult), Fail> {


### PR DESCRIPTION
This PR separates coroutines that perform I/O from background coroutines in the runtime using the new scheduler task groups. Splitting these two lets us distinguish between coroutines where we are waiting on a result and coroutines that run forever. We also have the ability to poll a single coroutine, so we replace our poll on every system call with a poll to the specific coroutine.