### PR TITLE
[shim] Fix evaluation of conditional expression in epoll_create

### DIFF
--- a/shim/src/interpose.c
+++ b/shim/src/interpose.c
@@ -523,7 +523,7 @@ int epoll_create(int size)
     errno = 0;
 
     // Create epoll on demikernel side.
-    if ((ret = __epoll_create(size) == -1) && (errno == EBADF))
+    if (((ret = __epoll_create(size)) == -1) && (errno == EBADF))
     {
         errno = last_errno;
         return linux_epfd;


### PR DESCRIPTION
Incorrect parenthesis were causing the evaluation of conditional expression to be incorrect.