### PR TITLE
[shim] Bad Initialization for `vfcntl()`, `epoll_ctl()`, `epoll_wait()` and `epoll_create()`

### DIFF
--- a/shim/src/interpose.c
+++ b/shim/src/interpose.c
@@ -506,7 +506,7 @@ int epoll_create(int size)
 
     bool reentrant = is_reentrant_demi_call();
 
-    if (reentrant)
+    if (in_init || reentrant)
     {
         return (libc_epoll_create(size));
     }

--- a/shim/src/interpose.c
+++ b/shim/src/interpose.c
@@ -420,13 +420,14 @@ int epoll_create1(int flags)
 
 int epoll_ctl(int epfd, int op, int fd, struct epoll_event *event)
 {
-    if (!initialized_libc)
-        init_libc();
+    init_libc();
 
     bool reentrant = is_reentrant_demi_call();
 
-    if ((!initialized) || (reentrant))
+    if (in_init || reentrant)
+    {
         return (libc_epoll_ctl(epfd, op, fd, event));
+    }
 
     init();
 

--- a/shim/src/interpose.c
+++ b/shim/src/interpose.c
@@ -458,12 +458,11 @@ int epoll_ctl(int epfd, int op, int fd, struct epoll_event *event)
 
 int epoll_wait(int epfd, struct epoll_event *events, int maxevents, int timeout)
 {
-    if (!initialized_libc)
-        init_libc();
+    init_libc();
 
     bool reentrant = is_reentrant_demi_call();
 
-    if ((!initialized) || (reentrant))
+    if (in_init || reentrant)
     {
         return (libc_epoll_wait(epfd, events, maxevents, timeout));
     }
@@ -482,6 +481,7 @@ int epoll_wait(int epfd, struct epoll_event *events, int maxevents, int timeout)
             errno = last_errno;
             if (epfd >= EPOLL_MAX_FDS)
                 epfd -= EPOLL_MAX_FDS;
+
             return (libc_epoll_wait(epfd, events, maxevents, timeout));
         }
         else


### PR DESCRIPTION
## Description

This PR isolates some changes introduced by https://github.com/microsoft/demikernel/pull/1351.