### PR TITLE
[ci] Enable perf report for dev branch

### DIFF
--- a/.github/workflows/catnap.yml
+++ b/.github/workflows/catnap.yml
@@ -174,7 +174,6 @@ jobs:
   report-performance:
     name: Report Performance
     needs: [ redis-pipeline, release-pipeline ]
-    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/catnip.yml
+++ b/.github/workflows/catnip.yml
@@ -126,7 +126,6 @@ jobs:
   report-performance:
     name: Report Performance
     needs: release-pipeline
-    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/catpowder.yml
+++ b/.github/workflows/catpowder.yml
@@ -126,7 +126,6 @@ jobs:
   report-performance:
     name: Report Performance
     needs: release-pipeline
-    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
The merge on dev branch does not trigger the run for report-performance. This change enables that.