### PR TITLE
[runtime] Add return values to transmit and receive in the network runtime

### DIFF
--- a/src/rust/inetstack/protocols/tcp/active_open.rs
+++ b/src/rust/inetstack/protocols/tcp/active_open.rs
@@ -187,7 +187,7 @@ impl<N: NetworkRuntime> SharedActiveOpenSocket<N> {
             data: None,
             tx_checksum_offload: self.tcp_config.get_rx_checksum_offload(),
         };
-        self.transport.transmit(segment);
+        self.transport.transmit(segment)?;
 
         let mut remote_window_scale = None;
         let mut mss = FALLBACK_MSS;
@@ -321,7 +321,10 @@ impl<N: NetworkRuntime> SharedActiveOpenSocket<N> {
                 tx_checksum_offload: self.tcp_config.get_rx_checksum_offload(),
             };
             // Send SYN.
-            self.transport.transmit(segment);
+            if let Err(e) = self.transport.transmit(segment) {
+                warn!("Could not send SYN: {:?}", e);
+                continue;
+            }
 
             // Wait for either a response or timeout.
             let mut recv_queue: SharedAsyncQueue<(Ipv4Header, TcpHeader, DemiBuffer)> = self.recv_queue.clone();

--- a/src/rust/inetstack/protocols/tcp/established/ctrlblk.rs
+++ b/src/rust/inetstack/protocols/tcp/established/ctrlblk.rs
@@ -851,7 +851,10 @@ impl<N: NetworkRuntime> SharedControlBlock<N> {
         };
 
         // Call the runtime to send the segment.
-        self.transport.transmit(segment);
+        if let Err(e) = self.transport.transmit(segment) {
+            warn!("could not emit packet: {:?}", e);
+            return;
+        }
 
         // Post-send operations follow.
         // Review: We perform these after the send, in order to keep send latency as low as possible.

--- a/src/rust/inetstack/protocols/tcp/passive_open.rs
+++ b/src/rust/inetstack/protocols/tcp/passive_open.rs
@@ -328,7 +328,9 @@ impl<N: NetworkRuntime> SharedPassiveSocket<N> {
         };
 
         // Send it.
-        self.transport.transmit(segment);
+        if let Err(e) = self.transport.transmit(segment) {
+            warn!("Could not send RST: {:?}", e);
+        }
     }
 
     async fn send_syn_ack_and_wait_for_ack(
@@ -434,8 +436,7 @@ impl<N: NetworkRuntime> SharedPassiveSocket<N> {
             data: None,
             tx_checksum_offload: self.tcp_config.get_rx_checksum_offload(),
         };
-        self.transport.transmit(segment);
-        Ok(())
+        self.transport.transmit(segment)
     }
 
     async fn wait_for_ack(

--- a/src/rust/inetstack/protocols/udp/socket.rs
+++ b/src/rust/inetstack/protocols/udp/socket.rs
@@ -130,8 +130,7 @@ impl<N: NetworkRuntime> SharedUdpSocket<N> {
             buf,
             self.checksum_offload,
         );
-        self.network.transmit(datagram);
-        Ok(())
+        self.network.transmit(datagram)
     }
 
     pub async fn pop(&mut self, size: usize) -> Result<(SocketAddrV4, DemiBuffer), Fail> {

--- a/src/rust/inetstack/test_helpers/runtime.rs
+++ b/src/rust/inetstack/test_helpers/runtime.rs
@@ -95,7 +95,7 @@ impl NetworkRuntime for SharedTestRuntime {
         })))
     }
 
-    fn transmit<P: PacketBuf>(&mut self, mut pkt: P) {
+    fn transmit<P: PacketBuf>(&mut self, mut pkt: P) -> Result<(), Fail> {
         let header_size: usize = pkt.header_size();
         let body_size: usize = pkt.body_size();
         debug!("transmit frame: {:?} body: {:?}", self.outgoing.len(), body_size);
@@ -110,14 +110,15 @@ impl NetworkRuntime for SharedTestRuntime {
             buf[header_size..].copy_from_slice(&body[..]);
         }
         self.outgoing.push_back(buf);
+        Ok(())
     }
 
-    fn receive(&mut self) -> ArrayVec<DemiBuffer, RECEIVE_BATCH_SIZE> {
+    fn receive(&mut self) -> Result<ArrayVec<DemiBuffer, RECEIVE_BATCH_SIZE>, Fail> {
         let mut out = ArrayVec::new();
         if let Some(buf) = self.incoming.pop_front() {
             out.push(buf);
         }
-        out
+        Ok(out)
     }
 }
 

--- a/src/rust/runtime/network/mod.rs
+++ b/src/rust/runtime/network/mod.rs
@@ -127,8 +127,8 @@ pub trait NetworkRuntime: Clone + 'static + MemoryRuntime {
     fn new(config: &Config) -> Result<Self, Fail>;
 
     /// Transmits a single [PacketBuf].
-    fn transmit<P: PacketBuf>(&mut self, pkt: P);
+    fn transmit<P: PacketBuf>(&mut self, pkt: P) -> Result<(), Fail>;
 
     /// Receives a batch of [DemiBuffer].
-    fn receive(&mut self) -> ArrayVec<DemiBuffer, RECEIVE_BATCH_SIZE>;
+    fn receive(&mut self) -> Result<ArrayVec<DemiBuffer, RECEIVE_BATCH_SIZE>, Fail>;
 }


### PR DESCRIPTION
This PR adds return values to the transmit and receive functions in the network runtime trait, so that we can remove panics and silent errors to return a value.