### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/catnap.yml
+++ b/.github/workflows/catnap.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0
     - name: Setup SSH
@@ -64,7 +64,7 @@ jobs:
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: catnap-debug-pipeline-logs
         path: |
@@ -81,7 +81,7 @@ jobs:
       run: echo "Release pipeline skipped because branch is not main, unstable, dev, or does not contain 'do-release'."
     - name: Checkout
       if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0
     - name: Setup SSH
@@ -116,7 +116,7 @@ jobs:
     - name: Archive Logs
       if: always()
       continue-on-error: true
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: catnap-release-pipeline-logs
         path: |
@@ -140,12 +140,12 @@ jobs:
       run: echo "Release pipeline skipped because branch is not main, unstable, dev, or does not contain 'do-release'."
     - name: Checkout
       if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0
     - name: Download Release Pipeline Logs
       if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: catnap-release-pipeline-logs
         path: ./catnap_release_pipeline_logs
@@ -165,7 +165,7 @@ jobs:
           --log-dir ./catnap_release_pipeline_logs)
     - name: Archive Performance Data
       if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: performance-data
         path: |

--- a/.github/workflows/catnapw.yml
+++ b/.github/workflows/catnapw.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0
     - name: Setup SSH
@@ -65,7 +65,7 @@ jobs:
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: catnapw-debug-pipeline-logs
         path: |
@@ -82,7 +82,7 @@ jobs:
       run: echo "Release pipeline skipped because branch is not main, unstable, dev, or does not contain 'do-release'."
     - name: Checkout
       if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0
     - name: Setup SSH
@@ -118,7 +118,7 @@ jobs:
     - name: Archive Logs
       if: always()
       continue-on-error: true
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: catnapw-release-pipeline-logs
         path: |
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0
     - name: Setup SSH
@@ -165,7 +165,7 @@ jobs:
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: catpowder-debug-pipeline-logs
         path: |
@@ -182,7 +182,7 @@ jobs:
       run: echo "Release pipeline skipped because branch is not main, unstable, dev, or does not contain 'do-release'."
     - name: Checkout
       if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0
     - name: Setup SSH
@@ -218,7 +218,7 @@ jobs:
     - name: Archive Logs
       if: always()
       continue-on-error: true
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: catpowder-release-pipeline-logs
         path: |

--- a/.github/workflows/catnip.yml
+++ b/.github/workflows/catnip.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0
     - name: Setup SSH
@@ -86,7 +86,7 @@ jobs:
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: catnip-debug-pipeline-logs
         path: |
@@ -103,7 +103,7 @@ jobs:
       run: echo "Release pipeline skipped because branch is not main, unstable, dev, or does not contain 'do-release'."
     - name: Checkout
       if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0
     - name: Setup SSH
@@ -161,7 +161,7 @@ jobs:
     - name: Archive Logs
       if: always()
       continue-on-error: true
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: catnip-release-pipeline-logs
         path: |
@@ -185,12 +185,12 @@ jobs:
       run: echo "Release pipeline skipped because branch is not main, unstable, dev, or does not contain 'do-release'."
     - name: Checkout
       if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0
     - name: Download Release Pipeline Logs
       if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: catnip-release-pipeline-logs
         path: ./catnip_release_pipeline_logs
@@ -210,7 +210,7 @@ jobs:
           --log-dir ./catnip_release_pipeline_logs)
     - name: Archive Performance Data
       if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: performance-data
         path: |

--- a/.github/workflows/catpowder.yml
+++ b/.github/workflows/catpowder.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0
     - name: Setup SSH
@@ -82,7 +82,7 @@ jobs:
           --client-addr $CLIENT_ADDR
     - name: Archive Logs
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: catpowder-debug-pipeline-logs
         path: |
@@ -99,7 +99,7 @@ jobs:
       run: echo "Release pipeline skipped because branch is not main, unstable, dev, or does not contain 'do-release'."
     - name: Checkout
       if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0
     - name: Setup SSH
@@ -153,7 +153,7 @@ jobs:
     - name: Archive Logs
       if: always()
       continue-on-error: true
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: catpowder-release-pipeline-logs
         path: |
@@ -177,12 +177,12 @@ jobs:
       run: echo "Release pipeline skipped because branch is not main, unstable, dev, or does not contain 'do-release'."
     - name: Checkout
       if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0
     - name: Download Release Pipeline Logs
       if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: catpowder-release-pipeline-logs
         path: ./catpowder_release_pipeline_logs
@@ -202,7 +202,7 @@ jobs:
           --log-dir ./catpowder_release_pipeline_logs)
     - name: Archive Performance Data
       if: ${{ env.SHOULD_RUN_RELEASE == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: performance-data
         path: |


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
