### PR TITLE
[include] Bug Fix: replace <winsock.h> with <WinSock2.h> in libos.h

### DIFF
--- a/include/demi/libos.h
+++ b/include/demi/libos.h
@@ -13,7 +13,7 @@
 #endif
 
 #ifdef _WIN32
-#include <winsock.h>
+#include <WinSock2.h>
 typedef int socklen_t;
 #endif
 


### PR DESCRIPTION
Fixes a missed header in the previous PR.