### PR TITLE
Enhancement shim datapath

### DIFF
--- a/shim/src/epoll.h
+++ b/shim/src/epoll.h
@@ -25,6 +25,7 @@ struct demi_event
 
 extern void epoll_table_init(void);
 extern int epoll_table_alloc(void);
+extern int epoll_get_ready(int epfd, demi_qtoken_t *qts, struct demi_event **evs);
 extern struct demi_event *epoll_get_event(int epfd, int i);
 extern struct demi_event *epoll_get_head(int epfd);
 extern struct demi_event *epoll_get_tail(int epfd);

--- a/shim/src/epoll/epoll.c
+++ b/shim/src/epoll/epoll.c
@@ -43,10 +43,31 @@ void epoll_table_init(void)
             epoll_table[i].events[j].used = j == 0? 1 : 0;
 
             epoll_table[i].events[j].id = j;
+            epoll_table[i].events[j].qt = -1;
             epoll_table[i].events[j].next_ev = INVALID_EV;
             epoll_table[i].events[j].prev_ev = INVALID_EV;
         }
     }
+}
+
+int epoll_get_ready(int epfd, demi_qtoken_t *qts, struct demi_event **evs)
+{
+    int nevents = 0;
+
+    struct demi_event *ev = epoll_get_head(epfd);
+    while (ev != NULL)
+    {
+        if ((ev->used) && (ev->qt != (demi_qtoken_t)-1))
+        {
+            qts[nevents] = ev->qt;
+            evs[nevents] = ev;
+            nevents++;
+        }
+
+        ev = epoll_get_next(epfd, ev);
+    }
+
+    return nevents;
 }
 
 struct demi_event *epoll_get_event(int epfd, int i)

--- a/shim/src/glue.c
+++ b/shim/src/glue.c
@@ -12,28 +12,21 @@
 #include "utils.h"
 #include "log.h"
 
-static struct hashset *__demi_reent_guards;
+static int __demi_reent_guard;
 
 #define MAX_THREADS_LOG2 10
 
 #define DEMI_CALL(type, fn, ...)                        \
     {                                                   \
-        pid_t tid = gettid();                           \
-        hashset_insert(__demi_reent_guards, tid);       \
+        __demi_reent_guard = 1;                         \
         type ret = fn(__VA_ARGS__);                     \
-        hashset_remove(__demi_reent_guards, tid);       \
+        __demi_reent_guard = 0;                         \
         return (ret);                                   \
     }
 
 int is_reentrant_demi_call()
 {
-    pid_t tid = gettid();
-    return hashset_contains(__demi_reent_guards, tid);
-}
-
-void init_reent_guards() {
-    __demi_reent_guards = hashset_create(MAX_THREADS_LOG2);
-    assert(__demi_reent_guards != NULL);
+    __demi_reent_guard;
 }
 
 int __demi_init(const struct demi_args *args)

--- a/shim/src/interpose.c
+++ b/shim/src/interpose.c
@@ -10,6 +10,8 @@
 #include "utils.h"
 #include <assert.h>
 #include <demi/types.h>
+#include <demi/sga.h>
+#include <demi/wait.h>
 #include <dlfcn.h>
 #include <errno.h>
 #include <glue.h>

--- a/shim/src/queue.c
+++ b/shim/src/queue.c
@@ -3,6 +3,7 @@
 
 #include "epoll.h"
 #include "utils.h"
+#include "log.h"
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/shim/src/utils.h
+++ b/shim/src/utils.h
@@ -7,10 +7,10 @@
 #include <stdint.h>
 
 #define UNUSED(x) ((void)(x))
-
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
-
 #define MEM_BARRIER() __asm__ volatile("" ::: "memory")
+#define LIKELY(x) __builtin_expect((x),1)
+#define UNLIKELY(x) __builtin_expect((x),0)
 
 #define LIKELY(x) __builtin_expect((x), 1)
 


### PR DESCRIPTION
Adding a batch of optimizations for the shim layer
- Use static arrays instead of custom hashtable and hashset
- Hint to the compiler likely and unlikely events in branch conditions
- Add missing O3 flag to the shim makefile
- Use demi_wait_any instead of regular demi_wait to reduce the number of demi calls and background processes run (greatly improves tail latency)