### PR TITLE
[shim] Missing Initialization on Many Calls

### DIFF
--- a/shim/src/interpose.c
+++ b/shim/src/interpose.c
@@ -509,9 +509,8 @@ int epoll_create(int size)
 
     init();
 
+    // Create epoll on kernel side.
     int ret = libc_epoll_create(size);
-
-    // First, create epoll on kernel side.
     if (ret == -1)
     {
         ERROR("epoll_create() failed - %s", strerror(errno));
@@ -522,7 +521,9 @@ int epoll_create(int size)
 
     int last_errno = errno;
     errno = 0;
-    if ((ret = __epoll_create(size)) == -1 && errno == EBADF)
+
+    // Create epoll on demikernel side.
+    if ((ret = __epoll_create(size) == -1) && (errno == EBADF))
     {
         errno = last_errno;
         return linux_epfd;

--- a/shim/src/interpose.c
+++ b/shim/src/interpose.c
@@ -58,7 +58,7 @@
                                                               \
         bool reentrant = is_reentrant_demi_call();            \
                                                               \
-        if ((!initialized) || (reentrant))                    \
+        if (reentrant)                                        \
             return (fn_libc(__VA_ARGS__));                    \
                                                               \
         INTERPOSE_CALL2(type, fn_libc, fn_demi, __VA_ARGS__); \

--- a/shim/src/interpose.c
+++ b/shim/src/interpose.c
@@ -58,7 +58,7 @@
                                                               \
         bool reentrant = is_reentrant_demi_call();            \
                                                               \
-        if (reentrant)                                        \
+        if ((in_init) || (reentrant))                         \
             return (fn_libc(__VA_ARGS__));                    \
                                                               \
         INTERPOSE_CALL2(type, fn_libc, fn_demi, __VA_ARGS__); \

--- a/shim/src/interpose.c
+++ b/shim/src/interpose.c
@@ -498,8 +498,7 @@ int socket(int domain, int type, int protocol)
 
 int epoll_create(int size)
 {
-    if (!initialized_libc)
-        init_libc();
+    init_libc();
 
     bool reentrant = is_reentrant_demi_call();
 


### PR DESCRIPTION
## Description

This PR fixes initialization issues of Demikernel in the POSIX SHIM layer.

Without this modification, initialization would be performed only when `epoll_create()` is the very first call performed by the application.