### PR TITLE
[tcp-echo] Measure end-to-end CPU cycles

### DIFF
--- a/examples/tcp-echo/main.rs
+++ b/examples/tcp-echo/main.rs
@@ -18,6 +18,7 @@ use clap::{
 };
 use client::TcpEchoClient;
 use demikernel::{
+    timer,
     LibOS,
     LibOSName,
 };
@@ -270,6 +271,7 @@ fn start_client_thread(
 //======================================================================================================================
 
 fn main() -> Result<()> {
+    timer!("main");
     let args: ProgramArguments = ProgramArguments::new(
         "tcp-echo",
         "Pedro Henrique Penna <ppenna@microsoft.com>",


### PR DESCRIPTION
Measure the end-to-end CPU cycles for the tcp-echo test.