### PR TITLE
[examples] Revert timer in main

### DIFF
--- a/examples/pipe-open/main.rs
+++ b/examples/pipe-open/main.rs
@@ -14,7 +14,6 @@ use anyhow::Result;
 use args::ProgramArguments;
 use client::PipeClient;
 use demikernel::{
-    timer,
     LibOS,
     LibOSName,
 };
@@ -25,8 +24,6 @@ mod client;
 mod server;
 
 fn main() -> Result<()> {
-    timer!("pipe-open::main");
-
     let args: ProgramArguments = ProgramArguments::new(
         "pipe-open",
         "Pedro Henrique Penna <ppenna@microsoft.com>",

--- a/examples/rust/pipe-ping-pong.rs
+++ b/examples/rust/pipe-ping-pong.rs
@@ -9,7 +9,6 @@ use ::core::slice;
 use ::demikernel::{
     demi_sgarray_t,
     runtime::types::demi_opcode_t,
-    timer,
     LibOS,
     LibOSName,
     QDesc,
@@ -278,8 +277,6 @@ fn usage(program_name: &String) {
 //======================================================================================================================
 
 pub fn main() -> Result<()> {
-    timer!("pipe-ping-pong::main");
-
     let args: Vec<String> = env::args().collect();
 
     if args.len() >= 3 {

--- a/examples/rust/pipe-push-pop.rs
+++ b/examples/rust/pipe-push-pop.rs
@@ -8,7 +8,6 @@ use ::anyhow::Result;
 use ::demikernel::{
     demi_sgarray_t,
     runtime::types::demi_opcode_t,
-    timer,
     LibOS,
     LibOSName,
     QDesc,
@@ -247,8 +246,6 @@ fn usage(program_name: &String) {
 //======================================================================================================================
 
 pub fn main() -> Result<()> {
-    timer!("pipe-push-pop::main");
-
     let args: Vec<String> = env::args().collect();
 
     if args.len() >= 3 {

--- a/examples/rust/tcp-dump.rs
+++ b/examples/rust/tcp-dump.rs
@@ -20,7 +20,6 @@ use ::demikernel::{
         demi_opcode_t,
         demi_qresult_t,
     },
-    timer,
     LibOS,
     LibOSName,
     QDesc,
@@ -258,8 +257,6 @@ impl Drop for Application {
 //==============================================================================
 
 fn main() -> Result<()> {
-    timer!("tcp-dump::main");
-
     let args: ProgramArguments = ProgramArguments::new(
         "tcp-dump",
         "Pedro Henrique Penna <ppenna@microsoft.com>",

--- a/examples/rust/tcp-ping-pong.rs
+++ b/examples/rust/tcp-ping-pong.rs
@@ -9,7 +9,6 @@ use ::anyhow::Result;
 use ::demikernel::{
     demi_sgarray_t,
     runtime::types::demi_opcode_t,
-    timer,
     LibOS,
     LibOSName,
     QDesc,
@@ -417,8 +416,6 @@ fn usage(program_name: &String) {
 //======================================================================================================================
 
 pub fn main() -> Result<()> {
-    timer!("tcp-ping-pong::main");
-
     let args: Vec<String> = env::args().collect();
 
     if args.len() >= 3 {

--- a/examples/rust/tcp-pktgen.rs
+++ b/examples/rust/tcp-pktgen.rs
@@ -17,7 +17,6 @@ use ::clap::{
 use ::demikernel::{
     demi_sgarray_t,
     runtime::types::demi_opcode_t,
-    timer,
     LibOS,
     LibOSName,
     QDesc,
@@ -354,8 +353,6 @@ impl Drop for Application {
 
 /// Drives the application.
 fn main() -> Result<()> {
-    timer!("tcp-pktgen::main");
-
     let args: ProgramArguments = ProgramArguments::new(
         "tcp-pktgen",
         "Pedro Henrique Penna <ppenna@microsoft.com>",

--- a/examples/rust/tcp-push-pop.rs
+++ b/examples/rust/tcp-push-pop.rs
@@ -9,7 +9,6 @@ use ::anyhow::Result;
 use ::demikernel::{
     demi_sgarray_t,
     runtime::types::demi_opcode_t,
-    timer,
     LibOS,
     LibOSName,
     QDesc,
@@ -327,8 +326,6 @@ fn usage(program_name: &String) {
 //======================================================================================================================
 
 pub fn main() -> Result<()> {
-    timer!("tcp-push-pop::main");
-
     let args: Vec<String> = env::args().collect();
 
     if args.len() >= 3 {

--- a/examples/rust/udp-dump.rs
+++ b/examples/rust/udp-dump.rs
@@ -17,7 +17,6 @@ use ::clap::{
 use ::demikernel::{
     demi_sgarray_t,
     runtime::types::demi_opcode_t,
-    timer,
     LibOS,
     LibOSName,
     QDesc,
@@ -197,8 +196,6 @@ impl Drop for Application {
 
 /// Drives the application.
 fn main() -> Result<()> {
-    timer!("udp-dump::main");
-
     let args: ProgramArguments = ProgramArguments::new(
         "udp-dump",
         "Pedro Henrique Penna <ppenna@microsoft.com>",

--- a/examples/rust/udp-echo.rs
+++ b/examples/rust/udp-echo.rs
@@ -17,7 +17,6 @@ use ::clap::{
 use ::demikernel::{
     demi_sgarray_t,
     runtime::types::demi_opcode_t,
-    timer,
     LibOS,
     LibOSName,
     QDesc,
@@ -293,8 +292,6 @@ impl Drop for Application {
 //======================================================================================================================
 
 fn main() -> Result<()> {
-    timer!("udp-echo::main");
-
     let args: ProgramArguments = ProgramArguments::new(
         "udp-echo",
         "Pedro Henrique Penna <ppenna@microsoft.com>",

--- a/examples/rust/udp-ping-pong.rs
+++ b/examples/rust/udp-ping-pong.rs
@@ -12,7 +12,6 @@ use ::demikernel::{
         demi_opcode_t,
         demi_qresult_t,
     },
-    timer,
     LibOS,
     LibOSName,
     QDesc,
@@ -335,8 +334,6 @@ fn usage(program_name: &String) {
 //======================================================================================================================
 
 pub fn main() -> Result<()> {
-    timer!("udp-ping-pong::main");
-
     let args: Vec<String> = env::args().collect();
 
     if args.len() >= 4 {

--- a/examples/rust/udp-pktgen.rs
+++ b/examples/rust/udp-pktgen.rs
@@ -17,7 +17,6 @@ use ::clap::{
 use ::demikernel::{
     demi_sgarray_t,
     runtime::types::demi_opcode_t,
-    timer,
     LibOS,
     LibOSName,
     QDesc,
@@ -369,8 +368,6 @@ impl Drop for Application {
 
 /// Drives the application.
 fn main() -> Result<()> {
-    timer!("udp-pktgen::main");
-
     let args: ProgramArguments = ProgramArguments::new(
         "udp-pktgen",
         "Pedro Henrique Penna <ppenna@microsoft.com>",

--- a/examples/rust/udp-push-pop.rs
+++ b/examples/rust/udp-push-pop.rs
@@ -9,7 +9,6 @@ use ::anyhow::Result;
 use ::demikernel::{
     demi_sgarray_t,
     runtime::types::demi_opcode_t,
-    timer,
     LibOS,
     LibOSName,
     QDesc,
@@ -286,8 +285,6 @@ fn usage(program_name: &String) {
 //======================================================================================================================
 
 pub fn main() -> Result<()> {
-    timer!("udp-push-pop::main");
-
     let args: Vec<String> = env::args().collect();
 
     if args.len() >= 3 {

--- a/examples/rust/udp-relay.rs
+++ b/examples/rust/udp-relay.rs
@@ -17,7 +17,6 @@ use ::clap::{
 use ::demikernel::{
     demi_sgarray_t,
     runtime::types::demi_opcode_t,
-    timer,
     LibOS,
     LibOSName,
     QDesc,
@@ -263,8 +262,6 @@ impl Drop for Application {
 //==============================================================================
 
 fn main() -> Result<()> {
-    timer!("udp-relay::main");
-
     let args: ProgramArguments = ProgramArguments::new(
         "udp-relay",
         "Pedro Henrique Penna <ppenna@microsoft.com>",

--- a/examples/tcp-close/main.rs
+++ b/examples/tcp-close/main.rs
@@ -22,7 +22,6 @@ use crate::{
 };
 use ::anyhow::Result;
 use ::demikernel::{
-    timer,
     LibOS,
     LibOSName,
 };
@@ -39,8 +38,6 @@ const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 //======================================================================================================================
 
 fn main() -> Result<()> {
-    timer!("tcp-close::main");
-
     let args: ProgramArguments = ProgramArguments::new(
         "tcp-close",
         "Pedro Henrique Penna <ppenna@microsoft.com>",

--- a/examples/tcp-echo/main.rs
+++ b/examples/tcp-echo/main.rs
@@ -18,7 +18,6 @@ use clap::{
 };
 use client::TcpEchoClient;
 use demikernel::{
-    timer,
     LibOS,
     LibOSName,
 };
@@ -271,8 +270,6 @@ fn start_client_thread(
 //======================================================================================================================
 
 fn main() -> Result<()> {
-    timer!("tcp-echo::main");
-
     let args: ProgramArguments = ProgramArguments::new(
         "tcp-echo",
         "Pedro Henrique Penna <ppenna@microsoft.com>",

--- a/examples/tcp-wait/main.rs
+++ b/examples/tcp-wait/main.rs
@@ -25,7 +25,6 @@ use crate::{
 };
 use ::anyhow::Result;
 use ::demikernel::{
-    timer,
     LibOS,
     LibOSName,
 };
@@ -42,8 +41,6 @@ const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 //======================================================================================================================
 
 fn main() -> Result<()> {
-    timer!("tcp-wait::main");
-
     let args: ProgramArguments = ProgramArguments::new(
         "tcp-wait",
         "Anand Bonde <anand.bonde@gmail.com>",


### PR DESCRIPTION
The timer in main() functions never go off. This causes other unexpected issues as shown in the accompanying image.

![image](https://github.com/user-attachments/assets/7b10832b-e21a-41e0-910b-8e4a4fc654b9)

Until we find a satisfactory solution, we will not do end-2-end measurement using the existing framework. I will send out an additional PR to add end-2-end measurements using rdtscp directly.