### PR TITLE
[build] Missing Lib in LD_LIBRARY_PATH

### DIFF
--- a/linux.mk
+++ b/linux.mk
@@ -8,7 +8,7 @@
 export PREFIX ?= $(HOME)
 export INSTALL_PREFIX ?= $(HOME)
 export PKG_CONFIG_PATH ?= $(shell find $(PREFIX)/lib/ -name '*pkgconfig*' -type d 2> /dev/null | xargs | sed -e 's/\s/:/g')
-export LD_LIBRARY_PATH ?= $(HOME)/lib:$(shell find $(PREFIX)/lib/ -name '*x86_64-linux-gnu*' -type d 2> /dev/null | xargs | sed -e 's/\s/:/g')
+export LD_LIBRARY_PATH ?= $(CURDIR)/lib:$(shell find $(PREFIX)/lib/ -name '*x86_64-linux-gnu*' -type d 2> /dev/null | xargs | sed -e 's/\s/:/g')
 
 #=======================================================================================================================
 # Build Configuration


### PR DESCRIPTION
## Description

This PR fixes the build system to build the `LD_LIBRARY_PATH` to include the library directory.