### PR TITLE
[testing] Enhancement: Turn on more inetstack tests

### DIFF
--- a/tools/ci/config/test/catnip.yaml
+++ b/tools/ci/config/test/catnip.yaml
@@ -1,6 +1,16 @@
 catnip:
   udp_ping_pong: {}
   udp_push_pop: {}
+  tcp_close:
+    nclients: [32]
+    run_mode: [sequential, concurrent]
+    who_closes: [client, server]
+  tcp_wait:
+    nclients: [32]
+    scenario: [push_close_wait, push_async_close_wait,
+               push_async_close_pending_wait, pop_close_wait,
+               pop_async_close_wait,
+               pop_async_close_pending_wait]
   tcp_ping_pong: {}
   tcp_push_pop: {}
   tcp_echo:
@@ -9,7 +19,3 @@ catnip:
     nrequests: [128, 1024]
     run_mode: [sequential, concurrent]
     nthreads: [1]
-tcp_close:
-    nclients: [1]
-    run_mode: [sequential, concurrent]
-    who_closes: [client, server]

--- a/tools/ci/config/test/catpowder.yaml
+++ b/tools/ci/config/test/catpowder.yaml
@@ -1,15 +1,21 @@
 catpowder:
   udp_ping_pong: {}
   udp_push_pop: {}
+  tcp_close:
+    nclients: [32]
+    run_mode: [sequential, concurrent]
+    who_closes: [client, server]
+  tcp_wait:
+    nclients: [32]
+    scenario: [push_close_wait, push_async_close_wait,
+               push_async_close_pending_wait, pop_close_wait,
+               pop_async_close_wait,
+               pop_async_close_pending_wait]
   tcp_ping_pong: {}
   tcp_push_pop: {}
   tcp_echo:
     bufsize: [64, 1024]
-    nclients: [1]
+    nclients: [1, 32]
     nrequests: [128, 1024]
-    run_mode: [sequential]
-    nthreads: [1]
-  tcp_close:
-    nclients: [1]
     run_mode: [sequential, concurrent]
-    who_closes: [client, server]
+    nthreads: [1]


### PR DESCRIPTION
This PR turns on more TCP echo tests. The goal of this PR is to align Catpowder and Catnip with the same set of tests that Catnap currently runs on our CI.